### PR TITLE
  Fix day slice in SCHISM station netcdf time.units

### DIFF
--- a/bin/utils/process_schism_stations_cli.py
+++ b/bin/utils/process_schism_stations_cli.py
@@ -535,7 +535,7 @@ def process_schism_stations(prop, logger):
                         time = ncfile.createVariable('time', np.float32, ('time'))
                         time.units = (f'seconds since {prop.start_date_full[0:4]}-'
                                       f'{prop.start_date_full[4:6]}-'
-                                      f'{prop.start_date_full[4:6]} '
+                                      f'{prop.start_date_full[6:8]} '
                                       f'{prop.start_date_full[-2:]}:00:00')
                         # Do rest of vars
                         lon = ncfile.createVariable('lon', np.float32, ('station'))


### PR DESCRIPTION
  ## Summary
  - Fixed a bug in `process_schism_stations_cli.py` where the `time.units` format string used `start_date_full[4:6]` (month) for both the month and day fields
  - Corrected the day field to use `start_date_full[6:8]`

  ## Details
  This bug fix was identified during code review of PR #38 but was stuck locally didn't get pushed before #38 was merged. This PR applies the same fix to `main`.

  The time.units string was being constructed as:
  ```python
  # Before (bug): month slice used for both month and day
  f'seconds since {prop.start_date_full[0:4]}-{prop.start_date_full[4:6]}-{prop.start_date_full[4:6]} ...'

  # After (fix): correct day slice
  f'seconds since {prop.start_date_full[0:4]}-{prop.start_date_full[4:6]}-{prop.start_date_full[6:8]} ...'

  This produced timestamps like seconds since 2025-02-02 ... instead of seconds since 2025-02-08 ..., causing incorrect time references in SCHISM station netCDF output.

  Test plan

  - Already tested as part of PR #38