### PR TITLE
Fix 2D skill shape mismatch and pyinterp compatibility

### DIFF
--- a/src/ofs_skill/visualization/plotting_2d.py
+++ b/src/ofs_skill/visualization/plotting_2d.py
@@ -513,7 +513,7 @@ def plot_2d(prop1,logger):
         #Pair satellite and model files/dates,
         #if not paired already from the previous step
         #
-        if list(set(sat_dates).difference(mod_dates)):
+        if set(sat_dates) != set(mod_dates):
             #Oops there must be missing sat or mod data, let's correct it
             # Get satellite indices & dates that intersect model dates
             sat_ind,sat_dates = get_intersection(sat_dates,mod_dates)
@@ -522,7 +522,7 @@ def plot_2d(prop1,logger):
             mod_ind,mod_dates = get_intersection(mod_dates,sat_dates)
             mod_files = [mod_files[i] for i in mod_ind]
             # Check pairing again to make sure
-            if list(set(sat_dates).difference(mod_dates)):
+            if set(sat_dates) != set(mod_dates):
                 logger.error('Cannot pair satellite and model data! Abort!')
                 sys.exit(-1)
 
@@ -562,7 +562,7 @@ def plot_2d(prop1,logger):
                             round((((k+1)/(len(sat_dates)))*100),2))
                 try:
                     stats1d = metrics_two_d.return_one_d(z_sat[k,:,:],z_mod[k,:,:],logger)
-                except:
+                except Exception:
                     stats1d=None
                 stats1d_all.append(stats1d)
                 diff = z_mod[k,:,:] - z_sat[k,:,:]
@@ -604,7 +604,7 @@ def plot_2d(prop1,logger):
             #Write 2D skill csv
             try:
                 write_2dskill_csv(prop1,stats1d_all,sat_dates,logger)
-            except:
+            except Exception:
                 logger.error('Problem writting 2D skill csv.')
         else:
             logger.error('Only %s %s satellite times available, skipping statistics.',

--- a/src/ofs_skill/visualization/processing_2d.py
+++ b/src/ofs_skill/visualization/processing_2d.py
@@ -25,7 +25,7 @@ Functions:
 Author: AJK
 Created: 09/2024
 Last Modified: 03/2025 - Renamed from 'leaflet_contour', updates for intake
-Last Modified: 01/2026 - Refactored and updated to process model data if 
+Last Modified: 01/2026 - Refactored and updated to process model data if
                          observations are missing.
 """
 from __future__ import annotations
@@ -703,8 +703,11 @@ def interp_grid(
     import pyinterp
     from global_land_mask import globe
 
+    # pyinterp >= 2026.2 renamed RTree -> RTree3D and changed IDW API
+    _new_pyinterp = hasattr(pyinterp, 'RTree3D')
+
     logger.info('--- Resampling grid ---')
-    mesh = pyinterp.RTree()
+    mesh = pyinterp.RTree3D() if _new_pyinterp else pyinterp.RTree()
     mesh.packing(np.vstack((lons, lats)).T, sst)
 
     # --- Estimate source spacing (in meters) ---
@@ -726,28 +729,40 @@ def interp_grid(
 
     # --- First pass (strict) ---
     targets = np.vstack((lon_grid.ravel(), lat_grid.ravel())).T
-    sst_out, _ = mesh.inverse_distance_weighting(
-        targets,
-        within=True,
-        radius=base_radius,
-        k=8,
-        num_threads=0,
-    )
+    if _new_pyinterp:
+        idw_config = pyinterp.core.config.rtree.InverseDistanceWeighting()
+        idw_config = (idw_config
+                      .with_k(8)
+                      .with_radius(base_radius)
+                      .with_num_threads(0)
+                      .with_boundary_check(
+                          pyinterp.core.config.rtree.BoundaryCheck.CONVEX_HULL))
+        sst_out, _ = mesh.inverse_distance_weighting(targets, idw_config)
+    else:
+        sst_out, _ = mesh.inverse_distance_weighting(
+            targets, within=True, radius=base_radius, k=8, num_threads=0,
+        )
     sst_out = sst_out.reshape(lon_grid.shape)
 
     # --- Second pass (fill remaining gaps) ---
     mask = np.isnan(sst_out)
     if np.any(mask):
         logger.debug(f'Filling {mask.sum()} NaN values with larger radius...')
-        sst_fill, _ = mesh.inverse_distance_weighting(
-            np.vstack((lon_grid[mask], lat_grid[mask])).T,
-            #targets[mask],
-            within=False,
-            #radius=100 * base_radius,
-            radius=None,
-            k=16,
-            num_threads=0,
-        )
+        fill_targets = np.vstack((lon_grid[mask], lat_grid[mask])).T
+        if _new_pyinterp:
+            idw_fill = pyinterp.core.config.rtree.InverseDistanceWeighting()
+            idw_fill = (idw_fill
+                        .with_k(16)
+                        .with_radius(None)
+                        .with_num_threads(0)
+                        .with_boundary_check(
+                            pyinterp.core.config.rtree.BoundaryCheck.NONE))
+            sst_fill, _ = mesh.inverse_distance_weighting(
+                fill_targets, idw_fill)
+        else:
+            sst_fill, _ = mesh.inverse_distance_weighting(
+                fill_targets, within=False, radius=None, k=16, num_threads=0,
+            )
         sst_out[mask] = sst_fill
 
     # ==========================================


### PR DESCRIPTION
### Description of Changes
This PR fixes two issues in the 2D satellite skill assessment pipeline (`create_2dplot`):

1) **Shape mismatch bug** (`plotting_2d.py`): The satellite/model date pairing condition `set(sat_dates).difference(mod_dates)` only checked one direction — whether satellite dates were missing from model. When model had *more* timesteps than satellite (the common case), the condition evaluated to False, pairing was skipped, and `z_mod` ended up with more timesteps than `z_sat`, causing the error `"satellite and model arrays are different shapes!"`. Fixed by changing to `set(sat_dates) != set(mod_dates)` which catches mismatches in both directions.

2) **pyinterp API compatibility** (`processing_2d.py`): pyinterp >= 2026.2 renamed `RTree` to `RTree3D` and changed `inverse_distance_weighting()` from keyword arguments to a config object API. Added version detection (`hasattr(pyinterp, 'RTree3D')`) so the code works with both old and new pyinterp versions without requiring a dependency version bump.

Additionally fixed two pre-existing bare `except:` clauses flagged by ruff (changed to `except Exception:`).

---
### Expected Outcome of Changes
- The `create_2dplot` pipeline will no longer fail with "satellite and model arrays are different shapes!" when model output contains more hourly timesteps than satellite observations (e.g., model writes JSON for every hour but satellite data is only available for a subset of hours).
- The pipeline will work correctly with both pre-2026.2 and >= 2026.2 versions of pyinterp, requiring no changes to `pyproject.toml` or `environment.yml`.

---
### Developer Questions and Checklist
**Is this a high priority PR? If yes, why and is there a date by which it needs to be merged?**
Yes — the shape mismatch bug is currently blocking 2D skill assessments in production (e.g., dbofs).

**Are there any changes needed to how the code should be run on the server? (Commands, flags, job timings, etc.)**
No.

**Does this update need to be installed on the server?**
Yes, to fix the shape mismatch error occurring in production.

**Does this update require front end/web app changes?**
No.

**Does this impact code development work on adding SCHISM?**
No.

**Does this impact the expected number of output files for integration tests?**
No.

---
### Test Plan
- Ran full e2e test of `create_2dplot.py` for dbofs with 6-hour window (2026-03-01 00:00–06:00Z, nowcast)
- Verified 35 model JSON files and 14 observation JSON files were produced
- Confirmed `plot_2d()` completed all 7 time steps (100%) without the shape error
- Confirmed 2D skill statistics table was created successfully
- IDW interpolation worked correctly with pyinterp 2026.2 using the new config object API