### PR TITLE
Fix ROMS station indexing TypeError on Linux

### DIFF
--- a/src/ofs_skill/model_processing/indexing.py
+++ b/src/ofs_skill/model_processing/indexing.py
@@ -746,24 +746,27 @@ def index_nearest_station(
         lon_rho_np = np.array(model_netcdf['lon_rho'])
         lat_rho_np = np.array(model_netcdf['lat_rho'])
 
+        lat_flat = lat_rho_np.ravel()
+        lon_flat = lon_rho_np.ravel()
+
         for obs_p in range(len(ctl_file_extract)):
-            dist = np.empty(len(model_netcdf['lon_rho']))
+            dist = np.empty(lat_flat.shape)
             dist[:] = np.nan
             obs_lon = float(ctl_file_extract[obs_p][1])
             obs_lat = float(ctl_file_extract[obs_p][0])
 
             nearby_nodes = np.argwhere(
-                (lon_rho_np < obs_lon + 0.1) &
-                (lon_rho_np > obs_lon - 0.1) &
-                (lat_rho_np < obs_lat + 0.1) &
-                (lat_rho_np > obs_lat - 0.1)
+                (lon_flat < obs_lon + 0.1) &
+                (lon_flat > obs_lon - 0.1) &
+                (lat_flat < obs_lat + 0.1) &
+                (lat_flat > obs_lat - 0.1)
             )
 
             if nearby_nodes.size > 0:
-                for i_index in nearby_nodes:
+                for i_index in nearby_nodes[:, 0]:
                     distance = calculate_station_distance(
-                        lat_rho_np[i_index],
-                        lon_rho_np[i_index],
+                        float(lat_flat[i_index]),
+                        float(lon_flat[i_index]),
                         obs_lat,
                         obs_lon
                     )


### PR DESCRIPTION
### Description of Changes

Fixes a `TypeError: only 0-dimensional arrays can be converted to Python scalars` crash in `index_nearest_station()` when running ROMS-based OFS (e.g., CBOFS) on Linux.

**Root cause:** In the ROMS branch of `index_nearest_station`, `np.argwhere()` returns multi-element index arrays. When these are used to index `lat_rho_np` and `lon_rho_np`, the result is a NumPy array (not a scalar), which is then passed to `math.cos()` via `calculate_station_distance()`. The Linux conda-forge NumPy build enforces strict scalar conversion and raises `TypeError`, while the Windows NumPy pip wheel allows implicit size-1 array coercion with a deprecation warning.

**Fix:** Flatten `lat_rho`/`lon_rho` with `ravel()` before the `argwhere` search, extract scalar indices with `[:, 0]`, and explicitly convert to `float()` before passing to the Haversine distance function. This matches the pattern already used in the SCHISM/FVCOM code path (line 719). The flattened indices remain compatible with downstream `np.unravel_index()` calls in `write_ofs_ctlfile.py`.

---
### Expected Outcome of Changes

- ROMS-based OFS (CBOFS, DBOFS, etc.) station indexing works on both Linux and Windows.
- No change to output values — the same nearest-station indices are produced.

---
### Developer Questions and Checklist
**Is this a high priority PR? If yes, why and is there a date by which it needs to be merged?**
Yes — this blocks ROMS 1D skill assessments on the Linux server.

**Are there any changes needed to how the code should be run on the server? (Commands, flags, job timings, etc.)**
No.

**Does this update need to be installed on the server?**
Yes.

**Does this update require front end/web app changes? (If yes, provide documentation to Min)**
No.

**Does this impact code development work on adding SCHISM? (If yes, tag Atieh)**
No.

**Does this impact the expected number of output files for integration tests (i.e., will the integration test fail even though code changes result in desired change in the number of outputs?)**
No.

- [x] Developer's name is removed throughout the code?
- [x] Did you add relevant labels to the PR?
- [x] Have you run pylint and is the code at an acceptable pylint score? (>8.0)
- [x] Jobs contain the appropriate file checking and handle errors for any missing data?
- [x] Is log free of critical ERRORs or WARNINGs? For errors that are not critical and can remain in code, is there sufficient handling and logging?

---
### Testing Instructions

Run a 1D skill assessment for any ROMS-based OFS (CBOFS, DBOFS, etc.) on the Linux server:

```bash
python ./bin/visualization/create_1dplot.py -o cbofs -p ./ -s 2026-03-01T00:00:00Z -e 2026-03-02T00:00:00Z -d MLLW -ws nowcast -t stations -vs water_level,currents
```

- Verify the `TypeError` no longer occurs when processing currents (or any variable).
- Verify station matching logs show "Nearest station found" as expected.
- Verify output plots and control files are identical to a known-good Windows run.

### Reminder checklist for PR reviewer:
- [ ] Run PEP8 compliance tests to ensure the code follows best practices
- [ ] Check that documentation in the script is sufficient
- [ ] Validate the output values (if applicable) to make sure the calculations are correct and make scientific/physical sense; include a comment on the pull request including what validation you performed, for replicability.
- [ ] Test code both locally and on the linux server, using several OFS as test cases
- [ ] When approving or commenting on a pull request, add information on the calls you use in case they need to be replicated.