### PR TITLE
reduce static plot DPI

### DIFF
--- a/src/ofs_skill/visualization/make_static_plots.py
+++ b/src/ofs_skill/visualization/make_static_plots.py
@@ -124,6 +124,7 @@ def scalar_plots(now_fores_paired, name_var, station_id, node, prop, logger):
         ncolors, 2.5, 0.9, 0.65,
     )
     image_type = 'png'
+    dpi = 100
 
     # Get target error range
     if name_var != 'ice_conc':
@@ -201,7 +202,7 @@ def scalar_plots(now_fores_paired, name_var, station_id, node, prop, logger):
     filename = f'{prop.ofs}_{station_id[0]}_{save_name}_timeseries_' +\
         f'{naming_ws}_{prop.ofsfiletype}.{image_type}'
     filepath = os.path.join(prop.om_files, filename)
-    fig.savefig(filepath, format=image_type, dpi=200, bbox_inches='tight')
+    fig.savefig(filepath, format=image_type, dpi=dpi, bbox_inches='tight')
 
 
 def vector_plots(now_fores_paired, name_var, station_id, node, prop, logger):
@@ -220,6 +221,7 @@ def vector_plots(now_fores_paired, name_var, station_id, node, prop, logger):
         ncolors, 2.5, 0.9, 0.65,
     )
     image_type = 'png'
+    dpi = 100
 
     # Get target error range
     if name_var != 'ice_conc':
@@ -312,7 +314,7 @@ def vector_plots(now_fores_paired, name_var, station_id, node, prop, logger):
     filename = f'{prop.ofs}_{station_id[0]}_currents_timeseries_{naming_ws}_' \
         + f'{prop.ofsfiletype}.{image_type}'
     filepath = os.path.join(prop.om_files, filename)
-    fig.savefig(filepath, format=image_type, dpi=200, bbox_inches='tight')
+    fig.savefig(filepath, format=image_type, dpi=dpi, bbox_inches='tight')
     plt.close('all')
 
 
@@ -324,6 +326,7 @@ def bar_plots(data, info, ytitle, prop, logger):
     '''
 
     image_type = 'png'
+    dpi = 100
 
     #Format y axis label
     ytitle=ytitle.replace('<br>', '\n').replace('<i>','').replace(' or error','')
@@ -457,5 +460,5 @@ def bar_plots(data, info, ytitle, prop, logger):
     plt.tight_layout(pad=3)
     filename = f'{prop.ofs}_{info[2]}_{info[7]}_{namestat}_bars.{image_type}'
     filepath = os.path.join(prop.om_files, filename)
-    fig.savefig(filepath, format=image_type, dpi=300, bbox_inches='tight')
+    fig.savefig(filepath, format=image_type, dpi=dpi, bbox_inches='tight')
     plt.close('all')


### PR DESCRIPTION
### Description of Changes

The static plots for the overview/O&M dashboard were taking up too much space on the CO-OPS server. This update reduces the static plot DPI from 300 to 100.

### Expected Outcome of Changes

Smaller static plot sizes, and a smaller memory footprint on the server.

### Developer Questions and Checklist
**Is this a high priority PR? If yes, why and is there a date by which it needs to be merged?**
Yes, currently the static plot files are filling up the CO-OPS server.

**Are there any changes needed to how the code should be run on the server? (Commands, flags, job timings, etc.)**
No. But a reminder to set `static_plots=True` in the configuration file.

**Does this update need to be installed on the server?**
Yes.

**Does this update require front end/web app changes? (If yes, provide documentation to Min)**
No.

**Does this impact code development work on adding SCHISM? (If yes, tag Atieh)**
No.

**Does this impact code development work on adding ADCIRC?**
_No/Yes + tag Jack if yes_
No.

**Does this impact the expected number of output files for integration tests (i.e., will the integration test fail even though code changes result in desired change in the number of outputs?)**
No.

- [ ] Developer's name is removed throughout the code?
- [ ] Did you add relevant labels to the PR?
- [ ] Have you run pylint and is the code at an acceptable pylint score? (>8.0)
- [ ] Jobs contain the appropriate file checking and handle errors for any missing data?
- [ ] Is log free of critical ERRORs or WARNINGs? For errors that are not critical and can remain in code, is there sufficient handling and logging?

### Testing Instructions

No testing required, but if you'd like, just turn static plots on in `ofs_dps.conf`, and complete a 1D run of your choice. Check in ./data/visual/om_files/ for static plots, and verify that they are <~120 kb in size.

### Reminder checklist for PR reviewer:
- [ ] Run PEP8 compliance tests to ensure the code follows best practices
- [ ] Check that documentation in the script is sufficient
- [ ] Validate the output values (if applicable) to make sure the calculations are correct and make scientific/physical sense; include a comment on the pull request including what validation you performed, for replicability.
- [ ] Test code both locally and on the linux server, using several OFS as test cases
- [ ] When approving or commenting on a pull request, add information on the calls you use in case they need to be replicated.
