### PR TITLE
Fix NECOFS depth indexing KeyError on missing z variable

### DIFF
--- a/src/ofs_skill/model_processing/indexing.py
+++ b/src/ofs_skill/model_processing/indexing.py
@@ -334,7 +334,7 @@ def index_nearest_node(
 
     elif model_source == 'adcirc':
         raise NotImplementedError('ADCIRC indexing not yet implemented.')
-    
+
     else:
         raise ValueError(f'Unknown model source: {model_source}')
 
@@ -394,8 +394,16 @@ def index_nearest_depth(
         length = len(index_min_dist)
 
         if model_source == 'fvcom':
-            zc_np = np.array(model_netcdf['zc'])  # Element center depths
-            z_np = np.array(model_netcdf['z'])    # Node depths
+            if 'zc' in model_netcdf:
+                zc_np = np.array(model_netcdf['zc'])  # Element center depths
+            if 'z' in model_netcdf:
+                z_np = np.array(model_netcdf['z'])    # Node depths
+            else:
+                # Some FVCOM outputs (e.g. NECOFS) lack pre-computed z;
+                # approximate from sigma coordinates and bathymetry
+                siglay = np.array(model_netcdf['siglay'])
+                h = np.array(model_netcdf['h'])
+                z_np = siglay * h
         elif model_source == 'roms':
             lon_rho_np = np.array(model_netcdf['lon_rho'])
             s_rho_np = np.array(model_netcdf['s_rho'])
@@ -592,17 +600,17 @@ def index_nearest_depth(
                         index_min_depth.append(0)
                         depth_value.append(0.0)
                         logger.info(
-                            'Nearest depth found: node %s of %s', 
+                            'Nearest depth found: node %s of %s',
                             idx + 1, len(index_min_dist)
                         )
                     else:
-                        # We raise en exception here for STOFS-2D-Global non-water level variables 
+                        # We raise en exception here for STOFS-2D-Global non-water level variables
                         # because it does not have depth-wise data, and logic elsewhere should steer users
                         # away from calling this function with STOFS-2D-Global and other variables.
                         raise ValueError('STOFS-2D-Global does not have depth-resolved data, cannot find nearest depth')
                 else:
                     raise NotImplementedError('ADCIRC depth indexing not yet implemented for models other than STOFS-2D-Global.')
-                
+
     elif prop.ofsfiletype == 'stations':
         if 'stofs' in prop.ofs:
             return [], []
@@ -610,7 +618,25 @@ def index_nearest_depth(
         depth_value = []
         length = len(index_min_dist)
         if model_source == 'fvcom':
-            z_np = np.array(model_netcdf['z'])
+            if name_var == 'wl':
+                # Water level (zeta) is a 2D surface variable — no depth indexing needed
+                for idx in range(length):
+                    if ~np.isnan(index_min_dist[idx]):
+                        index_min_depth.append(0)
+                        depth_value.append(0.0)
+                        logger.info('Nearest depth found: node %s of %s', idx + 1, length)
+                    else:
+                        index_min_depth.append(np.nan)
+                        depth_value.append(np.nan)
+                return index_min_depth, np.abs(depth_value)
+            if 'z' in model_netcdf:
+                z_np = np.array(model_netcdf['z'])
+            else:
+                # Some FVCOM outputs (e.g. NECOFS) lack pre-computed z;
+                # compute from sigma coordinates and bathymetry
+                siglay = np.array(model_netcdf['siglay'])
+                h = np.array(model_netcdf['h'])
+                z_np = siglay * h
         elif model_source == 'roms':
             s_rho_np = np.array(model_netcdf['s_rho'])
             h_np = np.array(model_netcdf['h'])
@@ -637,7 +663,7 @@ def index_nearest_depth(
                             )
                             continue
                         else:
-                            # We raise en exception here for STOFS-2D-Global non-water level variables 
+                            # We raise en exception here for STOFS-2D-Global non-water level variables
                             # because it does not have depth-wise data, and logic elsewhere should steer users
                             # away from calling this function with STOFS-2D-Global and other variables.
                             raise ValueError('STOFS-2D-Global does not have depth-resolved data, cannot find nearest depth')


### PR DESCRIPTION
## Summary

Fixes a `KeyError: 'z'` that occurs when running the 1D skill assessment pipeline for **NECOFS** (and potentially other FVCOM models whose output lacks a pre-computed `z` variable).

### Problem

NECOFS's FVCOM station output does not include a pre-computed `z` variable for vertical depth coordinates — it only provides `siglev`/`siglay` (sigma coordinates) and `h` (bathymetry). The `index_nearest_depth()` function in `indexing.py` unconditionally accessed `model_netcdf['z']` for all FVCOM models, causing a `KeyError` during control file creation.

The error is **transient** in practice: once the model control file (e.g. `necofs_wl_model_station.ctl`) is cached from a previous successful run, this code path is skipped entirely. It only manifests when the control file needs to be (re)created.

```
KeyError: "No variable named 'z'. Variables on the dataset include 
['time', 'x', 'y', 'lon', 'lat', ..., 'zeta', 'uwind_speed', 'vwind_speed', 'siglev', 'siglay']"
```

### Fix

- **Water level short-circuit for FVCOM stations**: `zeta` is a 2D surface variable with no depth dimension — depth indexing is unnecessary. Return `depth=0` for all stations, matching how SCHISM and ADCIRC already handle `wl`.
- **`z` fallback for 3D variables** (temp, salt, currents): When the pre-computed `z` variable is absent, approximate depth from `siglay * h`. This ignores surface elevation (`zeta`) in the depth calculation, but for the purpose of finding the nearest sigma layer to a station depth, it is sufficiently accurate — `zeta` is typically O(1m) vs bathymetry O(10-100m).
- **Guard `zc` access in fields branch**: Same issue for element-center depths in the 2D fields processing path.

## Test plan

- [ ] Run NECOFS 1D water_level (stations) with no cached ctl file — should succeed without `KeyError`
- [ ] Run an FVCOM model that *does* have `z` (e.g. sfbofs, ngofs2) — verify no regression
- [ ] Run NECOFS 3D variable (temp/salt) if station data is available — verify `siglay * h` fallback produces reasonable depth indexing