### PR TITLE
Improve list_of_files error handling and add whichcast validation

### DIFF
--- a/bin/visualization/create_1dplot.py
+++ b/bin/visualization/create_1dplot.py
@@ -365,6 +365,15 @@ def create_1dplot(prop, logger):
 
     logger.info('Starting parameter validation...')
 
+    # Validate whichcast values
+    valid_whichcasts = {'nowcast', 'forecast_a', 'forecast_b', 'hindcast'}
+    for wc in prop.whichcasts:
+        if wc.lower() not in valid_whichcasts:
+            logger.error("Invalid whichcast value: '%s'. "
+                         'Valid values: %s. Abort!',
+                         wc, sorted(valid_whichcasts))
+            sys.exit(-1)
+
     # Do forecast_a start and end date reshuffle
 
     if 'forecast_a' in prop.whichcasts:

--- a/bin/visualization/create_2dplot.py
+++ b/bin/visualization/create_2dplot.py
@@ -131,7 +131,10 @@ def validate_and_initialize_parameters(prop):
             sys.exit(-1)
 
     if 'forecast_a' in prop.whichcasts and prop.forecast_hr is None:
-        logger.error('Forecast_Hr is required if Whichcast is forecast_a. Abort!')
+        logger.error(
+            'Forecast_Hr (e.g., "now", "06z", "12z") is required '
+            'if Whichcast is forecast_a. Abort!'
+        )
         sys.exit(-1)
 
     # Create necessary directories

--- a/bin/visualization/create_2dplot.py
+++ b/bin/visualization/create_2dplot.py
@@ -126,11 +126,11 @@ def validate_and_initialize_parameters(prop):
     prop.whichcasts = prop.whichcasts.replace(']', '')
     prop.whichcasts = prop.whichcasts.split(',')
     for whichcast in prop.whichcasts:
-        if whichcast not in {'nowcast', 'forecast_a', 'forecast_b'}:
+        if whichcast not in {'nowcast', 'forecast_a', 'forecast_b', 'hindcast'}:
             logger.error("Invalid whichcast value: '%s'. Abort!",prop.whichcasts)
             sys.exit(-1)
 
-    if prop.whichcasts == 'forecast_a' and prop.forecast_hr is None:
+    if 'forecast_a' in prop.whichcasts and prop.forecast_hr is None:
         logger.error('Forecast_Hr is required if Whichcast is forecast_a. Abort!')
         sys.exit(-1)
 

--- a/bin/visualization/create_2dplot.py
+++ b/bin/visualization/create_2dplot.py
@@ -127,7 +127,7 @@ def validate_and_initialize_parameters(prop):
     prop.whichcasts = prop.whichcasts.split(',')
     for whichcast in prop.whichcasts:
         if whichcast not in {'nowcast', 'forecast_a', 'forecast_b', 'hindcast'}:
-            logger.error("Invalid whichcast value: '%s'. Abort!",prop.whichcasts)
+            logger.error("Invalid whichcast value: '%s'. Abort!", whichcast)
             sys.exit(-1)
 
     if 'forecast_a' in prop.whichcasts and prop.forecast_hr is None:

--- a/src/ofs_skill/model_processing/list_of_files.py
+++ b/src/ofs_skill/model_processing/list_of_files.py
@@ -642,8 +642,8 @@ def list_of_files(prop: Any, dir_list: list[str], logger: Logger) -> list[str]:
     if prop.ofs == 'loofs2' and prop.whichcast == 'hindcast':
         use_s3_fallback = False
 
+    list_files = []
     try:
-        list_files = []
         dir_list_len = len(dir_list)
         for i_index in range(0, dir_list_len):
 
@@ -665,7 +665,14 @@ def list_of_files(prop: Any, dir_list: list[str], logger: Logger) -> list[str]:
                 # Old file format:
                 # nos.cbofs.fields.n001.20240901.t00z.nc
 
-                all_files = listdir(dir_list[i_index])
+                try:
+                    all_files = listdir(dir_list[i_index])
+                except OSError as e:
+                    logger.error('Cannot read directory %s: %s. Skipping.', dir_list[i_index], e)
+                    if use_s3_fallback:
+                        files = construct_expected_files(prop, dir_list[i_index], logger)
+                        list_files.append(files)
+                    continue
                 files = []
                 hr_cyc_day = []
                 #TODO: The above three definitions could be moved to before the whichcast if blocks to avoid repetition.
@@ -673,111 +680,119 @@ def list_of_files(prop: Any, dir_list: list[str], logger: Logger) -> list[str]:
                     ndays = 1
                 else:
                     ndays = 0
+                skipped_files = []
                 for af_name in all_files:
-                    spltstr = af_name.split('.')
-                    # First do old file names
-                    if 'nos.' in af_name:
-                        if 'fields.n' in af_name and prop.ofsfiletype == 'fields':
-                            checkstr = spltstr[-4][-3:] + spltstr[-2][1:3] + \
-                                spltstr[-3][-2:]
-                            if (checkstr not in hr_cyc_day
-                                and (datetime.strptime(spltstr[-3], '%Y%m%d') >=
-                                     datetime.strptime
-                                     (prop.startdate[:-2], '%Y%m%d'))
-                                and (datetime.strptime(spltstr[-3], '%Y%m%d') <=
-                                     datetime.strptime
-                                     (prop.enddate[:-2], '%Y%m%d') +
-                                     timedelta(days=ndays))
-                                and checkstr[0:3] != '000'
-                                ):
-                                hr_cyc_day.append(checkstr)
-                                files.append(af_name)
-                        elif ('stations.n' in af_name and
-                              prop.ofsfiletype == 'stations'):
-                            checkstr = '999' + spltstr[-2][1:3] + spltstr[-3][-2:]
-                            if (checkstr not in hr_cyc_day
-                                and (datetime.strptime(spltstr[-3], '%Y%m%d') >=
-                                     datetime.strptime
-                                     (prop.startdate[:-2], '%Y%m%d'))
-                                and (datetime.strptime(spltstr[-3], '%Y%m%d') <=
-                                     datetime.strptime
-                                     (prop.enddate[:-2], '%Y%m%d') +
-                                     timedelta(days=ndays))
-                                and checkstr[0:3] != '000'
-                                ):
-                                hr_cyc_day.append(checkstr)
-                                files.append(af_name)
+                    try:
+                        spltstr = af_name.split('.')
+                        # First do old file names
+                        if 'nos.' in af_name:
+                            if 'fields.n' in af_name and prop.ofsfiletype == 'fields':
+                                checkstr = spltstr[-4][-3:] + spltstr[-2][1:3] + \
+                                    spltstr[-3][-2:]
+                                if (checkstr not in hr_cyc_day
+                                    and (datetime.strptime(spltstr[-3], '%Y%m%d') >=
+                                         datetime.strptime
+                                         (prop.startdate[:-2], '%Y%m%d'))
+                                    and (datetime.strptime(spltstr[-3], '%Y%m%d') <=
+                                         datetime.strptime
+                                         (prop.enddate[:-2], '%Y%m%d') +
+                                         timedelta(days=ndays))
+                                    and checkstr[0:3] != '000'
+                                    ):
+                                    hr_cyc_day.append(checkstr)
+                                    files.append(af_name)
+                            elif ('stations.n' in af_name and
+                                  prop.ofsfiletype == 'stations'):
+                                checkstr = '999' + spltstr[-2][1:3] + spltstr[-3][-2:]
+                                if (checkstr not in hr_cyc_day
+                                    and (datetime.strptime(spltstr[-3], '%Y%m%d') >=
+                                         datetime.strptime
+                                         (prop.startdate[:-2], '%Y%m%d'))
+                                    and (datetime.strptime(spltstr[-3], '%Y%m%d') <=
+                                         datetime.strptime
+                                         (prop.enddate[:-2], '%Y%m%d') +
+                                         timedelta(days=ndays))
+                                    and checkstr[0:3] != '000'
+                                    ):
+                                    hr_cyc_day.append(checkstr)
+                                    files.append(af_name)
 
-                    # Now do new file names
-                    elif 'nos.' not in af_name:
-                        if 'fields.n' in af_name and prop.ofsfiletype == 'fields':
-                            checkstr = spltstr[-2][-3:] + spltstr[-5][1:3] + \
-                                spltstr[-4][-2:]
-                            if (checkstr not in hr_cyc_day
-                                and (datetime.strptime(spltstr[-4], '%Y%m%d') >=
-                                     datetime.strptime
-                                     (prop.startdate[:-2], '%Y%m%d'))
-                                and (datetime.strptime(spltstr[-4], '%Y%m%d') <=
-                                     datetime.strptime(prop.enddate[:-2], '%Y%m%d')
-                                     + timedelta(days=ndays))
-                                and checkstr[0:3] != '000'
-                                ):
-                                hr_cyc_day.append(checkstr)
-                                files.append(af_name)
-                        elif ('stations.n' in af_name and
-                              prop.ofsfiletype == 'stations'):
-                            checkstr = '999' + spltstr[-5][1:3] + spltstr[-4][-2:]
-                            if (checkstr not in hr_cyc_day
-                                and (datetime.strptime(spltstr[-4], '%Y%m%d') >=
-                                     datetime.strptime
-                                     (prop.startdate[:-2], '%Y%m%d'))
-                                and (datetime.strptime(spltstr[-4], '%Y%m%d') <=
-                                     datetime.strptime(prop.enddate[:-2], '%Y%m%d')
-                                     + timedelta(days=ndays))
-                                and checkstr[0:3] != '000'
-                                ):
-                                hr_cyc_day.append(checkstr)
-                                files.append(af_name)
-                        elif prop.ofs in ('stofs_3d_atl', 'stofs_3d_pac'):  # add stofs filename format
-                            if 'n0' in af_name and 'fields' in af_name:  # skiping filed2d post process
-                                # Split the string based on underscores and periods
-                                spltstr = af_name.split('_')
-                                # Extract the values
-                                checkstr1 = spltstr[-2][-2:]
-                                checkstr2 = spltstr[-1].split('.')[0][1:3]
-                                if ((int(checkstr2) - 1 >= int(prop.startdate[-2:]))
-                                    and (int(checkstr1) - 1 <= int(prop.enddate[-2:]))
+                        # Now do new file names
+                        elif 'nos.' not in af_name:
+                            if 'fields.n' in af_name and prop.ofsfiletype == 'fields':
+                                checkstr = spltstr[-2][-3:] + spltstr[-5][1:3] + \
+                                    spltstr[-4][-2:]
+                                if (checkstr not in hr_cyc_day
+                                    and (datetime.strptime(spltstr[-4], '%Y%m%d') >=
+                                         datetime.strptime
+                                         (prop.startdate[:-2], '%Y%m%d'))
+                                    and (datetime.strptime(spltstr[-4], '%Y%m%d') <=
+                                         datetime.strptime(prop.enddate[:-2], '%Y%m%d')
+                                         + timedelta(days=ndays))
+                                    and checkstr[0:3] != '000'
                                     ):
+                                    hr_cyc_day.append(checkstr)
                                     files.append(af_name)
-                                    hr_cyc_day.append(checkstr1)
-                            elif prop.ofsfiletype == 'stations':
-                                # Split the string based on underscores and periods
-                                spltstr = af_name.split('_')
-                                # Extract the values
-                                checkstr1 = spltstr[-2][-2:]
-                                checkstr2 = spltstr[-1].split('.')[0][1:3]
-                                if ((int(checkstr2) - 1 >= int(prop.startdate[-2:]))
-                                    and (int(checkstr1) - 1 <= int(prop.enddate[-2:]))
+                            elif ('stations.n' in af_name and
+                                  prop.ofsfiletype == 'stations'):
+                                checkstr = '999' + spltstr[-5][1:3] + spltstr[-4][-2:]
+                                if (checkstr not in hr_cyc_day
+                                    and (datetime.strptime(spltstr[-4], '%Y%m%d') >=
+                                         datetime.strptime
+                                         (prop.startdate[:-2], '%Y%m%d'))
+                                    and (datetime.strptime(spltstr[-4], '%Y%m%d') <=
+                                         datetime.strptime(prop.enddate[:-2], '%Y%m%d')
+                                         + timedelta(days=ndays))
+                                    and checkstr[0:3] != '000'
                                     ):
+                                    hr_cyc_day.append(checkstr)
                                     files.append(af_name)
-                                    hr_cyc_day.append(checkstr1)
-                        elif prop.ofs in ('stofs_2d_glo'):
-                            # STOFS-2D-Global files each contain the full timeseries,
-                            # so we filter only on:
-                            # (1) station vs fields;
-                            # (2) netcdf format.
-                            # Example names: stofs_2d_glo.t00z.fields.cwl.nc, stofs_2d_glo.t00z.points.cwl.nc
-                            # For sorting, we need just the model cycle (only one file per time series;
-                            # only one day per directory).
-                            # But to work with the sorting method used for other OFS,
-                            # we have to construct a string that looks like the other checkstrs.
-                            if af_name.endswith('.nc'):
-                                if (prop.ofsfiletype == 'fields') and ('fields' in af_name):
-                                    files.append(af_name)
-                                    hr_cyc_day.append('000' + af_name.split('.')[1][1:3] + '00')
-                                elif (prop.ofsfiletype == 'stations') and ('points' in af_name):
-                                    files.append(af_name)
-                                    hr_cyc_day.append('000' + af_name.split('.')[1][1:3] + '00')
+                            elif prop.ofs in ('stofs_3d_atl', 'stofs_3d_pac'):  # add stofs filename format
+                                if 'n0' in af_name and 'fields' in af_name:  # skiping filed2d post process
+                                    # Split the string based on underscores and periods
+                                    spltstr = af_name.split('_')
+                                    # Extract the values
+                                    checkstr1 = spltstr[-2][-2:]
+                                    checkstr2 = spltstr[-1].split('.')[0][1:3]
+                                    if ((int(checkstr2) - 1 >= int(prop.startdate[-2:]))
+                                        and (int(checkstr1) - 1 <= int(prop.enddate[-2:]))
+                                        ):
+                                        files.append(af_name)
+                                        hr_cyc_day.append(checkstr1)
+                                elif prop.ofsfiletype == 'stations':
+                                    # Split the string based on underscores and periods
+                                    spltstr = af_name.split('_')
+                                    # Extract the values
+                                    checkstr1 = spltstr[-2][-2:]
+                                    checkstr2 = spltstr[-1].split('.')[0][1:3]
+                                    if ((int(checkstr2) - 1 >= int(prop.startdate[-2:]))
+                                        and (int(checkstr1) - 1 <= int(prop.enddate[-2:]))
+                                        ):
+                                        files.append(af_name)
+                                        hr_cyc_day.append(checkstr1)
+                            elif prop.ofs in ('stofs_2d_glo'):
+                                # STOFS-2D-Global files each contain the full timeseries,
+                                # so we filter only on:
+                                # (1) station vs fields;
+                                # (2) netcdf format.
+                                # Example names: stofs_2d_glo.t00z.fields.cwl.nc, stofs_2d_glo.t00z.points.cwl.nc
+                                # For sorting, we need just the model cycle (only one file per time series;
+                                # only one day per directory).
+                                # But to work with the sorting method used for other OFS,
+                                # we have to construct a string that looks like the other checkstrs.
+                                if af_name.endswith('.nc'):
+                                    if (prop.ofsfiletype == 'fields') and ('fields' in af_name):
+                                        files.append(af_name)
+                                        hr_cyc_day.append('000' + af_name.split('.')[1][1:3] + '00')
+                                    elif (prop.ofsfiletype == 'stations') and ('points' in af_name):
+                                        files.append(af_name)
+                                        hr_cyc_day.append('000' + af_name.split('.')[1][1:3] + '00')
+                    except (IndexError, ValueError, TypeError) as e:
+                        skipped_files.append(af_name)
+                        logger.debug('Skipping unparseable file in %s: %s (%s)', dir_list[i_index], af_name, e)
+                if skipped_files:
+                    logger.warning('Skipped %d unparseable file(s) in %s: %s',
+                                   len(skipped_files), dir_list[i_index], skipped_files[:5])
 
                 files = [dir_list[i_index] + '//' + i for i in files]
 
@@ -798,29 +813,24 @@ def list_of_files(prop: Any, dir_list: list[str], logger: Logger) -> list[str]:
                     files = construct_expected_files(prop, dir_list[i_index], logger)
 
             elif prop.whichcast == 'hindcast':
-                all_files = listdir(dir_list[i_index])
+                try:
+                    all_files = listdir(dir_list[i_index])
+                except OSError as e:
+                    logger.error('Cannot read directory %s: %s. Skipping.', dir_list[i_index], e)
+                    if use_s3_fallback:
+                        files = construct_expected_files(prop, dir_list[i_index], logger)
+                        list_files.append(files)
+                    continue
                 files = []
                 hr_cyc_day = []
                 ndays = 0
+                skipped_files = []
                 for af_name in all_files:
-                    spltstr = af_name.split('.')
-                    if ('stations.h' in af_name and
-                          prop.ofsfiletype == 'stations'):
-                        checkstr = '999' + spltstr[-5][1:3] + spltstr[-4][-2:]
-                        if (checkstr not in hr_cyc_day
-                            and (datetime.strptime(spltstr[-4], '%Y%m%d') >=
-                                 datetime.strptime
-                                 (prop.startdate[:-2], '%Y%m%d'))
-                            and (datetime.strptime(spltstr[-4], '%Y%m%d') <=
-                                 datetime.strptime(prop.enddate[:-2], '%Y%m%d')
-                                 + timedelta(days=ndays))
-                            and checkstr[0:3] != '000'
-                            ):
-                            hr_cyc_day.append(checkstr)
-                            files.append(af_name)
-                    elif ('out2d' in af_name and prop.ofsfiletype == 'fields'):
-                            checkstr = '999' + spltstr[-5][1:3] + \
-                                spltstr[-4][-2:]
+                    try:
+                        spltstr = af_name.split('.')
+                        if ('stations.h' in af_name and
+                              prop.ofsfiletype == 'stations'):
+                            checkstr = '999' + spltstr[-5][1:3] + spltstr[-4][-2:]
                             if (checkstr not in hr_cyc_day
                                 and (datetime.strptime(spltstr[-4], '%Y%m%d') >=
                                      datetime.strptime
@@ -832,6 +842,26 @@ def list_of_files(prop: Any, dir_list: list[str], logger: Logger) -> list[str]:
                                 ):
                                 hr_cyc_day.append(checkstr)
                                 files.append(af_name)
+                        elif ('out2d' in af_name and prop.ofsfiletype == 'fields'):
+                                checkstr = '999' + spltstr[-5][1:3] + \
+                                    spltstr[-4][-2:]
+                                if (checkstr not in hr_cyc_day
+                                    and (datetime.strptime(spltstr[-4], '%Y%m%d') >=
+                                         datetime.strptime
+                                         (prop.startdate[:-2], '%Y%m%d'))
+                                    and (datetime.strptime(spltstr[-4], '%Y%m%d') <=
+                                         datetime.strptime(prop.enddate[:-2], '%Y%m%d')
+                                         + timedelta(days=ndays))
+                                    and checkstr[0:3] != '000'
+                                    ):
+                                    hr_cyc_day.append(checkstr)
+                                    files.append(af_name)
+                    except (IndexError, ValueError, TypeError) as e:
+                        skipped_files.append(af_name)
+                        logger.debug('Skipping unparseable file in %s: %s (%s)', dir_list[i_index], af_name, e)
+                if skipped_files:
+                    logger.warning('Skipped %d unparseable file(s) in %s: %s',
+                                   len(skipped_files), dir_list[i_index], skipped_files[:5])
                 files = [dir_list[i_index] + '//' + i for i in files]
 
                 # Only sort if we have files
@@ -855,106 +885,121 @@ def list_of_files(prop: Any, dir_list: list[str], logger: Logger) -> list[str]:
                 # Old file format:
                 # nos.cbofs.fields.f001.20240901.t00z.nc
                 a_start = prop.startdate
-                all_files = listdir(dir_list[i_index])
+                try:
+                    all_files = listdir(dir_list[i_index])
+                except OSError as e:
+                    logger.error('Cannot read directory %s: %s. Skipping.', dir_list[i_index], e)
+                    if use_s3_fallback:
+                        files = construct_expected_files(prop, dir_list[i_index], logger)
+                        list_files.append(files)
+                    continue
                 files = []
                 hr_cyc_day = []
                 cycle_z = a_start[-2:] + 'z'
+                skipped_files = []
                 for af_name in all_files:
-                    spltstr = af_name.split('.')
-                    # First do old file names
-                    if 'nos.' in af_name:
-                        if ('fields.f' in af_name and
-                            prop.ofsfiletype == 'fields' and
-                            cycle_z in af_name):
-                            checkstr = spltstr[-4][-3:] + spltstr[-2][1:3] + \
-                                spltstr[-3][-2:]
-                            if (checkstr not in hr_cyc_day
-                                and (datetime.strptime(spltstr[-3], '%Y%m%d') ==
-                                     datetime.strptime
-                                     (a_start[:8], '%Y%m%d'))
-                                and checkstr[0:3] != '000'
-                                ):
-                                hr_cyc_day.append(checkstr)
-                                files.append(af_name)
-                        elif ('stations.f' in af_name and
-                              prop.ofsfiletype == 'stations' and
-                              cycle_z in af_name):
-                            checkstr = '999' + spltstr[-2][1:3] + spltstr[-3][-2:]
-                            if (checkstr not in hr_cyc_day
-                                and (datetime.strptime(spltstr[-3], '%Y%m%d') ==
-                                     datetime.strptime
-                                     (a_start[:8], '%Y%m%d'))
-                                and checkstr[0:3] != '000'
-                                ):
-                                hr_cyc_day.append(checkstr)
-                                files.append(af_name)
-
-                    # Now do new file names
-                    elif 'nos.' not in af_name:
-                        if ('fields.f' in af_name and
-                            prop.ofsfiletype == 'fields' and
-                            cycle_z in af_name):
-                            checkstr = spltstr[-2][-3:] + spltstr[-5][1:3] + \
-                                spltstr[-4][-2:]
-                            if (checkstr not in hr_cyc_day
-                                and (datetime.strptime(spltstr[-4], '%Y%m%d') ==
-                                     datetime.strptime
-                                     (a_start[:8], '%Y%m%d'))
-                                and checkstr[0:3] != '000'
-                                ):
-                                hr_cyc_day.append(checkstr)
-                                files.append(af_name)
-                        elif ('stations.f' in af_name and
-                              prop.ofsfiletype == 'stations' and
-                              cycle_z in af_name):
-                            checkstr = '999' + spltstr[-5][1:3] + spltstr[-4][-2:]
-                            if (checkstr not in hr_cyc_day
-                                and (datetime.strptime(spltstr[-4], '%Y%m%d') ==
-                                     datetime.strptime
-                                     (a_start[:8], '%Y%m%d'))
-                                and checkstr[0:3] != '000'
-                                ):
-                                hr_cyc_day.append(checkstr)
-                                files.append(af_name)
-                        elif prop.ofs in ('stofs_3d_atl', 'stofs_3d_pac'):   # add stofs filename format
-                            if 'f0' in af_name and 'fields' in af_name:  # skiping filed2d post process
-                                # Split the string based on underscores and periods
-                                spltstr = af_name.split('_')
-                                # Extract the values
-                                checkstr1 = spltstr[-2][-2:]
-                                checkstr2 = spltstr[-1].split('.')[0][1:3]
-
-                                if (int(checkstr2) - 1 >= int(a_start[-2:])):
+                    try:
+                        spltstr = af_name.split('.')
+                        # First do old file names
+                        if 'nos.' in af_name:
+                            if ('fields.f' in af_name and
+                                prop.ofsfiletype == 'fields' and
+                                cycle_z in af_name):
+                                checkstr = spltstr[-4][-3:] + spltstr[-2][1:3] + \
+                                    spltstr[-3][-2:]
+                                if (checkstr not in hr_cyc_day
+                                    and (datetime.strptime(spltstr[-3], '%Y%m%d') ==
+                                         datetime.strptime
+                                         (a_start[:8], '%Y%m%d'))
+                                    and checkstr[0:3] != '000'
+                                    ):
+                                    hr_cyc_day.append(checkstr)
                                     files.append(af_name)
-                                    hr_cyc_day.append(checkstr1)
+                            elif ('stations.f' in af_name and
+                                  prop.ofsfiletype == 'stations' and
+                                  cycle_z in af_name):
+                                checkstr = '999' + spltstr[-2][1:3] + spltstr[-3][-2:]
+                                if (checkstr not in hr_cyc_day
+                                    and (datetime.strptime(spltstr[-3], '%Y%m%d') ==
+                                         datetime.strptime
+                                         (a_start[:8], '%Y%m%d'))
+                                    and checkstr[0:3] != '000'
+                                    ):
+                                    hr_cyc_day.append(checkstr)
+                                    files.append(af_name)
 
-                            elif prop.ofsfiletype == 'stations':
-                                # Split the string based on underscores and periods
-                                spltstr = af_name.split('_')
-                                # Extract the values
-                                checkstr1 = spltstr[-2][-2:]
-                                checkstr2 = spltstr[-1].split('.')[0][1:3]
+                        # Now do new file names
+                        elif 'nos.' not in af_name:
+                            if ('fields.f' in af_name and
+                                prop.ofsfiletype == 'fields' and
+                                cycle_z in af_name):
+                                checkstr = spltstr[-2][-3:] + spltstr[-5][1:3] + \
+                                    spltstr[-4][-2:]
+                                if (checkstr not in hr_cyc_day
+                                    and (datetime.strptime(spltstr[-4], '%Y%m%d') ==
+                                         datetime.strptime
+                                         (a_start[:8], '%Y%m%d'))
+                                    and checkstr[0:3] != '000'
+                                    ):
+                                    hr_cyc_day.append(checkstr)
+                                    files.append(af_name)
+                            elif ('stations.f' in af_name and
+                                  prop.ofsfiletype == 'stations' and
+                                  cycle_z in af_name):
+                                checkstr = '999' + spltstr[-5][1:3] + spltstr[-4][-2:]
+                                if (checkstr not in hr_cyc_day
+                                    and (datetime.strptime(spltstr[-4], '%Y%m%d') ==
+                                         datetime.strptime
+                                         (a_start[:8], '%Y%m%d'))
+                                    and checkstr[0:3] != '000'
+                                    ):
+                                    hr_cyc_day.append(checkstr)
+                                    files.append(af_name)
+                            elif prop.ofs in ('stofs_3d_atl', 'stofs_3d_pac'):   # add stofs filename format
+                                if 'f0' in af_name and 'fields' in af_name:  # skiping filed2d post process
+                                    # Split the string based on underscores and periods
+                                    spltstr = af_name.split('_')
+                                    # Extract the values
+                                    checkstr1 = spltstr[-2][-2:]
+                                    checkstr2 = spltstr[-1].split('.')[0][1:3]
 
-                                if (int(checkstr2) - 1 >= int(a_start[-2:])):
-                                    files.append(af_name)
-                                    hr_cyc_day.append(checkstr1)
-                        elif prop.ofs in ('stofs_2d_glo'):
-                            # STOFS-2D-Global files each contain the full timeseries,
-                            # so we filter on:
-                            # (1) station vs fields;
-                            # (2) netcdf format;
-                            # (3) model cycle (e.g., t00z, t12z).
-                            # Example names: stofs_2d_glo.t00z.fields.cwl.nc, stofs_2d_glo.t00z.points.cwl.nc
-                            # The sorting variable is unnecessary in this case as we only have one model cycle,
-                            # only one file per time series, and only one day per directory. But
-                            # we need to assign it anyway.
-                            if af_name.endswith('.nc') and (cycle_z in af_name):
-                                if (prop.ofsfiletype == 'fields') and ('fields' in af_name):
-                                    files.append(af_name)
-                                    hr_cyc_day.append('0000000')
-                                elif (prop.ofsfiletype == 'stations') and ('points' in af_name):
-                                    files.append(af_name)
-                                    hr_cyc_day.append('0000000')
+                                    if (int(checkstr2) - 1 >= int(a_start[-2:])):
+                                        files.append(af_name)
+                                        hr_cyc_day.append(checkstr1)
+
+                                elif prop.ofsfiletype == 'stations':
+                                    # Split the string based on underscores and periods
+                                    spltstr = af_name.split('_')
+                                    # Extract the values
+                                    checkstr1 = spltstr[-2][-2:]
+                                    checkstr2 = spltstr[-1].split('.')[0][1:3]
+
+                                    if (int(checkstr2) - 1 >= int(a_start[-2:])):
+                                        files.append(af_name)
+                                        hr_cyc_day.append(checkstr1)
+                            elif prop.ofs in ('stofs_2d_glo'):
+                                # STOFS-2D-Global files each contain the full timeseries,
+                                # so we filter on:
+                                # (1) station vs fields;
+                                # (2) netcdf format;
+                                # (3) model cycle (e.g., t00z, t12z).
+                                # Example names: stofs_2d_glo.t00z.fields.cwl.nc, stofs_2d_glo.t00z.points.cwl.nc
+                                # The sorting variable is unnecessary in this case as we only have one model cycle,
+                                # only one file per time series, and only one day per directory. But
+                                # we need to assign it anyway.
+                                if af_name.endswith('.nc') and (cycle_z in af_name):
+                                    if (prop.ofsfiletype == 'fields') and ('fields' in af_name):
+                                        files.append(af_name)
+                                        hr_cyc_day.append('0000000')
+                                    elif (prop.ofsfiletype == 'stations') and ('points' in af_name):
+                                        files.append(af_name)
+                                        hr_cyc_day.append('0000000')
+                    except (IndexError, ValueError, TypeError) as e:
+                        skipped_files.append(af_name)
+                        logger.debug('Skipping unparseable file in %s: %s (%s)', dir_list[i_index], af_name, e)
+                if skipped_files:
+                    logger.warning('Skipped %d unparseable file(s) in %s: %s',
+                                   len(skipped_files), dir_list[i_index], skipped_files[:5])
 
                 files = [dir_list[i_index] + '//' + i for i in files]
 
@@ -979,20 +1024,52 @@ def list_of_files(prop: Any, dir_list: list[str], logger: Logger) -> list[str]:
                 # Old file format:
                 # nos.cbofs.fields.f001.20240901.t00z.nc
 
-                all_files = listdir(dir_list[i_index])
+                try:
+                    all_files = listdir(dir_list[i_index])
+                except OSError as e:
+                    logger.error('Cannot read directory %s: %s. Skipping.', dir_list[i_index], e)
+                    if use_s3_fallback:
+                        files = construct_expected_files(prop, dir_list[i_index], logger)
+                        list_files.append(files)
+                    continue
                 files = []
                 hr_cyc_day = []
                 if prop.ofs == 'wcofs':
                     ndays = 1
                 else:
                     ndays = 0
+                skipped_files = []
                 for af_name in all_files:
-                    spltstr = af_name.split('.')
-                    # Old file names
-                    if 'nos.' in af_name:
-                        if 'fields.f' in af_name and prop.ofsfiletype == 'fields':
-                            if 'f0' in af_name:
-                                checkstr = (spltstr[-4][-3:] + spltstr[-2][1:3]
+                    try:
+                        spltstr = af_name.split('.')
+                        # Old file names
+                        if 'nos.' in af_name:
+                            if 'fields.f' in af_name and prop.ofsfiletype == 'fields':
+                                if 'f0' in af_name:
+                                    checkstr = (spltstr[-4][-3:] + spltstr[-2][1:3]
+                                                + spltstr[-3][-2:])
+                                    if (checkstr not in hr_cyc_day
+                                        and (datetime.strptime(spltstr[-3], '%Y%m%d') >=
+                                             datetime.strptime
+                                             (prop.startdate[:-2], '%Y%m%d') -
+                                             timedelta(days=ndays))
+                                        and (datetime.strptime(spltstr[-3], '%Y%m%d') <=
+                                             datetime.strptime
+                                             (prop.enddate[:-2], '%Y%m%d'))
+                                        and checkstr[0:3] != '000'
+                                        ):
+                                        if (prop.ofs == 'wcofs'
+                                            and int(checkstr[0:3]) >= 1
+                                            and int(checkstr[0:3]) < 25):
+                                            hr_cyc_day.append(checkstr)
+                                            files.append(af_name)
+                                        elif (int(checkstr[0:3]) >= 1
+                                              and int(checkstr[0:3]) < 7):
+                                            hr_cyc_day.append(checkstr)
+                                            files.append(af_name)
+                            elif ('stations.f' in af_name and
+                                  prop.ofsfiletype == 'stations'):
+                                checkstr = ('999' + spltstr[-2][1:3]
                                             + spltstr[-3][-2:])
                                 if (checkstr not in hr_cyc_day
                                     and (datetime.strptime(spltstr[-3], '%Y%m%d') >=
@@ -1002,37 +1079,37 @@ def list_of_files(prop: Any, dir_list: list[str], logger: Logger) -> list[str]:
                                     and (datetime.strptime(spltstr[-3], '%Y%m%d') <=
                                          datetime.strptime
                                          (prop.enddate[:-2], '%Y%m%d'))
-                                    and checkstr[0:3] != '000'
                                     ):
-                                    if (prop.ofs == 'wcofs'
-                                        and int(checkstr[0:3]) >= 1
-                                        and int(checkstr[0:3]) < 25):
-                                        hr_cyc_day.append(checkstr)
-                                        files.append(af_name)
-                                    elif (int(checkstr[0:3]) >= 1
-                                          and int(checkstr[0:3]) < 7):
-                                        hr_cyc_day.append(checkstr)
-                                        files.append(af_name)
-                        elif ('stations.f' in af_name and
-                              prop.ofsfiletype == 'stations'):
-                            checkstr = ('999' + spltstr[-2][1:3]
-                                        + spltstr[-3][-2:])
-                            if (checkstr not in hr_cyc_day
-                                and (datetime.strptime(spltstr[-3], '%Y%m%d') >=
-                                     datetime.strptime
-                                     (prop.startdate[:-2], '%Y%m%d') -
-                                     timedelta(days=ndays))
-                                and (datetime.strptime(spltstr[-3], '%Y%m%d') <=
-                                     datetime.strptime
-                                     (prop.enddate[:-2], '%Y%m%d'))
-                                ):
-                                hr_cyc_day.append(checkstr)
-                                files.append(af_name)
-                    # New file names
-                    elif 'nos.' not in af_name:
-                        if 'fields.f' in af_name and prop.ofsfiletype == 'fields':
-                            if 'f0' in af_name:
-                                checkstr = (spltstr[-2][-3:] + spltstr[-5][1:3]
+                                    hr_cyc_day.append(checkstr)
+                                    files.append(af_name)
+                        # New file names
+                        elif 'nos.' not in af_name:
+                            if 'fields.f' in af_name and prop.ofsfiletype == 'fields':
+                                if 'f0' in af_name:
+                                    checkstr = (spltstr[-2][-3:] + spltstr[-5][1:3]
+                                                + spltstr[-4][-2:])
+                                    if (checkstr not in hr_cyc_day
+                                        and (datetime.strptime(spltstr[-4], '%Y%m%d') >=
+                                             datetime.strptime
+                                             (prop.startdate[:-2], '%Y%m%d') -
+                                             timedelta(days=ndays))
+                                        and (datetime.strptime(spltstr[-4], '%Y%m%d') <=
+                                             datetime.strptime
+                                             (prop.enddate[:-2], '%Y%m%d'))
+                                        and checkstr[0:3] != '000'
+                                        ):
+                                        if (prop.ofs == 'wcofs'
+                                            and int(checkstr[0:3]) >= 1
+                                            and int(checkstr[0:3]) < 25):
+                                            hr_cyc_day.append(checkstr)
+                                            files.append(af_name)
+                                        elif (int(checkstr[0:3]) >= 1
+                                              and int(checkstr[0:3]) < 7):
+                                            hr_cyc_day.append(checkstr)
+                                            files.append(af_name)
+                            elif ('stations.f' in af_name and
+                                  prop.ofsfiletype == 'stations'):
+                                checkstr = ('999' + spltstr[-5][1:3]
                                             + spltstr[-4][-2:])
                                 if (checkstr not in hr_cyc_day
                                     and (datetime.strptime(spltstr[-4], '%Y%m%d') >=
@@ -1044,73 +1121,56 @@ def list_of_files(prop: Any, dir_list: list[str], logger: Logger) -> list[str]:
                                          (prop.enddate[:-2], '%Y%m%d'))
                                     and checkstr[0:3] != '000'
                                     ):
-                                    if (prop.ofs == 'wcofs'
-                                        and int(checkstr[0:3]) >= 1
-                                        and int(checkstr[0:3]) < 25):
-                                        hr_cyc_day.append(checkstr)
-                                        files.append(af_name)
-                                    elif (int(checkstr[0:3]) >= 1
-                                          and int(checkstr[0:3]) < 7):
-                                        hr_cyc_day.append(checkstr)
-                                        files.append(af_name)
-                        elif ('stations.f' in af_name and
-                              prop.ofsfiletype == 'stations'):
-                            checkstr = ('999' + spltstr[-5][1:3]
-                                        + spltstr[-4][-2:])
-                            if (checkstr not in hr_cyc_day
-                                and (datetime.strptime(spltstr[-4], '%Y%m%d') >=
-                                     datetime.strptime
-                                     (prop.startdate[:-2], '%Y%m%d') -
-                                     timedelta(days=ndays))
-                                and (datetime.strptime(spltstr[-4], '%Y%m%d') <=
-                                     datetime.strptime
-                                     (prop.enddate[:-2], '%Y%m%d'))
-                                and checkstr[0:3] != '000'
-                                ):
-                                hr_cyc_day.append(checkstr)
-                                files.append(af_name)
-                        elif prop.ofs in ('stofs_3d_atl', 'stofs_3d_pac'):    # add stofs filename format
-                            if 'f0' in af_name and 'fields' in af_name:  # skiping filed2d post process:
-                                # Split the string based on underscores and periods
-                                spltstr = af_name.split('_')
-                                # Extract the values
-                                checkstr1 = spltstr[-2][-2:]
-                                checkstr2 = spltstr[-1].split('.')[0][1:3]
+                                    hr_cyc_day.append(checkstr)
+                                    files.append(af_name)
+                            elif prop.ofs in ('stofs_3d_atl', 'stofs_3d_pac'):    # add stofs filename format
+                                if 'f0' in af_name and 'fields' in af_name:  # skiping filed2d post process:
+                                    # Split the string based on underscores and periods
+                                    spltstr = af_name.split('_')
+                                    # Extract the values
+                                    checkstr1 = spltstr[-2][-2:]
+                                    checkstr2 = spltstr[-1].split('.')[0][1:3]
 
-                                if ((int(checkstr2) - 1 >= int(prop.startdate[-2:]))
-                                    and (int(checkstr1) - 1 <= int(prop.enddate[-2:]))
-                                    ):
-                                    files.append(af_name)
-                                    hr_cyc_day.append(checkstr1)
-                            elif prop.ofsfiletype == 'stations':
-                                # Split the string based on underscores and periods
-                                spltstr = af_name.split('_')
-                                # Extract the values
-                                checkstr1 = spltstr[-2][-2:]
-                                checkstr2 = spltstr[-1].split('.')[0][1:3]
+                                    if ((int(checkstr2) - 1 >= int(prop.startdate[-2:]))
+                                        and (int(checkstr1) - 1 <= int(prop.enddate[-2:]))
+                                        ):
+                                        files.append(af_name)
+                                        hr_cyc_day.append(checkstr1)
+                                elif prop.ofsfiletype == 'stations':
+                                    # Split the string based on underscores and periods
+                                    spltstr = af_name.split('_')
+                                    # Extract the values
+                                    checkstr1 = spltstr[-2][-2:]
+                                    checkstr2 = spltstr[-1].split('.')[0][1:3]
 
-                                if ((int(checkstr2) - 1 >= int(prop.startdate[-2:]))
-                                    and (int(checkstr1) - 1 <= int(prop.enddate[-2:]))
-                                    ):
-                                    files.append(af_name)
-                                    hr_cyc_day.append(checkstr1)
-                        elif prop.ofs in ['stofs_2d_glo']:
-                            # STOFS-2D-Global files each contain the full timeseries,
-                            # so we filter only on:
-                            # (1) station vs fields;
-                            # (2) netcdf format.
-                            # Example names: stofs_2d_glo.t00z.fields.cwl.nc, stofs_2d_glo.t00z.points.cwl.nc
-                            # For sorting, we need just the model cycle (only one file per time series;
-                            # only one day per directory).
-                            # But to work with the sorting method used for other OFS,
-                            # we have to construct a string that looks like the other checkstrs.
-                            if af_name.endswith('.nc'):
-                                if (prop.ofsfiletype == 'fields') and ('fields' in af_name):
-                                    files.append(af_name)
-                                    hr_cyc_day.append('000' + af_name.split('.')[1][1:3] + '00')
-                                elif (prop.ofsfiletype == 'stations') and ('points' in af_name):
-                                    files.append(af_name)
-                                    hr_cyc_day.append('000' + af_name.split('.')[1][1:3] + '00')
+                                    if ((int(checkstr2) - 1 >= int(prop.startdate[-2:]))
+                                        and (int(checkstr1) - 1 <= int(prop.enddate[-2:]))
+                                        ):
+                                        files.append(af_name)
+                                        hr_cyc_day.append(checkstr1)
+                            elif prop.ofs in ['stofs_2d_glo']:
+                                # STOFS-2D-Global files each contain the full timeseries,
+                                # so we filter only on:
+                                # (1) station vs fields;
+                                # (2) netcdf format.
+                                # Example names: stofs_2d_glo.t00z.fields.cwl.nc, stofs_2d_glo.t00z.points.cwl.nc
+                                # For sorting, we need just the model cycle (only one file per time series;
+                                # only one day per directory).
+                                # But to work with the sorting method used for other OFS,
+                                # we have to construct a string that looks like the other checkstrs.
+                                if af_name.endswith('.nc'):
+                                    if (prop.ofsfiletype == 'fields') and ('fields' in af_name):
+                                        files.append(af_name)
+                                        hr_cyc_day.append('000' + af_name.split('.')[1][1:3] + '00')
+                                    elif (prop.ofsfiletype == 'stations') and ('points' in af_name):
+                                        files.append(af_name)
+                                        hr_cyc_day.append('000' + af_name.split('.')[1][1:3] + '00')
+                    except (IndexError, ValueError, TypeError) as e:
+                        skipped_files.append(af_name)
+                        logger.debug('Skipping unparseable file in %s: %s (%s)', dir_list[i_index], af_name, e)
+                if skipped_files:
+                    logger.warning('Skipped %d unparseable file(s) in %s: %s',
+                                   len(skipped_files), dir_list[i_index], skipped_files[:5])
 
                 files = [dir_list[i_index] + '//' + i for i in files]
 
@@ -1132,14 +1192,19 @@ def list_of_files(prop: Any, dir_list: list[str], logger: Logger) -> list[str]:
             # Append files to master
             list_files.append(files)
 
-        list_files = sum(list_files, [])
-
     except Exception as e:
-        logger.error('Problem with list_of_files, check model directory')
-        logger.error('Exception message: %s', e)
+        logger.error(
+            'Unexpected error in list_of_files while processing directories. '
+            'ofs=%s, whichcast=%s, filetype=%s, dirs_searched=%d, '
+            'partial_results=%d. Exception: %s',
+            prop.ofs, prop.whichcast, prop.ofsfiletype,
+            len(dir_list),
+            len(list_files) if isinstance(list_files, list) else 0,
+            e,
+            exc_info=True
+        )
 
-    # Ensure list_files is properly flattened (handle any edge cases)
-    # This must happen OUTSIDE try/except so it runs even if there was an exception
+    # Flatten list_files (each entry is a list from one directory)
     flattened = []
     for item in list_files:
         if isinstance(item, list):
@@ -1148,8 +1213,17 @@ def list_of_files(prop: Any, dir_list: list[str], logger: Logger) -> list[str]:
             flattened.append(item)
     list_files = flattened
 
-    if list_files == []:
-        logger.error('Problem in list_of_files.py; no files found! Aborting program')
+    if not list_files:
+        logger.error(
+            'No model files found after scanning all directories. '
+            'ofs=%s, whichcast=%s, filetype=%s, '
+            'directories_searched=%s, s3_fallback=%s, '
+            'startdate=%s, enddate=%s',
+            prop.ofs, prop.whichcast, prop.ofsfiletype,
+            dir_list, use_s3_fallback,
+            getattr(prop, 'startdate', 'N/A'),
+            getattr(prop, 'enddate', 'N/A')
+        )
         raise SystemExit(1)
 
     # Now check individual files and use S3 fallback if enabled

--- a/src/ofs_skill/model_processing/list_of_files.py
+++ b/src/ofs_skill/model_processing/list_of_files.py
@@ -789,7 +789,9 @@ def list_of_files(prop: Any, dir_list: list[str], logger: Logger) -> list[str]:
                                         hr_cyc_day.append('000' + af_name.split('.')[1][1:3] + '00')
                     except (IndexError, ValueError, TypeError) as e:
                         skipped_files.append(af_name)
-                        logger.debug('Skipping unparseable file in %s: %s (%s)', dir_list[i_index], af_name, e)
+                        logger.debug(
+                            'Skipping unparseable file in %s: %s (%s)',
+                            dir_list[i_index], af_name, e)
                 if skipped_files:
                     logger.warning('Skipped %d unparseable file(s) in %s: %s',
                                    len(skipped_files), dir_list[i_index], skipped_files[:5])
@@ -843,22 +845,24 @@ def list_of_files(prop: Any, dir_list: list[str], logger: Logger) -> list[str]:
                                 hr_cyc_day.append(checkstr)
                                 files.append(af_name)
                         elif ('out2d' in af_name and prop.ofsfiletype == 'fields'):
-                                checkstr = '999' + spltstr[-5][1:3] + \
-                                    spltstr[-4][-2:]
-                                if (checkstr not in hr_cyc_day
-                                    and (datetime.strptime(spltstr[-4], '%Y%m%d') >=
-                                         datetime.strptime
-                                         (prop.startdate[:-2], '%Y%m%d'))
-                                    and (datetime.strptime(spltstr[-4], '%Y%m%d') <=
-                                         datetime.strptime(prop.enddate[:-2], '%Y%m%d')
-                                         + timedelta(days=ndays))
-                                    and checkstr[0:3] != '000'
-                                    ):
-                                    hr_cyc_day.append(checkstr)
-                                    files.append(af_name)
+                            checkstr = '999' + spltstr[-5][1:3] + \
+                                spltstr[-4][-2:]
+                            if (checkstr not in hr_cyc_day
+                                and (datetime.strptime(spltstr[-4], '%Y%m%d') >=
+                                     datetime.strptime
+                                     (prop.startdate[:-2], '%Y%m%d'))
+                                and (datetime.strptime(spltstr[-4], '%Y%m%d') <=
+                                     datetime.strptime(prop.enddate[:-2], '%Y%m%d')
+                                     + timedelta(days=ndays))
+                                and checkstr[0:3] != '000'
+                                ):
+                                hr_cyc_day.append(checkstr)
+                                files.append(af_name)
                     except (IndexError, ValueError, TypeError) as e:
                         skipped_files.append(af_name)
-                        logger.debug('Skipping unparseable file in %s: %s (%s)', dir_list[i_index], af_name, e)
+                        logger.debug(
+                            'Skipping unparseable file in %s: %s (%s)',
+                            dir_list[i_index], af_name, e)
                 if skipped_files:
                     logger.warning('Skipped %d unparseable file(s) in %s: %s',
                                    len(skipped_files), dir_list[i_index], skipped_files[:5])
@@ -996,7 +1000,9 @@ def list_of_files(prop: Any, dir_list: list[str], logger: Logger) -> list[str]:
                                         hr_cyc_day.append('0000000')
                     except (IndexError, ValueError, TypeError) as e:
                         skipped_files.append(af_name)
-                        logger.debug('Skipping unparseable file in %s: %s (%s)', dir_list[i_index], af_name, e)
+                        logger.debug(
+                            'Skipping unparseable file in %s: %s (%s)',
+                            dir_list[i_index], af_name, e)
                 if skipped_files:
                     logger.warning('Skipped %d unparseable file(s) in %s: %s',
                                    len(skipped_files), dir_list[i_index], skipped_files[:5])
@@ -1167,7 +1173,9 @@ def list_of_files(prop: Any, dir_list: list[str], logger: Logger) -> list[str]:
                                         hr_cyc_day.append('000' + af_name.split('.')[1][1:3] + '00')
                     except (IndexError, ValueError, TypeError) as e:
                         skipped_files.append(af_name)
-                        logger.debug('Skipping unparseable file in %s: %s (%s)', dir_list[i_index], af_name, e)
+                        logger.debug(
+                            'Skipping unparseable file in %s: %s (%s)',
+                            dir_list[i_index], af_name, e)
                 if skipped_files:
                     logger.warning('Skipped %d unparseable file(s) in %s: %s',
                                    len(skipped_files), dir_list[i_index], skipped_files[:5])
@@ -1192,6 +1200,8 @@ def list_of_files(prop: Any, dir_list: list[str], logger: Logger) -> list[str]:
             # Append files to master
             list_files.append(files)
 
+    except (SystemExit, KeyboardInterrupt):
+        raise
     except Exception as e:
         logger.error(
             'Unexpected error in list_of_files while processing directories. '

--- a/tests/list_of_files_error_handling_test.py
+++ b/tests/list_of_files_error_handling_test.py
@@ -1,0 +1,288 @@
+"""
+Unit tests for error handling improvements in list_of_files().
+
+Validates that:
+- Unparseable filenames are skipped without aborting the entire scan
+- Unreadable directories don't kill processing of subsequent directories
+- All files unparseable still raises SystemExit(1)
+- Empty directories are handled gracefully
+- Improved diagnostic logging includes context (ofs, whichcast, etc.)
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from ofs_skill.model_processing.list_of_files import list_of_files
+
+
+class MockLogger:
+    """Mock logger that records all messages for assertions."""
+
+    def __init__(self):
+        self.infos = []
+        self.warnings = []
+        self.errors = []
+        self.debugs = []
+
+    def info(self, msg, *args, **kwargs):
+        self.infos.append(msg % args if args else msg)
+
+    def warning(self, msg, *args, **kwargs):
+        self.warnings.append(msg % args if args else msg)
+
+    def error(self, msg, *args, **kwargs):
+        self.errors.append(msg % args if args else msg)
+
+    def debug(self, msg, *args, **kwargs):
+        self.debugs.append(msg % args if args else msg)
+
+
+class MockProps:
+    """Mock ModelProperties for testing."""
+
+    def __init__(self, ofs='cbofs', whichcast='nowcast', ofsfiletype='fields',
+                 startdate='2024090100', enddate='2024090223',
+                 forecast_hr='00z'):
+        self.ofs = ofs
+        self.whichcast = whichcast
+        self.ofsfiletype = ofsfiletype
+        self.startdate = startdate
+        self.enddate = enddate
+        self.forecast_hr = forecast_hr
+
+
+@pytest.fixture
+def logger():
+    return MockLogger()
+
+
+@pytest.fixture
+def props_nowcast():
+    return MockProps(whichcast='nowcast', ofsfiletype='fields')
+
+
+@pytest.fixture
+def props_forecast_a():
+    return MockProps(whichcast='forecast_a', ofsfiletype='fields')
+
+
+@pytest.fixture
+def props_forecast_b():
+    return MockProps(whichcast='forecast_b', ofsfiletype='fields')
+
+
+@pytest.fixture
+def props_hindcast():
+    return MockProps(whichcast='hindcast', ofsfiletype='stations')
+
+
+class TestPerFileErrorResilience:
+    """Test that unparseable filenames are skipped without aborting."""
+
+    @patch('ofs_skill.model_processing.list_of_files.utils')
+    @patch('ofs_skill.model_processing.list_of_files.listdir')
+    @patch('os.path.exists', return_value=True)
+    def test_nowcast_skips_bad_files_keeps_good(self, mock_exists, mock_listdir,
+                                                 mock_utils, props_nowcast, logger):
+        """One malformed filename among valid ones: valid files returned, bad skipped."""
+        mock_utils.Utils.return_value.read_config_section.return_value = {
+            'use_s3_fallback': 'False'
+        }
+        # Mix of valid new-format files and a malformed one that matches the
+        # 'fields.n' pattern but has too few segments to parse (triggers IndexError)
+        mock_listdir.return_value = [
+            'cbofs.t00z.20240901.fields.n001.nc',  # valid new format (6 segments)
+            'cbofs.fields.n001.nc',  # malformed: matches 'fields.n' but only 4 segments -> IndexError
+            'cbofs.t06z.20240901.fields.n001.nc',  # valid
+        ]
+
+        result = list_of_files(props_nowcast, ['/fake/dir'], logger)
+
+        # Should have 2 valid files (the malformed one is skipped)
+        assert len(result) == 2
+        # All results should be real model files
+        assert all('fields.n' in f for f in result)
+        # Should have logged warnings about skipped files
+        assert any('Skipped' in w for w in logger.warnings)
+        # Should have debug messages for the malformed file
+        assert any('cbofs.fields.n001.nc' in d for d in logger.debugs)
+
+    @patch('ofs_skill.model_processing.list_of_files.utils')
+    @patch('ofs_skill.model_processing.list_of_files.listdir')
+    @patch('os.path.exists', return_value=True)
+    def test_forecast_a_skips_bad_files(self, mock_exists, mock_listdir,
+                                        mock_utils, props_forecast_a, logger):
+        """forecast_a: malformed filenames skipped, valid ones returned."""
+        mock_utils.Utils.return_value.read_config_section.return_value = {
+            'use_s3_fallback': 'False'
+        }
+        mock_listdir.return_value = [
+            'cbofs.t00z.20240901.fields.f001.nc',  # valid
+            'cbofs.t00z.fields.f001.nc',  # malformed: matches 'fields.f' + cycle_z but only 5 segments
+            'cbofs.t00z.20240901.fields.f002.nc',  # valid
+        ]
+
+        result = list_of_files(props_forecast_a, ['/fake/dir'], logger)
+
+        assert len(result) == 2
+        assert all('fields.f' in f for f in result)
+        assert any('Skipped' in w for w in logger.warnings)
+
+    @patch('ofs_skill.model_processing.list_of_files.utils')
+    @patch('ofs_skill.model_processing.list_of_files.listdir')
+    @patch('os.path.exists', return_value=True)
+    def test_forecast_b_skips_bad_files(self, mock_exists, mock_listdir,
+                                        mock_utils, props_forecast_b, logger):
+        """forecast_b: malformed filenames skipped, valid ones returned."""
+        mock_utils.Utils.return_value.read_config_section.return_value = {
+            'use_s3_fallback': 'False'
+        }
+        mock_listdir.return_value = [
+            'cbofs.t00z.20240901.fields.f001.nc',  # valid (f0xx matches forecast_b)
+            'cbofs.fields.f001.nc',  # malformed: matches 'fields.f' + 'f0' but too few segments
+            'cbofs.t00z.20240901.fields.f002.nc',  # valid
+        ]
+
+        result = list_of_files(props_forecast_b, ['/fake/dir'], logger)
+
+        assert len(result) == 2
+        assert all('fields.f' in f for f in result)
+        assert any('Skipped' in w for w in logger.warnings)
+
+    @patch('ofs_skill.model_processing.list_of_files.utils')
+    @patch('ofs_skill.model_processing.list_of_files.listdir')
+    @patch('os.path.exists', return_value=True)
+    def test_hindcast_skips_bad_files(self, mock_exists, mock_listdir,
+                                      mock_utils, props_hindcast, logger):
+        """hindcast: malformed filenames skipped, valid ones returned."""
+        mock_utils.Utils.return_value.read_config_section.return_value = {
+            'use_s3_fallback': 'False'
+        }
+        mock_listdir.return_value = [
+            'cbofs.t00z.20240901.stations.h001.nc',  # valid
+            'cbofs.stations.h001.nc',  # malformed: matches 'stations.h' but too few segments
+            'cbofs.t06z.20240901.stations.h001.nc',  # valid
+        ]
+
+        result = list_of_files(props_hindcast, ['/fake/dir'], logger)
+
+        assert len(result) == 2
+        assert all('stations.h' in f for f in result)
+        assert any('Skipped' in w for w in logger.warnings)
+
+
+class TestPerDirectoryErrorResilience:
+    """Test that one bad directory doesn't kill subsequent directories."""
+
+    @patch('ofs_skill.model_processing.list_of_files.utils')
+    @patch('ofs_skill.model_processing.list_of_files.listdir')
+    @patch('os.path.exists', return_value=True)
+    def test_bad_dir_among_good_dirs(self, mock_exists, mock_listdir,
+                                      mock_utils, props_nowcast, logger):
+        """Dir 2 raises OSError; files from dirs 1 and 3 still returned."""
+        mock_utils.Utils.return_value.read_config_section.return_value = {
+            'use_s3_fallback': 'False'
+        }
+
+        def listdir_side_effect(path):
+            if path == '/dir2':
+                raise PermissionError('Permission denied')
+            return ['cbofs.t00z.20240901.fields.n001.nc']
+
+        mock_listdir.side_effect = listdir_side_effect
+
+        result = list_of_files(props_nowcast, ['/dir1', '/dir2', '/dir3'], logger)
+
+        # Should have files from dir1 and dir3 (1 each)
+        assert len(result) == 2
+        # Should have logged an error about dir2
+        assert any('Cannot read directory' in e for e in logger.errors)
+        assert any('/dir2' in e for e in logger.errors)
+
+
+class TestAllFilesBadStillExits:
+    """Test that SystemExit(1) is still raised when no valid files found."""
+
+    @patch('ofs_skill.model_processing.list_of_files.utils')
+    @patch('ofs_skill.model_processing.list_of_files.listdir')
+    @patch('os.path.exists', return_value=True)
+    def test_all_unparseable_raises_system_exit(self, mock_exists, mock_listdir,
+                                                 mock_utils, props_nowcast, logger):
+        """All files are junk — should still abort with SystemExit."""
+        mock_utils.Utils.return_value.read_config_section.return_value = {
+            'use_s3_fallback': 'False'
+        }
+        mock_listdir.return_value = [
+            'README.md',
+            '.gitkeep',
+            'notes.txt',
+        ]
+
+        with pytest.raises(SystemExit) as exc_info:
+            list_of_files(props_nowcast, ['/fake/dir'], logger)
+        assert exc_info.value.code == 1
+
+    @patch('ofs_skill.model_processing.list_of_files.utils')
+    @patch('ofs_skill.model_processing.list_of_files.listdir')
+    @patch('os.path.exists', return_value=True)
+    def test_abort_message_includes_diagnostics(self, mock_exists, mock_listdir,
+                                                 mock_utils, props_nowcast, logger):
+        """Error message at abort includes ofs, whichcast, filetype, dirs, dates."""
+        mock_utils.Utils.return_value.read_config_section.return_value = {
+            'use_s3_fallback': 'False'
+        }
+        mock_listdir.return_value = ['junk.txt']
+
+        with pytest.raises(SystemExit):
+            list_of_files(props_nowcast, ['/fake/dir'], logger)
+
+        # Check the error log includes diagnostic context
+        abort_msgs = [e for e in logger.errors if 'No model files found' in e]
+        assert len(abort_msgs) == 1
+        msg = abort_msgs[0]
+        assert 'cbofs' in msg
+        assert 'nowcast' in msg
+        assert 'fields' in msg
+        assert '/fake/dir' in msg
+        assert '2024090100' in msg
+
+
+class TestEmptyDirectory:
+    """Test that empty directories are handled gracefully."""
+
+    @patch('ofs_skill.model_processing.list_of_files.utils')
+    @patch('ofs_skill.model_processing.list_of_files.listdir')
+    @patch('os.path.exists', return_value=True)
+    def test_empty_dir_no_crash(self, mock_exists, mock_listdir,
+                                 mock_utils, props_nowcast, logger):
+        """Empty directory contributes zero files; no crash."""
+        mock_utils.Utils.return_value.read_config_section.return_value = {
+            'use_s3_fallback': 'False'
+        }
+        mock_listdir.return_value = []
+
+        with pytest.raises(SystemExit):
+            list_of_files(props_nowcast, ['/empty/dir'], logger)
+
+    @patch('ofs_skill.model_processing.list_of_files.utils')
+    @patch('ofs_skill.model_processing.list_of_files.listdir')
+    @patch('os.path.exists', return_value=True)
+    def test_empty_dir_mixed_with_good_dir(self, mock_exists, mock_listdir,
+                                            mock_utils, props_nowcast, logger):
+        """One empty dir + one dir with valid files: valid files returned."""
+        mock_utils.Utils.return_value.read_config_section.return_value = {
+            'use_s3_fallback': 'False'
+        }
+
+        def listdir_side_effect(path):
+            if path == '/empty':
+                return []
+            return ['cbofs.t00z.20240901.fields.n001.nc']
+
+        mock_listdir.side_effect = listdir_side_effect
+
+        result = list_of_files(props_nowcast, ['/empty', '/good'], logger)
+
+        assert len(result) == 1
+        assert 'fields.n001' in result[0]


### PR DESCRIPTION
### Description of Changes

Closes #4.

Addresses intermittent `list_of_files` failures where the function aborts with "no files found" when files ARE available. The root cause is a single `try/except Exception` block wrapping ~490 lines of file discovery code—any individual file-parsing failure (e.g., an unexpected `.tmp` file or a partially downloaded file in a model directory) breaks out of the entire loop and discards all results.

Also adds early whichcast validation to `create_1dplot.py` (previously had none) and fixes two bugs in `create_2dplot.py`'s existing validation.

**Changes:**

**`list_of_files.py`:**
- Add per-file `try/except (IndexError, ValueError, TypeError)` in all 4 whichcast loops (nowcast, hindcast, forecast_a, forecast_b). One bad filename is now skipped with a warning instead of aborting the entire scan.
- Add per-directory `try/except OSError` around all 4 `listdir()` calls. One unreadable directory no longer kills processing of subsequent directories.
- Improve the outer `except Exception` handler to log diagnostic context (ofs, whichcast, filetype, directory count, partial result count) with `exc_info=True` for full tracebacks.
- Improve the abort-point error message to include ofs, whichcast, filetype, directories searched, S3 fallback status, startdate, and enddate.
- Move `list_files = []` above the `try` block to ensure the variable is always defined.
- Remove redundant `sum(list_files, [])` flattening (the existing robust flattening loop handles it).

**`create_1dplot.py`:**
- Add whichcast validation after `parse_arguments_to_list()`, checking against `{nowcast, forecast_a, forecast_b, hindcast}`. Invalid values now produce a clear error and exit immediately, instead of silently failing downstream.

**`create_2dplot.py`:**
- Add `hindcast` to the valid whichcast set (was previously rejected).
- Fix list-vs-string comparison bug: `prop.whichcasts == 'forecast_a'` (always `False` since `prop.whichcasts` is a list after `.split(',')`) changed to `'forecast_a' in prop.whichcasts`. This means the `forecast_hr` requirement for `forecast_a` is now actually enforced.

**`tests/list_of_files_error_handling_test.py`:**
- 9 new tests covering per-file resilience (all 4 whichcast types), per-directory resilience, SystemExit on all-bad files, diagnostic logging content, empty directory handling, and mixed empty/populated directory scenarios.

### Expected Outcome of Changes

- Runs that previously aborted due to a single unexpected file in a model directory will now skip the problematic file and continue processing. A `WARNING`-level log message identifies skipped files.
- When no files are found, the error message now provides actionable diagnostic information (OFS name, whichcast, filetype, directories searched, date range) instead of the generic "no files found! Aborting program".
- Invalid whichcast values passed to `create_1dplot.py` or `create_2dplot.py` are caught immediately with a clear error message, rather than causing cryptic failures downstream in `list_of_files`.
- No changes to the function signature, return type, or caller interface. Existing callers require no modifications.

### Developer Questions and Checklist

**Is this a high priority PR? If yes, why and is there a date by which it needs to be merged?**
No.

**Are there any changes needed to how the code should be run for operational runs? (Commands, flags, job timings, etc.)**
No. All existing commands and flags work identically.

**Does this update need to be deployed for operational runs?**
No, but it would improve reliability of operational runs by preventing false "no files found" aborts.

**Does this update require front end/web app changes?**
No.

**Does this impact code development work on adding SCHISM?**
No.

**Does this impact code development work on adding ADCIRC?**
No.

**Does this impact the expected number of output files for integration tests?**
No.

- [x] Developer's name is removed throughout the code
- [x] Did you add relevant labels to the PR?
- [x] Have you run pylint and is the code at an acceptable pylint score (>8)?
- [x] Jobs contain the appropriate file checking and handle errors for any missing data
- [x] Is log free of critical ERRORs or WARNINGs? For errors that are not critical and can remain in code, is there sufficient handling and logging?

### Testing Instructions

**Unit tests (177 pass):**
```bash
conda activate ofs_dps
python -m pytest tests/ -v
```

**Test error handling resilience (9 new tests):**
```bash
python -m pytest tests/list_of_files_error_handling_test.py -v
```

**Test whichcast validation (should exit with "Invalid whichcast" error):**
```bash
python ./bin/visualization/create_1dplot.py -o cbofs -p ./ -s 20260328 -e 20260328 -d NAVD -ws bogus_cast -t stations -vs water_level
```

**1D E2E (cbofs nowcast, any recent date with available data):**
```bash
python ./bin/visualization/create_1dplot.py -o cbofs -p ./ -s 20260328 -e 20260328 -d NAVD -ws nowcast -t stations -vs water_level
```

### Reminder checklist for PR reviewer

- [ ] Run PEP8 compliance tests to ensure the code follows best practices
- [ ] Check that documentation in the script is sufficient
- [ ] Validate the output values (if applicable) to make sure the calculations are correct and make scientific/physical sense
- [ ] Test code both on Windows and Linux (and MacOS, if available), using several OFS as test cases
- [ ] When approving or commenting on a pull request, add information on the calls you use in case they need to be replicated or referenced
