### PR TITLE
Expand CHS obs to support temperature, salinity, and currents in 1D

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,7 +347,7 @@ For observed water levels, whenever possible, data is downloaded using an API th
 For modeled water levels, datum conversions are made on-the-fly using netCDF files that contain a 2D grid of conversion factors for a variety of datums including MLLW, MLW, MHW, NAVD88, and xgeoid20b. These netCDF files are available for every OFS (titled `{OFS}_vdatums.nc`) on the [NOAA Open Data Dissemination Amazon S3 bucket](https://noaa-nos-ofs-pds.s3.amazonaws.com/index.html#OFS_Grid_Datum/). Currently,
 
 ## 2.4 1D observation data sources
-The 1D skill assessment automatically downloads time series of water level, temperature, salinity, and current velocity from NOAA CO-OPS, USGS, and NDBC observation stations that are within the geographic bounds of the user-defined OFS. The user can specify which station providers to use when running the software ([Section 3.5](#35-running-the-1d-skill-assessment)), and the default is to include all three. NDBC station retrieval is completed using the [searvey package](https://github.com/oceanmodeling/searvey).
+The 1D skill assessment automatically downloads time series of water level, temperature, salinity, and current velocity from NOAA CO-OPS, USGS, NDBC, and CHS (Canadian Hydrographic Service) observation stations that are within the geographic bounds of the user-defined OFS. The user can specify which station providers to use when running the software ([Section 3.5](#35-running-the-1d-skill-assessment)), and the default is to include all four. NDBC station retrieval is completed using the [searvey package](https://github.com/oceanmodeling/searvey).
 
 ## 2.5 2D observation data sources
 Currently, the 2D skill assessment can handle sea surface temperature (SST) only. It automatically downloads hourly L3C SST satellite products for the user-defined OFS, including from GOES-16, and GOES-18/West, and/or GOES-19/East. GOES-16 was replaced by GOES-19/East in April 2025, and is only used for skill assessment runs prior to that date. Future updates will include analysis using additional remote sensing products, such as L4 NASA SPoRT, as well as support for current velocity, sea surface height, and salinity.
@@ -600,10 +600,10 @@ where
 * _-d_ is the vertical datum used to retrieve water level observations
 * _-ws_ is the mode (nowcast, forecast_a, and/or forecast_b)
 * _-t_ is the file format/type (stations or fields).
-* _-so_ is the observation station owner/provider (NDBC, USGS, and/or CO-OPS, OR a custom `list` of station IDs)
+* _-so_ is the observation station owner/provider (NDBC, USGS, CO-OPS, and/or CHS, OR a custom `list` of station IDs)
 * _-vs_ is variable selction (water_level, water_temperature, salinity, and/or currents)
 
-So, this run is for CBOFS, from 10/01/2025 to 10/02/2025, using both nowcast and forecast OFS output with station files (and 6-minute time resolution), with a vertical water level datum of mean lower low water, observation retrieval from CO-OPS, NDBC, and USGS stations, and all oceanographic variables selected. All possible input options and arguments are summarized in the table below.
+So, this run is for CBOFS, from 10/01/2025 to 10/02/2025, using both nowcast and forecast OFS output with station files (and 6-minute time resolution), with a vertical water level datum of mean lower low water, observation retrieval from CO-OPS, NDBC, USGS, and CHS stations, and all oceanographic variables selected. All possible input options and arguments are summarized in the table below.
 
 
 | Option explanation | Option syntax | Verbose syntax | Arguments | Required/optional |
@@ -617,11 +617,11 @@ So, this run is for CBOFS, from 10/01/2025 to 10/02/2025, using both nowcast and
 |Mode, or 'cast'|-ws|--WhichCast|nowcast, forecast_a, and/or forecast_b|required<br><sub>(can use one or all)</sub>|
 |OFS file format|-t|--FileType|stations OR fields|optional<br><sub>(Choose only one -- default is stations)</sub>|
 |Forecast cycle hour<br><sub>(for use only with forecast_a mode)</sub>|-f|--Forecast_Hr|e.g. '06hr', '12hr'|optional<br><sub>(default is '00hr', or closest cycle to '00hr')</sub>|
-|Observation station owner selection|-so|--Station_Owner|USGS, NDBC, and/or CO-OPS, or 'list'|optional<br><sub>(Choose one or multiple -- default is CO-OPS, NDBC, USGS)</sub>|
+|Observation station owner selection|-so|--Station_Owner|USGS, NDBC, CO-OPS, CHS, or 'list'|optional<br><sub>(Choose one or multiple -- default is CO-OPS, NDBC, USGS, CHS)</sub>|
 |Enable forecast horizon & model cycle skill|-hs|--Horizon_Skill|None, just include -hs|optional<br><sub>(default is False)</sub>|
 |Variable selection|-vs|--Var_Selection|water_level, water_temperature, salinity, currents|optional<br><sub>(default is all variables)</sub>|
 
-Note that, in the above call for CBOFS, the defaults for optional flags `-vs`, `-so`, and `-t` are `water_level,water_temperature,currents`, `co-ops,ndbc,usgs`, and `stations` respectively. So the same run can be achieved using a shorter call:
+Note that, in the above call for CBOFS, the defaults for optional flags `-vs`, `-so`, and `-t` are `water_level,water_temperature,currents`, `co-ops,ndbc,usgs,chs`, and `stations` respectively. So the same run can be achieved using a shorter call:
 
 ```
 python ./bin/visualization/create_1dplot.py -p ./ -o cbofs -s 2025-10-01T00:00:00Z -e 2025-10-02T00:00:00Z -d MLLW -ws nowcast,forecast_b

--- a/bin/visualization/create_1dplot.py
+++ b/bin/visualization/create_1dplot.py
@@ -45,7 +45,7 @@ Arguments:
  -ws whichcast, --Whichcast"
                        'Nowcast', 'Forecast_A', 'Forecast_B'
  -so stationowner, --Station_Owner" [optional]
-                       'NDBC', 'CO-OPS', 'USGS'
+                       'NDBC', 'CO-OPS', 'USGS', 'CHS'
 Output:
 Output:
 Name                 Description

--- a/bin/visualization/create_1dplot.py
+++ b/bin/visualization/create_1dplot.py
@@ -260,7 +260,8 @@ def create_1dplot_2nd_part(
                         now_fores_paired, var_info[1],
                         [read_ofs_ctl_file[-1][i],
                          read_station_ctl_file[0][obs_row][2],
-                         read_station_ctl_file[0][obs_row][1].split('_')[-1]],
+                         read_station_ctl_file[0][obs_row][1].split('_')[-1],
+                         read_station_ctl_file[1][obs_row][2]],
                         read_ofs_ctl_file[1][i],
                         prop,logger)
                 elif var_info[1] == 'cu':
@@ -274,7 +275,8 @@ def create_1dplot_2nd_part(
                         now_fores_paired, var_info[1],
                         [read_ofs_ctl_file[-1][i],
                          read_station_ctl_file[0][obs_row][2],
-                         read_station_ctl_file[0][obs_row][1].split('_')[-1]],
+                         read_station_ctl_file[0][obs_row][1].split('_')[-1],
+                         read_station_ctl_file[1][obs_row][2]],
                         read_ofs_ctl_file[1][i],
                         prop,logger)
 
@@ -288,7 +290,8 @@ def create_1dplot_2nd_part(
                         var_info[1],
                         [read_ofs_ctl_file[-1][i],
                          read_station_ctl_file[0][obs_row][2],
-                         read_station_ctl_file[0][obs_row][1].split('_')[-1]],
+                         read_station_ctl_file[0][obs_row][1].split('_')[-1],
+                         read_station_ctl_file[1][obs_row][2]],
                         read_ofs_ctl_file[1][i],
                         prop, logger)
                     if deltat <= -1:
@@ -300,7 +303,8 @@ def create_1dplot_2nd_part(
                             now_fores_paired, var_info[1],
                             [read_ofs_ctl_file[-1][i],
                               read_station_ctl_file[0][obs_row][2],
-                              read_station_ctl_file[0][obs_row][1].split('_')[-1]],
+                              read_station_ctl_file[0][obs_row][1].split('_')[-1],
+                              read_station_ctl_file[1][obs_row][2]],
                             read_ofs_ctl_file[1][i],
                             prop,logger)
                         logger.info(
@@ -312,7 +316,8 @@ def create_1dplot_2nd_part(
                             now_fores_paired, var_info[1],
                             [read_ofs_ctl_file[-1][i],
                               read_station_ctl_file[0][obs_row][2],
-                              read_station_ctl_file[0][obs_row][1].split('_')[-1]],
+                              read_station_ctl_file[0][obs_row][1].split('_')[-1],
+                              read_station_ctl_file[1][obs_row][2]],
                             read_ofs_ctl_file[1][i],
                             prop,logger)
             except Exception as ex:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,7 +115,7 @@ extend-exclude = '''
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
-python_files = ["test_*.py"]
+python_files = ["test_*.py", "*_test.py"]
 python_functions = ["test_*"]
 addopts = "--verbose --cov=src/ofs_skill --cov-report=html --cov-report=term-missing"
 markers = [

--- a/src/ofs_skill/obs_retrieval/get_station_observations.py
+++ b/src/ofs_skill/obs_retrieval/get_station_observations.py
@@ -10,7 +10,7 @@ Technical Contact(s): Name:  FC
 Abstract:
 
    This is the final station observation data function.
-   This function calls the Tides and Currents, NDBC, and USGS retrieval
+   This function calls the Tides and Currents, NDBC, USGS, and CHS retrieval
    function in loop for all stations found in the
    ofs_inventory_stations(OFS, Start_Date, End_Date, Path) and variables
    ['water_level', 'water_temperature', 'salinity', 'currents'].

--- a/src/ofs_skill/obs_retrieval/get_station_observations.py
+++ b/src/ofs_skill/obs_retrieval/get_station_observations.py
@@ -758,6 +758,24 @@ def get_station_observations(prop,logger):
                                 start_date_full,
                                 end_date_full
                             )
+
+                        elif (
+                            variable == 'currents'
+                        ):  # different format than scalar variables
+                            formatted_series = \
+                                vector(
+                                timeseries,
+                                start_date_full,
+                                end_date_full
+                            )
+
+                        else:
+                            formatted_series = \
+                                scalar(
+                                timeseries,
+                                start_date_full,
+                                end_date_full
+                            )
                     except Exception as e_x:
                         logger.error('Fail when getting CHS %s '
                                      'data for station %s',

--- a/src/ofs_skill/obs_retrieval/inventory_chs_station.py
+++ b/src/ofs_skill/obs_retrieval/inventory_chs_station.py
@@ -60,10 +60,22 @@ def inventory_chs_station(
 
     try:
         logger.info('Calling CHS service for inventory...')
-        data = get_chs_stations()
-    except urllib.error.HTTPError as ex:
+        data = get_chs_stations(
+            lon_min=lon1, lon_max=lon2,
+            lat_min=lat1, lat_max=lat2,
+        )
+    except (urllib.error.HTTPError, Exception) as ex:
         logger.error('CHS data download failed! Error: %s', ex)
         return None
+
+    if data.empty:
+        logger.info('No CHS stations found within bounding box')
+        return None
+
+    codes_per_station = data['timeSeries'].apply(
+        lambda ts_list: {ts['code'] for ts in ts_list}
+        if isinstance(ts_list, list) else set()
+    )
 
     inventory_chs = pd.DataFrame(
         {
@@ -72,16 +84,17 @@ def inventory_chs_station(
             'Y': data['latitude'],
             'Source': 'CHS',
             'Name': data['officialName'],
-            'has_wl': True,
-            'has_temp': False,
-            'has_salt': False,
-            'has_cu': False,
+            'has_wl': codes_per_station.apply(
+                lambda c: 'wlo' in c),
+            'has_temp': codes_per_station.apply(
+                lambda c: bool(c & {'wt1', 'wt2'})),
+            'has_salt': codes_per_station.apply(
+                lambda c: bool(c & {'ws1', 'ws2'})),
+            'has_cu': codes_per_station.apply(
+                lambda c: bool(c & {'wcs1', 'wcs2'})
+                and bool(c & {'wcd1', 'wcd2'})),
         }
     )
-    inventory_chs = inventory_chs[
-        inventory_chs['X'].between(lon1, lon2)]
-    inventory_chs = inventory_chs[
-        inventory_chs['Y'].between(lat1, lat2)]
 
     logger.info('inventory_chs_station.py ran successfully')
 

--- a/src/ofs_skill/obs_retrieval/inventory_chs_station.py
+++ b/src/ofs_skill/obs_retrieval/inventory_chs_station.py
@@ -8,8 +8,6 @@ an inventory of all buoy stations within specified geographic bounds.
 Created on Wed Feb  4 16:58:00 2026
 """
 
-import urllib.error
-import urllib.request
 from logging import Logger
 from typing import Optional
 
@@ -64,7 +62,7 @@ def inventory_chs_station(
             lon_min=lon1, lon_max=lon2,
             lat_min=lat1, lat_max=lat2,
         )
-    except (urllib.error.HTTPError, Exception) as ex:
+    except Exception as ex:
         logger.error('CHS data download failed! Error: %s', ex)
         return None
 

--- a/src/ofs_skill/obs_retrieval/ofs_inventory_stations.py
+++ b/src/ofs_skill/obs_retrieval/ofs_inventory_stations.py
@@ -418,8 +418,8 @@ if __name__ == '__main__':
         '-so',
         '--Station_Owner',
         required=False,
-        default = 'co-ops,ndbc,usgs',
-        help="'CO-OPS','NDBC','USGS',", )
+        default = 'co-ops,ndbc,usgs,chs',
+        help="'CO-OPS', 'NDBC', 'USGS', 'CHS'", )
 
 
     args = parser.parse_args()

--- a/src/ofs_skill/obs_retrieval/retrieve_chs_station.py
+++ b/src/ofs_skill/obs_retrieval/retrieve_chs_station.py
@@ -1,13 +1,19 @@
 """
 Retrieve CHS (Canadian Hydrographic Service) station observations.
 
-This module uses SEARVEY to retrieve all CHS water level time series.
+This module uses SEARVEY to retrieve CHS time series data for water level,
+water temperature, salinity, and currents.
+
+Supported variables:
+    - water_level: Time series code 'wlo'
+    - water_temperature: Time series codes 'wt1', 'wt2' (fallback)
+    - salinity: Time series codes 'ws1', 'ws2' (fallback)
+    - currents: Speed ('wcs1'/'wcs2') + direction ('wcd1'/'wcd2')
 
 @author: PWL
 Created on Wed Feb  4 19:51:12 2026
 """
 
-import time
 from datetime import datetime, timedelta
 from logging import Logger
 from typing import Optional
@@ -15,8 +21,18 @@ from typing import Optional
 import pandas as pd
 from searvey._chs_api import fetch_chs_station
 
+# CHS time series codes per variable, in priority order (try first, fallback)
+_SCALAR_CODE_MAP = {
+    'water_level': ['wlo'],
+    'water_temperature': ['wt1', 'wt2'],
+    'salinity': ['ws1', 'ws2'],
+}
 
-def make_datetime_list(start_date, end_date, interval_hours):
+_CURRENT_SPEED_CODES = ['wcs1', 'wcs2']
+_CURRENT_DIR_CODES = ['wcd1', 'wcd2']
+
+
+def _make_date_chunks(start_date, end_date, interval_hours):
     """
     Generates a list of datetimes every `interval_hours` between start and
     end dates (inclusive of start & end). Returns list of datetime objects.
@@ -33,6 +49,128 @@ def make_datetime_list(start_date, end_date, interval_hours):
     return date_list
 
 
+def _fetch_chs_chunked(date_list, id_number, time_series_code, logger):
+    """
+    Fetch CHS data in 7-day chunks for a single time series code.
+
+    Uses searvey's built-in rate limiting (default 5 req/sec).
+
+    Args:
+        date_list: List of datetime chunk boundaries
+        id_number: CHS station ID
+        time_series_code: CHS time series code (e.g., 'wlo', 'wt1')
+        logger: Logger instance
+
+    Returns:
+        Concatenated DataFrame of all chunks, or None if no data.
+    """
+    data_all_append = []
+    for i in range(len(date_list) - 1):
+        data_station = fetch_chs_station(
+            station_id=str(id_number),
+            time_series_code=time_series_code,
+            start_date=datetime.strftime(date_list[i], '%Y-%m-%d'),
+            end_date=datetime.strftime(date_list[i + 1], '%Y-%m-%d'),
+        )
+        if 'errors' in data_station.columns or data_station.empty is True:
+            continue
+        data_all_append.append(data_station)
+
+    if len(data_all_append) > 0:
+        data_all = pd.concat(data_all_append, ignore_index=True)
+        return data_all
+    return None
+
+
+def _format_raw_data(data_all):
+    """Format raw CHS API response into standard columns."""
+    data_all['DateTime'] = pd.to_datetime(
+        data_all['eventDate'], format='%Y-%m-%dT%H:%M:%SZ')
+    drop_cols = [c for c in ['eventDate', 'qcFlagCode',
+                             'timeSeriesId', 'reviewed']
+                 if c in data_all.columns]
+    data_all = data_all.drop(columns=drop_cols)
+    data_all.rename(columns={'value': 'OBS'}, inplace=True)
+    data_all.drop_duplicates(subset=['DateTime'], keep='first',
+                             inplace=True)
+    return data_all
+
+
+def _retrieve_chs_scalar(date_list, id_number, variable, logger):
+    """
+    Retrieve a scalar CHS variable (water_level, temperature, salinity).
+
+    Tries codes in priority order; returns data from the first code
+    that yields results.
+    """
+    codes = _SCALAR_CODE_MAP.get(variable)
+    if codes is None:
+        return None
+
+    data_all = None
+    for code in codes:
+        data_all = _fetch_chs_chunked(date_list, id_number, code, logger)
+        if data_all is not None:
+            logger.info('CHS %s data found using code %s for station %s',
+                        variable, code, str(id_number))
+            break
+
+    if data_all is None:
+        return None
+
+    data_all = _format_raw_data(data_all)
+    data_all['DEP01'] = 0.0
+    if variable == 'water_level':
+        data_all['Datum'] = 'IGLD'
+
+    return data_all
+
+
+def _retrieve_chs_currents(date_list, id_number, logger):
+    """
+    Retrieve CHS current speed and direction, merge into single DataFrame.
+
+    Fetches speed and direction separately, then inner-merges on DateTime
+    so only timestamps with both values are kept.
+    """
+    speed_data = None
+    for code in _CURRENT_SPEED_CODES:
+        speed_data = _fetch_chs_chunked(date_list, id_number, code, logger)
+        if speed_data is not None:
+            logger.info('CHS current speed found using code %s for '
+                        'station %s', code, str(id_number))
+            break
+
+    dir_data = None
+    for code in _CURRENT_DIR_CODES:
+        dir_data = _fetch_chs_chunked(date_list, id_number, code, logger)
+        if dir_data is not None:
+            logger.info('CHS current direction found using code %s for '
+                        'station %s', code, str(id_number))
+            break
+
+    if speed_data is None or dir_data is None:
+        return None
+
+    # Parse DateTimes for both
+    for df in [speed_data, dir_data]:
+        df['DateTime'] = pd.to_datetime(
+            df['eventDate'], format='%Y-%m-%dT%H:%M:%SZ')
+
+    speed_data = speed_data[['DateTime', 'value']].drop_duplicates(
+        subset=['DateTime'], keep='first')
+    dir_data = dir_data[['DateTime', 'value']].drop_duplicates(
+        subset=['DateTime'], keep='first')
+
+    merged = speed_data.merge(dir_data, on='DateTime',
+                              suffixes=('_speed', '_dir'))
+    merged.rename(columns={'value_speed': 'OBS', 'value_dir': 'DIR'},
+                  inplace=True)
+    merged['DEP01'] = 0.0
+
+    return merged
+
+
 def retrieve_chs_station(
     start_date: str,
     end_date: str,
@@ -43,67 +181,43 @@ def retrieve_chs_station(
     """
     Retrieve CHS station data using SEARVEY library.
 
-    This function fetches all CHS data for a given station and time period.
+    This function fetches CHS data for a given station and time period.
 
     Args:
         start_date: Start date in YYYYMMDD format
         end_date: End date in YYYYMMDD format
         id_number: CHS station ID
-        variable: Variable to retrieve -- water level only!
+        variable: Variable to retrieve ('water_level',
+                  'water_temperature', 'salinity', 'currents')
         logger: Logger instance for logging messages
 
     Returns:
         DataFrame with columns:
             - DateTime: Observation timestamps
-            - DEP01: Depth (for currents/temperature/salinity)
+            - DEP01: Depth (0.0 for all CHS observations)
             - OBS: Observation values
             - DIR: Direction (for currents only)
-            - Datum: Vertical datum (for water_level only)
+            - Datum: Vertical datum (for water_level only, 'IGLD')
         Returns None if no data available.
-
-    Note:
-        - Water level returned in LWD datum
     """
-    data_station = []
-    start_date = start_date[:4] + '-' + start_date[4:6] + '-' + start_date[6:]
-    end_date = end_date[:4] + '-' + end_date[4:6] + '-' + end_date[6:]
-    start_date_dt = datetime.strptime(start_date, '%Y-%m-%d')
-    end_date_dt = datetime.strptime(end_date, '%Y-%m-%d')
+    start_date_str = (start_date[:4] + '-' + start_date[4:6]
+                      + '-' + start_date[6:])
+    end_date_str = (end_date[:4] + '-' + end_date[4:6]
+                    + '-' + end_date[6:])
+    start_date_dt = datetime.strptime(start_date_str, '%Y-%m-%d')
+    end_date_dt = datetime.strptime(end_date_str, '%Y-%m-%d')
+
     if (end_date_dt - start_date_dt).days > 7:
-        # Chunk the time
-        date_list = make_datetime_list(start_date_dt, end_date_dt, 7*24)
+        date_list = _make_date_chunks(start_date_dt, end_date_dt, 7 * 24)
     else:
         date_list = [start_date_dt, end_date_dt]
-    data_all_append = []
-    for i in range(len(date_list)-1):
-        data_station = fetch_chs_station(
-            station_id=str(id_number),
-            time_series_code='wlo',
-            start_date=datetime.strftime(date_list[i],'%Y-%m-%d'),
-            end_date=datetime.strftime(date_list[i+1],'%Y-%m-%d'),
-            )
-        if 'errors' in data_station.columns or data_station.empty is True:
-            continue
-        data_all_append.append(data_station)
-        time.sleep(0.33)
 
-    if len(data_all_append) > 0:
-        data_all = pd.concat(data_all_append, ignore_index=True)
-        # Do a bunch of formatting
-        data_all['DateTime'] = pd.to_datetime(data_all['eventDate'],
-                                              format='%Y-%m-%dT%H:%M:%SZ')
-        data_all = data_all.drop(columns=['eventDate',
-                                          'qcFlagCode',
-                                          'timeSeriesId',
-                                          'reviewed'])
-        data_all.rename(columns={'value': 'OBS'},
-                        inplace=True)
-        data_all['DEP01'] = 0.0
-        data_all['Datum'] = 'IGLD'
-        data_all.drop_duplicates(subset=['DateTime'], keep='first',
-                                 inplace=True)
+    if variable == 'currents':
+        data_all = _retrieve_chs_currents(date_list, id_number, logger)
     else:
-        data_all = None
+        data_all = _retrieve_chs_scalar(
+            date_list, id_number, variable, logger)
+
     if data_all is None:
         logger.error(
             'Retrieve CHS station %s failed for %s -- station contacted, '

--- a/src/ofs_skill/obs_retrieval/retrieve_chs_station.py
+++ b/src/ofs_skill/obs_retrieval/retrieve_chs_station.py
@@ -49,7 +49,7 @@ def _make_date_chunks(start_date, end_date, interval_hours):
     return date_list
 
 
-def _fetch_chs_chunked(date_list, id_number, time_series_code, logger):
+def _fetch_chs_chunked(date_list, id_number, time_series_code):
     """
     Fetch CHS data in 7-day chunks for a single time series code.
 
@@ -59,26 +59,24 @@ def _fetch_chs_chunked(date_list, id_number, time_series_code, logger):
         date_list: List of datetime chunk boundaries
         id_number: CHS station ID
         time_series_code: CHS time series code (e.g., 'wlo', 'wt1')
-        logger: Logger instance
 
     Returns:
         Concatenated DataFrame of all chunks, or None if no data.
     """
     data_all_append = []
-    for i in range(len(date_list) - 1):
+    for start, end in zip(date_list, date_list[1:]):
         data_station = fetch_chs_station(
             station_id=str(id_number),
             time_series_code=time_series_code,
-            start_date=datetime.strftime(date_list[i], '%Y-%m-%d'),
-            end_date=datetime.strftime(date_list[i + 1], '%Y-%m-%d'),
+            start_date=datetime.strftime(start, '%Y-%m-%d'),
+            end_date=datetime.strftime(end, '%Y-%m-%d'),
         )
-        if 'errors' in data_station.columns or data_station.empty is True:
+        if 'errors' in data_station.columns or data_station.empty:
             continue
         data_all_append.append(data_station)
 
-    if len(data_all_append) > 0:
-        data_all = pd.concat(data_all_append, ignore_index=True)
-        return data_all
+    if data_all_append:
+        return pd.concat(data_all_append, ignore_index=True)
     return None
 
 
@@ -109,7 +107,7 @@ def _retrieve_chs_scalar(date_list, id_number, variable, logger):
 
     data_all = None
     for code in codes:
-        data_all = _fetch_chs_chunked(date_list, id_number, code, logger)
+        data_all = _fetch_chs_chunked(date_list, id_number, code)
         if data_all is not None:
             logger.info('CHS %s data found using code %s for station %s',
                         variable, code, str(id_number))
@@ -135,7 +133,7 @@ def _retrieve_chs_currents(date_list, id_number, logger):
     """
     speed_data = None
     for code in _CURRENT_SPEED_CODES:
-        speed_data = _fetch_chs_chunked(date_list, id_number, code, logger)
+        speed_data = _fetch_chs_chunked(date_list, id_number, code)
         if speed_data is not None:
             logger.info('CHS current speed found using code %s for '
                         'station %s', code, str(id_number))
@@ -143,7 +141,7 @@ def _retrieve_chs_currents(date_list, id_number, logger):
 
     dir_data = None
     for code in _CURRENT_DIR_CODES:
-        dir_data = _fetch_chs_chunked(date_list, id_number, code, logger)
+        dir_data = _fetch_chs_chunked(date_list, id_number, code)
         if dir_data is not None:
             logger.info('CHS current direction found using code %s for '
                         'station %s', code, str(id_number))

--- a/src/ofs_skill/obs_retrieval/retrieve_chs_station.py
+++ b/src/ofs_skill/obs_retrieval/retrieve_chs_station.py
@@ -31,6 +31,18 @@ _SCALAR_CODE_MAP = {
 _CURRENT_SPEED_CODES = ['wcs1', 'wcs2']
 _CURRENT_DIR_CODES = ['wcd1', 'wcd2']
 
+# Matched sensor pairs for currents: speed and direction must come from
+# the same sensor number to avoid mixing sensors at different depths.
+_CURRENT_SENSOR_PAIRS = [('wcs1', 'wcd1'), ('wcs2', 'wcd2')]
+
+# CHS QC flag codes (from IWLS API):
+#   '1' = Not quality controlled
+#   '2' = Correct value
+#   '3' = Suspect/doubtful
+#   '4' = Erroneous/rejected
+# Accept codes 1 and 2; reject 3 (suspect) and 4 (erroneous).
+_ACCEPTED_QC_CODES = {'1', '2'}
+
 
 def _make_date_chunks(start_date, end_date, interval_hours):
     """
@@ -80,8 +92,17 @@ def _fetch_chs_chunked(date_list, id_number, time_series_code):
     return None
 
 
+def _filter_qc(data_all):
+    """Filter out records with rejected/suspect QC flags."""
+    if 'qcFlagCode' in data_all.columns:
+        data_all = data_all[
+            data_all['qcFlagCode'].isin(_ACCEPTED_QC_CODES)]
+    return data_all
+
+
 def _format_raw_data(data_all):
-    """Format raw CHS API response into standard columns."""
+    """Filter QC flags and format raw CHS API response into standard columns."""
+    data_all = _filter_qc(data_all)
     data_all['DateTime'] = pd.to_datetime(
         data_all['eventDate'], format='%Y-%m-%dT%H:%M:%SZ')
     drop_cols = [c for c in ['eventDate', 'qcFlagCode',
@@ -128,26 +149,30 @@ def _retrieve_chs_currents(date_list, id_number, logger):
     """
     Retrieve CHS current speed and direction, merge into single DataFrame.
 
-    Fetches speed and direction separately, then inner-merges on DateTime
-    so only timestamps with both values are kept.
+    Tries matched sensor pairs (wcs1+wcd1, then wcs2+wcd2) to avoid
+    mixing sensors at different depths. Falls back across pairs only if
+    a matched pair is not available.
     """
-    speed_data = None
-    for code in _CURRENT_SPEED_CODES:
-        speed_data = _fetch_chs_chunked(date_list, id_number, code)
-        if speed_data is not None:
-            logger.info('CHS current speed found using code %s for '
-                        'station %s', code, str(id_number))
+    # Try matched sensor pairs first (same sensor number for speed+dir)
+    for speed_code, dir_code in _CURRENT_SENSOR_PAIRS:
+        speed_data = _fetch_chs_chunked(date_list, id_number, speed_code)
+        dir_data = _fetch_chs_chunked(date_list, id_number, dir_code)
+        if speed_data is not None and dir_data is not None:
+            logger.info('CHS currents found using matched pair %s/%s '
+                        'for station %s',
+                        speed_code, dir_code, str(id_number))
             break
+    else:
+        # No matched pair found
+        logger.warning('CHS currents: no matched speed/direction sensor '
+                       'pair found for station %s', str(id_number))
+        return None
 
-    dir_data = None
-    for code in _CURRENT_DIR_CODES:
-        dir_data = _fetch_chs_chunked(date_list, id_number, code)
-        if dir_data is not None:
-            logger.info('CHS current direction found using code %s for '
-                        'station %s', code, str(id_number))
-            break
+    # Apply QC filtering before merge
+    speed_data = _filter_qc(speed_data)
+    dir_data = _filter_qc(dir_data)
 
-    if speed_data is None or dir_data is None:
+    if speed_data.empty or dir_data.empty:
         return None
 
     # Parse DateTimes for both

--- a/src/ofs_skill/obs_retrieval/retrieve_chs_station.py
+++ b/src/ofs_skill/obs_retrieval/retrieve_chs_station.py
@@ -156,6 +156,8 @@ def _retrieve_chs_currents(date_list, id_number, logger):
     # Try matched sensor pairs first (same sensor number for speed+dir)
     for speed_code, dir_code in _CURRENT_SENSOR_PAIRS:
         speed_data = _fetch_chs_chunked(date_list, id_number, speed_code)
+        if speed_data is None:
+            continue
         dir_data = _fetch_chs_chunked(date_list, id_number, dir_code)
         if speed_data is not None and dir_data is not None:
             logger.info('CHS currents found using matched pair %s/%s '

--- a/src/ofs_skill/obs_retrieval/write_obs_ctlfile.py
+++ b/src/ofs_skill/obs_retrieval/write_obs_ctlfile.py
@@ -35,12 +35,12 @@ from coastalmodeling_vdatum import vdatum
 
 from ofs_skill.obs_retrieval import retrieve_properties, utils
 from ofs_skill.obs_retrieval.ofs_inventory_stations import ofs_inventory_stations
+from ofs_skill.obs_retrieval.retrieve_chs_station import retrieve_chs_station
 from ofs_skill.obs_retrieval.retrieve_ndbc_station import retrieve_ndbc_station
 from ofs_skill.obs_retrieval.retrieve_t_and_c_station import (
     retrieve_t_and_c_station,
 )
 from ofs_skill.obs_retrieval.retrieve_usgs_station import retrieve_usgs_station
-from ofs_skill.obs_retrieval.retrieve_chs_station import retrieve_chs_station
 
 _COOPS_MAX_WORKERS = 6
 _NDBC_MAX_WORKERS = 6
@@ -452,49 +452,66 @@ def _process_chs_station(id_number, name, x_value, y_value,
             'CHS %s data found for '
             'station %s.', variable, str(id_number)
             )
-        if 'l' not in ofs[0]:
-            if (str(
-                    data_station['Datum'][1]
-                    ).upper() == datum):
-                zdiff = 0
-            else:
-                ldatum = datum.lower()
-                dummyval = 10
-                _,_,z = vdatum.convert(
-                    data_station['Datum'][1].lower(),
-                    ldatum,
-                    y_value,
-                    x_value,
-                    dummyval, #use dummy value
-                    online=True,
-                    epoch=None)
-                if math.isinf(z):
-                    zdiff = 'RANGE'
+
+        if variable == 'water_level':
+            if 'l' not in ofs[0]:
+                if (str(
+                        data_station['Datum'][1]
+                        ).upper() == datum):
+                    zdiff = 0
                 else:
-                    zdiff = round(z-dummyval,2) # datum offset
-        else:
-            if datum == 'IGLD':
-                if ofs == 'leofs':
-                    zdiff = 173.5
-                elif ofs == 'lmhofs':
-                    zdiff = 176.0
-                elif ofs == 'lsofs':
-                    zdiff = 183.2
-                elif ofs == 'loofs' or ofs == 'loofs2':
-                    zdiff = 74.2
-            elif datum == 'LWD':
-                zdiff = 0 # No correction needed
+                    ldatum = datum.lower()
+                    dummyval = 10
+                    _,_,z = vdatum.convert(
+                        data_station['Datum'][1].lower(),
+                        ldatum,
+                        y_value,
+                        x_value,
+                        dummyval, #use dummy value
+                        online=True,
+                        epoch=None)
+                    if math.isinf(z):
+                        zdiff = 'RANGE'
+                    else:
+                        zdiff = round(z-dummyval,2) # datum offset
             else:
-                zdiff = 'UNKNOWN'
-        return (
-            f'{str( id_number )} '
-            f'{str( id_number )}_{name_var}_'
-            f'{ofs}_CHS "{name}"\n  {y_value:.3f} '
-            f'{x_value:.3f} '
-            f'{zdiff}  0.0  {data_station["Datum"][1]}\n'
+                if datum == 'IGLD':
+                    if ofs == 'leofs':
+                        zdiff = 173.5
+                    elif ofs == 'lmhofs':
+                        zdiff = 176.0
+                    elif ofs == 'lsofs':
+                        zdiff = 183.2
+                    elif ofs == 'loofs' or ofs == 'loofs2':
+                        zdiff = 74.2
+                elif datum == 'LWD':
+                    zdiff = 0 # No correction needed
+                else:
+                    zdiff = 'UNKNOWN'
+            return (
+                f'{str( id_number )} '
+                f'{str( id_number )}_{name_var}_'
+                f'{ofs}_CHS "{name}"\n  {y_value:.3f} '
+                f'{x_value:.3f} '
+                f'{zdiff}  0.0  {data_station["Datum"][1]}\n'
+                )
+
+        else:
+            data_station['DEP01'] = data_station[
+                'DEP01'].astype(float)
+            return (
+                f'{str( id_number )} {str( id_number )}_{name_var}_'
+                f'{ofs}_CHS "{name}"\n  {y_value:.3f} '
+                f'{x_value:.3f} 0.0  '
+                f'{data_station["DEP01"].mean():.2f}  '
+                f'0.0\n'
+                )
+    except Exception as ex:
+        logger.info(
+            'CHS %s data not found for '
+            'station %s. Exception: %s', variable,
+            str(id_number), ex
             )
-    except:
-        pass
 
 def _process_variable(variable, inventory, var_to_col, start_date, end_date,
                       datum, datum_list, ofs, usgs_max_workers,

--- a/src/ofs_skill/obs_retrieval/write_obs_ctlfile.py
+++ b/src/ofs_skill/obs_retrieval/write_obs_ctlfile.py
@@ -454,7 +454,14 @@ def _process_chs_station(id_number, name, x_value, y_value,
             )
 
         if variable == 'water_level':
-            if 'l' not in ofs[0]:
+            # CHS IWLS API returns water levels relative to chart datum.
+            # For Great Lakes, chart datum IS the Low Water Datum (LWD).
+            # The Datum column is labeled 'IGLD' for consistency with the
+            # pipeline, but the GL offsets below convert from LWD to IGLD
+            # when the user requests IGLD.
+            if ofs not in [
+                    'leofs', 'lmhofs', 'loofs',
+                    'loofs2', 'lsofs']:
                 if (str(
                         data_station['Datum'][1]
                         ).upper() == datum):

--- a/src/ofs_skill/obs_retrieval/write_obs_ctlfile.py
+++ b/src/ofs_skill/obs_retrieval/write_obs_ctlfile.py
@@ -512,6 +512,7 @@ def _process_chs_station(id_number, name, x_value, y_value,
             'station %s. Exception: %s', variable,
             str(id_number), ex
             )
+    return None
 
 def _process_variable(variable, inventory, var_to_col, start_date, end_date,
                       datum, datum_list, ofs, usgs_max_workers,

--- a/src/ofs_skill/skill_assessment/get_skill.py
+++ b/src/ofs_skill/skill_assessment/get_skill.py
@@ -863,7 +863,7 @@ if __name__ == '__main__':
         '-so',
         '--Station_Owner',
         required=False,
-        help="'CO-OPS', 'NDBC', 'USGS',", )
+        help="'CO-OPS', 'NDBC', 'USGS', 'CHS'", )
 
     args = parser.parse_args()
     prop1 = model_properties.ModelProperties()

--- a/src/ofs_skill/visualization/plotting_scalar.py
+++ b/src/ofs_skill/visualization/plotting_scalar.py
@@ -644,6 +644,23 @@ def oned_scalar_plot(
                 row=1, col=1,
             )
 
+    # Add annotation if assumed surface depth (no depth data from API)
+    if name_var != 'wl' and len(station_id) > 3:
+        try:
+            obs_depth = float(station_id[3])
+            if obs_depth == 0.0:
+                fig.add_annotation(
+                    text='<b>Note: no obs depth<br>available from API.<br>'
+                         'Assumed surface (0 m)</b>',
+                    xref='x domain', yref='y domain',
+                    font=dict(size=12, color='#E68A00'),
+                    x=0, y=0.0,
+                    showarrow=False,
+                    row=1, col=1,
+                )
+        except (ValueError, TypeError):
+            pass
+
     # Set x-axis moving bar
     fig.update_xaxes(
         showspikes=True,

--- a/src/ofs_skill/visualization/plotting_vector.py
+++ b/src/ofs_skill/visualization/plotting_vector.py
@@ -533,6 +533,23 @@ def oned_vector_plot1(
         ),
     )
 
+    # Add annotation if assumed surface depth (no depth data from API)
+    if len(station_id) > 3:
+        try:
+            obs_depth = float(station_id[3])
+            if obs_depth == 0.0:
+                fig.add_annotation(
+                    text='<b>Note: no obs depth<br>available from API.<br>'
+                         'Assumed surface (0 m)</b>',
+                    xref='x domain', yref='y domain',
+                    font=dict(size=12, color='#E68A00'),
+                    x=0, y=0.0,
+                    showarrow=False,
+                    row=1, col=1,
+                )
+        except (ValueError, TypeError):
+            pass
+
     # Set x-axis moving bar
     fig.update_xaxes(
         showspikes=True,

--- a/tests/chs_retrieval_test.py
+++ b/tests/chs_retrieval_test.py
@@ -326,18 +326,43 @@ class TestRetrieveCurrents:
 
     @patch('ofs_skill.obs_retrieval.retrieve_chs_station.fetch_chs_station')
     def test_currents_no_speed_returns_none(self, mock_fetch, logger):
-        """If speed data is missing, should return None."""
+        """If speed data is missing from all pairs, should return None."""
         empty_df = pd.DataFrame(columns=[
             'eventDate', 'qcFlagCode', 'value', 'timeSeriesId', 'reviewed'])
         dir_df = _make_chs_api_response([90.0, 135.0])
 
-        # wcs1 empty, wcs2 empty, then wcd1 would succeed but speed is None
-        mock_fetch.side_effect = [empty_df, empty_df, dir_df]
+        # Pair 1: wcs1 empty, wcd1 has data -> pair fails (no speed)
+        # Pair 2: wcs2 empty, wcd2 has data -> pair fails (no speed)
+        mock_fetch.side_effect = [empty_df, dir_df, empty_df, dir_df]
 
         result = retrieve_chs_station(
             '20250101', '20250102', 'test_st', 'currents', logger)
 
         assert result is None
+
+    @patch('ofs_skill.obs_retrieval.retrieve_chs_station.fetch_chs_station')
+    def test_currents_matched_sensor_pair(self, mock_fetch, logger):
+        """Speed and direction must come from same sensor number."""
+        empty_df = pd.DataFrame(columns=[
+            'eventDate', 'qcFlagCode', 'value', 'timeSeriesId', 'reviewed'])
+        speed_df = _make_chs_api_response([1.0])
+        dir_df = _make_chs_api_response([90.0])
+
+        # Pair 1: wcs1 empty, wcd1 has data -> pair fails
+        # Pair 2: wcs2 has data, wcd2 has data -> pair succeeds
+        mock_fetch.side_effect = [empty_df, dir_df, speed_df, dir_df]
+
+        result = retrieve_chs_station(
+            '20250101', '20250102', 'test_st', 'currents', logger)
+
+        assert result is not None
+        calls = mock_fetch.call_args_list
+        # Pair 1 tried wcs1 first (failed), then wcd1
+        assert calls[0][1]['time_series_code'] == 'wcs1'
+        assert calls[1][1]['time_series_code'] == 'wcd1'
+        # Pair 2 tried wcs2 (succeeded), then wcd2 (succeeded)
+        assert calls[2][1]['time_series_code'] == 'wcs2'
+        assert calls[3][1]['time_series_code'] == 'wcd2'
 
     @patch('ofs_skill.obs_retrieval.retrieve_chs_station.fetch_chs_station')
     def test_currents_api_codes(self, mock_fetch, logger):

--- a/tests/chs_retrieval_test.py
+++ b/tests/chs_retrieval_test.py
@@ -1,0 +1,391 @@
+"""
+Test suite for CHS (Canadian Hydrographic Service) observation retrieval.
+
+This module tests the CHS data retrieval functionality including:
+- Inventory retrieval with dynamic variable capability flags
+- Data retrieval for water level, temperature, salinity, and currents
+- Fallback time series code logic
+- Current speed/direction merge
+"""
+
+import logging
+from unittest.mock import patch
+
+import pandas as pd
+import pytest
+
+from ofs_skill.obs_retrieval.inventory_chs_station import (
+    inventory_chs_station,
+)
+from ofs_skill.obs_retrieval.retrieve_chs_station import (
+    retrieve_chs_station,
+)
+
+
+@pytest.fixture
+def logger():
+    """Create a logger for tests."""
+    logging.basicConfig(level=logging.INFO)
+    return logging.getLogger('test_chs')
+
+
+def _make_chs_api_response(values, start='2025-01-01', minutes=5):
+    """Helper to create a fake CHS API response DataFrame."""
+    n = len(values)
+    dates = pd.date_range(start, periods=n, freq=f'{minutes}min')
+    return pd.DataFrame({
+        'eventDate': [d.strftime('%Y-%m-%dT%H:%M:%SZ') for d in dates],
+        'qcFlagCode': ['1'] * n,
+        'value': values,
+        'timeSeriesId': ['fake_ts_id'] * n,
+        'reviewed': [False] * n,
+    })
+
+
+def _make_station_metadata(station_id, name, lat, lon, codes):
+    """Helper to create a fake station metadata row."""
+    ts_list = [
+        {'id': f'fake_{c}', 'code': c, 'nameEn': f'Fake {c}',
+         'nameFr': f'Faux {c}', 'phenomenonId': 'fake', 'owner': 'CHS-SHC'}
+        for c in codes
+    ]
+    return {
+        'id': station_id,
+        'code': '99999',
+        'officialName': name,
+        'alternativeName': None,
+        'operating': True,
+        'latitude': lat,
+        'longitude': lon,
+        'type': 'PERMANENT',
+        'timeSeries': ts_list,
+    }
+
+
+class TestCHSImports:
+    """Test that CHS modules can be imported correctly."""
+
+    def test_retrieve_chs_station_import(self):
+        from ofs_skill.obs_retrieval.retrieve_chs_station import (
+            retrieve_chs_station,
+        )
+        assert callable(retrieve_chs_station)
+
+    def test_inventory_chs_station_import(self):
+        from ofs_skill.obs_retrieval.inventory_chs_station import (
+            inventory_chs_station,
+        )
+        assert callable(inventory_chs_station)
+
+
+class TestInventoryCapabilityFlags:
+    """Test dynamic capability flag extraction from timeSeries metadata."""
+
+    @patch('ofs_skill.obs_retrieval.inventory_chs_station.get_chs_stations')
+    def test_wl_only_station(self, mock_get_stations, logger):
+        """Station with only wlo should have has_wl=True, others False."""
+        import geopandas as gpd
+        from shapely.geometry import Point
+
+        meta = _make_station_metadata(
+            'st1', 'Test WL', 45.0, -70.0, ['wlp', 'wlo', 'wlp-hilo'])
+        df = gpd.GeoDataFrame([meta],
+                              geometry=[Point(meta['longitude'],
+                                              meta['latitude'])],
+                              crs='EPSG:4326')
+        mock_get_stations.return_value = df
+
+        result = inventory_chs_station(44.0, 46.0, -71.0, -69.0, logger)
+
+        assert result is not None
+        assert len(result) == 1
+        assert result.iloc[0]['has_wl']
+        assert not result.iloc[0]['has_temp']
+        assert not result.iloc[0]['has_salt']
+        assert not result.iloc[0]['has_cu']
+
+    @patch('ofs_skill.obs_retrieval.inventory_chs_station.get_chs_stations')
+    def test_full_capability_station(self, mock_get_stations, logger):
+        """Station with all variable codes should have all flags True."""
+        import geopandas as gpd
+        from shapely.geometry import Point
+
+        meta = _make_station_metadata(
+            'st2', 'Test Full', 45.0, -70.0,
+            ['wlo', 'wt1', 'ws1', 'wcs1', 'wcd1'])
+        df = gpd.GeoDataFrame([meta],
+                              geometry=[Point(meta['longitude'],
+                                              meta['latitude'])],
+                              crs='EPSG:4326')
+        mock_get_stations.return_value = df
+
+        result = inventory_chs_station(44.0, 46.0, -71.0, -69.0, logger)
+
+        assert result.iloc[0]['has_wl']
+        assert result.iloc[0]['has_temp']
+        assert result.iloc[0]['has_salt']
+        assert result.iloc[0]['has_cu']
+
+    @patch('ofs_skill.obs_retrieval.inventory_chs_station.get_chs_stations')
+    def test_speed_only_no_currents(self, mock_get_stations, logger):
+        """Station with speed but no direction should have has_cu=False."""
+        import geopandas as gpd
+        from shapely.geometry import Point
+
+        meta = _make_station_metadata(
+            'st3', 'Speed Only', 45.0, -70.0, ['wlo', 'wcs1'])
+        df = gpd.GeoDataFrame([meta],
+                              geometry=[Point(meta['longitude'],
+                                              meta['latitude'])],
+                              crs='EPSG:4326')
+        mock_get_stations.return_value = df
+
+        result = inventory_chs_station(44.0, 46.0, -71.0, -69.0, logger)
+
+        assert not result.iloc[0]['has_cu']
+
+    @patch('ofs_skill.obs_retrieval.inventory_chs_station.get_chs_stations')
+    def test_fallback_codes(self, mock_get_stations, logger):
+        """Station with wt2 (not wt1) should still have has_temp=True."""
+        import geopandas as gpd
+        from shapely.geometry import Point
+
+        meta = _make_station_metadata(
+            'st4', 'Fallback', 45.0, -70.0, ['wlo', 'wt2', 'ws2'])
+        df = gpd.GeoDataFrame([meta],
+                              geometry=[Point(meta['longitude'],
+                                              meta['latitude'])],
+                              crs='EPSG:4326')
+        mock_get_stations.return_value = df
+
+        result = inventory_chs_station(44.0, 46.0, -71.0, -69.0, logger)
+
+        assert result.iloc[0]['has_temp']
+        assert result.iloc[0]['has_salt']
+
+    @patch('ofs_skill.obs_retrieval.inventory_chs_station.get_chs_stations')
+    def test_no_wlo_station(self, mock_get_stations, logger):
+        """Station without wlo should have has_wl=False."""
+        import geopandas as gpd
+        from shapely.geometry import Point
+
+        meta = _make_station_metadata(
+            'st5', 'Predictions Only', 45.0, -70.0, ['wlp', 'wlp-hilo'])
+        df = gpd.GeoDataFrame([meta],
+                              geometry=[Point(meta['longitude'],
+                                              meta['latitude'])],
+                              crs='EPSG:4326')
+        mock_get_stations.return_value = df
+
+        result = inventory_chs_station(44.0, 46.0, -71.0, -69.0, logger)
+
+        assert not result.iloc[0]['has_wl']
+
+    @patch('ofs_skill.obs_retrieval.inventory_chs_station.get_chs_stations')
+    def test_geo_filtering_passed_to_searvey(self, mock_get_stations, logger):
+        """Verify bbox params are passed to get_chs_stations."""
+        import geopandas as gpd
+        mock_get_stations.return_value = gpd.GeoDataFrame()
+
+        inventory_chs_station(44.0, 46.0, -71.0, -69.0, logger)
+
+        mock_get_stations.assert_called_once_with(
+            lon_min=-71.0, lon_max=-69.0,
+            lat_min=44.0, lat_max=46.0,
+        )
+
+
+class TestRetrieveScalar:
+    """Test scalar variable retrieval (water level, temp, salinity)."""
+
+    @patch('ofs_skill.obs_retrieval.retrieve_chs_station.fetch_chs_station')
+    def test_water_level(self, mock_fetch, logger):
+        """Water level should use wlo code and set Datum=IGLD."""
+        mock_fetch.return_value = _make_chs_api_response([1.0, 1.5, 2.0])
+
+        result = retrieve_chs_station(
+            '20250101', '20250102', 'test_st', 'water_level', logger)
+
+        assert result is not None
+        assert 'DateTime' in result.columns
+        assert 'OBS' in result.columns
+        assert 'DEP01' in result.columns
+        assert 'Datum' in result.columns
+        assert (result['Datum'] == 'IGLD').all()
+        assert (result['DEP01'] == 0.0).all()
+        mock_fetch.assert_called_with(
+            station_id='test_st',
+            time_series_code='wlo',
+            start_date='2025-01-01',
+            end_date='2025-01-02',
+        )
+
+    @patch('ofs_skill.obs_retrieval.retrieve_chs_station.fetch_chs_station')
+    def test_temperature(self, mock_fetch, logger):
+        """Temperature should use wt1 code and NOT set Datum."""
+        mock_fetch.return_value = _make_chs_api_response([5.0, 5.5, 6.0])
+
+        result = retrieve_chs_station(
+            '20250101', '20250102', 'test_st', 'water_temperature', logger)
+
+        assert result is not None
+        assert 'Datum' not in result.columns
+        assert (result['DEP01'] == 0.0).all()
+        mock_fetch.assert_called_with(
+            station_id='test_st',
+            time_series_code='wt1',
+            start_date='2025-01-01',
+            end_date='2025-01-02',
+        )
+
+    @patch('ofs_skill.obs_retrieval.retrieve_chs_station.fetch_chs_station')
+    def test_temperature_fallback_wt2(self, mock_fetch, logger):
+        """If wt1 returns empty, should fallback to wt2."""
+        empty_df = pd.DataFrame(columns=[
+            'eventDate', 'qcFlagCode', 'value', 'timeSeriesId', 'reviewed'])
+        good_df = _make_chs_api_response([5.0, 5.5])
+
+        mock_fetch.side_effect = [empty_df, good_df]
+
+        result = retrieve_chs_station(
+            '20250101', '20250102', 'test_st', 'water_temperature', logger)
+
+        assert result is not None
+        assert len(result) == 2
+        calls = mock_fetch.call_args_list
+        assert calls[0][1]['time_series_code'] == 'wt1'
+        assert calls[1][1]['time_series_code'] == 'wt2'
+
+    @patch('ofs_skill.obs_retrieval.retrieve_chs_station.fetch_chs_station')
+    def test_salinity(self, mock_fetch, logger):
+        """Salinity should use ws1 code and NOT set Datum."""
+        mock_fetch.return_value = _make_chs_api_response([23.0, 23.5])
+
+        result = retrieve_chs_station(
+            '20250101', '20250102', 'test_st', 'salinity', logger)
+
+        assert result is not None
+        assert 'Datum' not in result.columns
+        mock_fetch.assert_called_with(
+            station_id='test_st',
+            time_series_code='ws1',
+            start_date='2025-01-01',
+            end_date='2025-01-02',
+        )
+
+    @patch('ofs_skill.obs_retrieval.retrieve_chs_station.fetch_chs_station')
+    def test_no_data_returns_none(self, mock_fetch, logger):
+        """Should return None when no data available."""
+        empty_df = pd.DataFrame(columns=[
+            'eventDate', 'qcFlagCode', 'value', 'timeSeriesId', 'reviewed'])
+        mock_fetch.return_value = empty_df
+
+        result = retrieve_chs_station(
+            '20250101', '20250102', 'test_st', 'water_temperature', logger)
+
+        assert result is None
+
+
+class TestRetrieveCurrents:
+    """Test current speed/direction retrieval and merge."""
+
+    @patch('ofs_skill.obs_retrieval.retrieve_chs_station.fetch_chs_station')
+    def test_currents_merge(self, mock_fetch, logger):
+        """Speed and direction should be merged on DateTime."""
+        speed_df = _make_chs_api_response([1.0, 1.5, 2.0])
+        dir_df = _make_chs_api_response([90.0, 135.0, 180.0])
+
+        mock_fetch.side_effect = [speed_df, dir_df]
+
+        result = retrieve_chs_station(
+            '20250101', '20250102', 'test_st', 'currents', logger)
+
+        assert result is not None
+        assert 'OBS' in result.columns
+        assert 'DIR' in result.columns
+        assert 'DEP01' in result.columns
+        assert 'Datum' not in result.columns
+        assert len(result) == 3
+        assert list(result['OBS']) == [1.0, 1.5, 2.0]
+        assert list(result['DIR']) == [90.0, 135.0, 180.0]
+
+    @patch('ofs_skill.obs_retrieval.retrieve_chs_station.fetch_chs_station')
+    def test_currents_partial_overlap(self, mock_fetch, logger):
+        """Only timestamps with both speed and direction should be kept."""
+        speed_df = _make_chs_api_response([1.0, 1.5, 2.0])
+        # Direction has only 2 timestamps (same start)
+        dir_df = _make_chs_api_response([90.0, 135.0])
+
+        mock_fetch.side_effect = [speed_df, dir_df]
+
+        result = retrieve_chs_station(
+            '20250101', '20250102', 'test_st', 'currents', logger)
+
+        assert result is not None
+        assert len(result) == 2  # inner merge
+
+    @patch('ofs_skill.obs_retrieval.retrieve_chs_station.fetch_chs_station')
+    def test_currents_no_speed_returns_none(self, mock_fetch, logger):
+        """If speed data is missing, should return None."""
+        empty_df = pd.DataFrame(columns=[
+            'eventDate', 'qcFlagCode', 'value', 'timeSeriesId', 'reviewed'])
+        dir_df = _make_chs_api_response([90.0, 135.0])
+
+        # wcs1 empty, wcs2 empty, then wcd1 would succeed but speed is None
+        mock_fetch.side_effect = [empty_df, empty_df, dir_df]
+
+        result = retrieve_chs_station(
+            '20250101', '20250102', 'test_st', 'currents', logger)
+
+        assert result is None
+
+    @patch('ofs_skill.obs_retrieval.retrieve_chs_station.fetch_chs_station')
+    def test_currents_api_codes(self, mock_fetch, logger):
+        """Should call wcs1 for speed and wcd1 for direction."""
+        speed_df = _make_chs_api_response([1.0])
+        dir_df = _make_chs_api_response([90.0])
+
+        mock_fetch.side_effect = [speed_df, dir_df]
+
+        retrieve_chs_station(
+            '20250101', '20250102', 'test_st', 'currents', logger)
+
+        calls = mock_fetch.call_args_list
+        assert calls[0][1]['time_series_code'] == 'wcs1'
+        assert calls[1][1]['time_series_code'] == 'wcd1'
+
+
+class TestDateChunking:
+    """Test 7-day date chunking behavior."""
+
+    @patch('ofs_skill.obs_retrieval.retrieve_chs_station.fetch_chs_station')
+    def test_short_range_no_chunking(self, mock_fetch, logger):
+        """Ranges <= 7 days should result in a single API call."""
+        mock_fetch.return_value = _make_chs_api_response([1.0])
+
+        retrieve_chs_station(
+            '20250101', '20250105', 'test_st', 'water_level', logger)
+
+        assert mock_fetch.call_count == 1
+
+    @patch('ofs_skill.obs_retrieval.retrieve_chs_station.fetch_chs_station')
+    def test_long_range_chunked(self, mock_fetch, logger):
+        """Ranges > 7 days should be split into multiple API calls."""
+        mock_fetch.return_value = _make_chs_api_response([1.0])
+
+        retrieve_chs_station(
+            '20250101', '20250120', 'test_st', 'water_level', logger)
+
+        assert mock_fetch.call_count > 1
+
+
+class TestUnsupportedVariable:
+    """Test behavior with unsupported variable names."""
+
+    @patch('ofs_skill.obs_retrieval.retrieve_chs_station.fetch_chs_station')
+    def test_invalid_variable(self, mock_fetch, logger):
+        """Unsupported variable should return None."""
+        result = retrieve_chs_station(
+            '20250101', '20250102', 'test_st', 'ice_concentration', logger)
+
+        assert result is None

--- a/tests/chs_retrieval_test.py
+++ b/tests/chs_retrieval_test.py
@@ -285,6 +285,28 @@ class TestRetrieveScalar:
 
         assert result is None
 
+    @patch('ofs_skill.obs_retrieval.retrieve_chs_station.fetch_chs_station')
+    def test_qc_filtering_rejects_suspect_data(self, mock_fetch, logger):
+        """Records with qcFlagCode 3 (suspect) or 4 (erroneous) are filtered."""
+        n = 5
+        dates = pd.date_range('2025-01-01', periods=n, freq='5min')
+        df = pd.DataFrame({
+            'eventDate': [d.strftime('%Y-%m-%dT%H:%M:%SZ') for d in dates],
+            'qcFlagCode': ['1', '2', '3', '4', '1'],
+            'value': [5.0, 5.5, 999.0, -99.0, 6.0],
+            'timeSeriesId': ['ts'] * n,
+            'reviewed': [False] * n,
+        })
+        mock_fetch.return_value = df
+
+        result = retrieve_chs_station(
+            '20250101', '20250102', 'test_st', 'water_temperature', logger)
+
+        assert result is not None
+        assert len(result) == 3  # only codes '1' and '2' accepted
+        assert 999.0 not in result['OBS'].values
+        assert -99.0 not in result['OBS'].values
+
 
 class TestRetrieveCurrents:
     """Test current speed/direction retrieval and merge."""
@@ -329,16 +351,20 @@ class TestRetrieveCurrents:
         """If speed data is missing from all pairs, should return None."""
         empty_df = pd.DataFrame(columns=[
             'eventDate', 'qcFlagCode', 'value', 'timeSeriesId', 'reviewed'])
-        dir_df = _make_chs_api_response([90.0, 135.0])
 
-        # Pair 1: wcs1 empty, wcd1 has data -> pair fails (no speed)
-        # Pair 2: wcs2 empty, wcd2 has data -> pair fails (no speed)
-        mock_fetch.side_effect = [empty_df, dir_df, empty_df, dir_df]
+        # Pair 1: wcs1 empty -> skip direction, continue to pair 2
+        # Pair 2: wcs2 empty -> skip direction, no pairs left
+        mock_fetch.side_effect = [empty_df, empty_df]
 
         result = retrieve_chs_station(
             '20250101', '20250102', 'test_st', 'currents', logger)
 
         assert result is None
+        # Only speed codes tried (direction skipped due to early continue)
+        calls = mock_fetch.call_args_list
+        assert len(calls) == 2
+        assert calls[0][1]['time_series_code'] == 'wcs1'
+        assert calls[1][1]['time_series_code'] == 'wcs2'
 
     @patch('ofs_skill.obs_retrieval.retrieve_chs_station.fetch_chs_station')
     def test_currents_matched_sensor_pair(self, mock_fetch, logger):
@@ -348,21 +374,19 @@ class TestRetrieveCurrents:
         speed_df = _make_chs_api_response([1.0])
         dir_df = _make_chs_api_response([90.0])
 
-        # Pair 1: wcs1 empty, wcd1 has data -> pair fails
+        # Pair 1: wcs1 empty -> skip wcd1 (early continue)
         # Pair 2: wcs2 has data, wcd2 has data -> pair succeeds
-        mock_fetch.side_effect = [empty_df, dir_df, speed_df, dir_df]
+        mock_fetch.side_effect = [empty_df, speed_df, dir_df]
 
         result = retrieve_chs_station(
             '20250101', '20250102', 'test_st', 'currents', logger)
 
         assert result is not None
         calls = mock_fetch.call_args_list
-        # Pair 1 tried wcs1 first (failed), then wcd1
         assert calls[0][1]['time_series_code'] == 'wcs1'
-        assert calls[1][1]['time_series_code'] == 'wcd1'
-        # Pair 2 tried wcs2 (succeeded), then wcd2 (succeeded)
-        assert calls[2][1]['time_series_code'] == 'wcs2'
-        assert calls[3][1]['time_series_code'] == 'wcd2'
+        # wcd1 skipped because wcs1 was empty
+        assert calls[1][1]['time_series_code'] == 'wcs2'
+        assert calls[2][1]['time_series_code'] == 'wcd2'
 
     @patch('ofs_skill.obs_retrieval.retrieve_chs_station.fetch_chs_station')
     def test_currents_api_codes(self, mock_fetch, logger):


### PR DESCRIPTION
### Description of Changes

Expands CHS (Canadian Hydrographic Service) observation support from water-level-only to include temperature, salinity, and currents in the 1D skill assessment pipeline. The CHS API via searvey provides temperature (`wt1`/`wt2`), salinity (`ws1`/`ws2`), and current speed/direction (`wcs1`/`wcd1`) data that was previously ignored.

Also improves searvey integration by using built-in geo filtering and rate limiting instead of manual implementations.

Partially addresses #70 (depth work deferred — CHS API does not expose sensor depth metadata).

**Key changes:**
- `inventory_chs_station.py` — Dynamic capability flags from timeSeries metadata + searvey geo filtering
- `retrieve_chs_station.py` — Multi-variable retrieval with code fallback, matched sensor pairs for currents, and QC flag filtering (accepts codes 1/2, rejects 3/4)
- `write_obs_ctlfile.py` — Variable-aware CTL entry format for `_process_chs_station()`; replaced fragile `'l' not in ofs[0]` Great Lakes detection with explicit OFS list
- `get_station_observations.py` — CHS routing for currents (vector) and temp/salt (scalar)
- `create_1dplot.py` + `plotting_scalar.py` + `plotting_vector.py` — Added orange annotation on 1D plots when station has no obs depth available from the API (DEP01 = 0.0 for non-water-level variables). Displays: _"Note: no obs depth available from API. Assumed surface (0 m)"_. Similar in style/placement to the existing red datum mismatch warning. Appears on temperature, salinity, and current plots; does not appear on water level plots (surface measurement by definition).
- `pyproject.toml` — Fixed pytest config to discover both `test_*.py` and `*_test.py` files (increases discovered tests from 177 to 309)
- `chs_retrieval_test.py` — 22 new unit tests covering inventory flags, scalar/current retrieval, QC rejection, sensor pair matching, date chunking, and fallback logic

### Expected Outcome of Changes

- CHS stations with temperature, salinity, or current data will now be included in 1D skill assessment runs (previously only water level was retrieved)
- Inventory accuracy improved: `has_wl` is now dynamic (was hardcoded True for all 1570 CHS stations; only 463 actually have `wlo`)
- Non-water-level 1D plots display an orange annotation when the observation depth is unknown/assumed surface
- Existing water level behavior is unchanged (regression-safe)
- **Note:** Existing `inventory_all_{ofs}.csv` files must be deleted and regenerated to pick up the new CHS capability flags

### Developer Questions and Checklist

**Is this a high priority PR?** No

**Are there any changes needed to how the code should be run for operational runs?** No — CHS is already included in the default station owner list (`co-ops,ndbc,usgs,chs`)

**Does this update need to be deployed for operational runs?** No

**Does this update require front end/web app changes?** No

**Does this impact code development work on adding SCHISM?** No

**Does this impact code development work on adding ADCIRC?** No

**Does this impact the expected number of output files for integration tests?** Yes — runs against OFS extents that overlap CHS stations with temp/salt/current data will now produce additional `.obs` files for those variables

- [x] Developer's name is removed throughout the code?
- [x] Did you add relevant labels to the PR?
- [x] Have you run pylint and is the code at an acceptable pylint score (>8)?
- [x] Jobs contain appropriate file checking and handle errors for missing data?
- [x] Is log free of critical ERRORs or WARNINGs?

### Testing Instructions

**Unit tests:** `python -m pytest tests/ -x -q` (309 pass, including 22 new CHS tests)

**CHS inventory verification:**
```python
from ofs_skill.obs_retrieval.inventory_chs_station import inventory_chs_station
import logging
logger = logging.getLogger('test'); logging.basicConfig(level=logging.INFO)
result = inventory_chs_station(41.0, 50.0, -93.0, -75.0, logger)
print(result[['ID','Name','has_wl','has_temp','has_salt','has_cu']].to_string())
```

**CHS temperature retrieval:**
```python
from ofs_skill.obs_retrieval.retrieve_chs_station import retrieve_chs_station
import logging
logger = logging.getLogger('test'); logging.basicConfig(level=logging.INFO)
# Saint-Laurent I.O. (has wt1)
result = retrieve_chs_station('20250601', '20250603', '5cebf1de3d0f4a073c4bbae6', 'water_temperature', logger)
print(result.head())
```

**CHS currents retrieval:**
```python
from ofs_skill.obs_retrieval.retrieve_chs_station import retrieve_chs_station
import logging
logger = logging.getLogger('test'); logging.basicConfig(level=logging.INFO)
# Masset (has wcs1 + wcd1)
result = retrieve_chs_station('20250601', '20250603', '5cebf1de3d0f4a073c4bba44', 'currents', logger)
print(result[['DateTime','OBS','DIR','DEP01']].head())
```

**1D E2E (verified):**
- leofs nowcast water_level: 6 CHS stations paired + plotted, RMSE 0.03-0.05m
- sfbofs nowcast all variables: 26 plots, depth warning annotation on all 11 non-WL timeseries plots
- cbofs nowcast water_level + water_temperature: 25 plots, CHS path runs cleanly (0 CHS stations in Chesapeake)

**Depth warning verification:** Open any sfbofs temperature/salinity/currents plot and confirm the orange "Note: no obs depth available from API. Assumed surface (0 m)" annotation appears in the bottom-left of the timeseries panel. Water level plots should NOT have this annotation.

### Reminder checklist for PR reviewer

- [ ] Run PEP8 compliance tests
- [x] Check documentation sufficiency
- [x] Validate output values for correctness
- [ ] Test on Windows and Linux (and MacOS if available)
- [x] Document test calls used

## Example figure w/ warning label:
<img width="900" height="700" alt="sfbofs_46237_currents_timeseries_nowcast_stations" src="https://github.com/user-attachments/assets/4d3d302d-0584-452a-95b8-0aa999939ae7" />
