### PR TITLE
Fix 2D whichcast loop to continue on error

### DIFF
--- a/bin/visualization/create_2dplot.py
+++ b/bin/visualization/create_2dplot.py
@@ -411,8 +411,8 @@ if __name__ == '__main__':
     ''' Set up paths & assign to prop1, do date validation '''
     prop1, logger = validate_and_initialize_parameters(prop1)
 
-    try:
-        for i in prop1.whichcasts:
+    for i in prop1.whichcasts:
+        try:
             prop1.whichcast = i.lower()
             logger.info('Running scripts for whichcast = %s',i)
 
@@ -462,8 +462,13 @@ if __name__ == '__main__':
 
             logger.info('Finished 2D processing for %s', prop1.whichcast)
 
-    except Exception as e:
-        logger.error('Problem processing 2d files - ABORT')
-        logger.error('Exception: %s', e)
+        except SystemExit as e:
+            logger.error('2D processing for %s exited prematurely '
+                         '(exit code %s). Continuing to next whichcast.',
+                         i, e.code)
+        except Exception as e:
+            logger.error('Problem processing 2d files for %s - '
+                         'continuing to next whichcast.', i)
+            logger.error('Exception: %s', e)
 
     logger.info('Finished create_2d_plot.py!')

--- a/bin/visualization/create_2dplot.py
+++ b/bin/visualization/create_2dplot.py
@@ -463,6 +463,8 @@ if __name__ == '__main__':
             logger.info('Finished 2D processing for %s', prop1.whichcast)
 
         except SystemExit as e:
+            # Catch sys.exit() calls from list_of_files, intake_model,
+            # and other functions in the call chain that still use sys.exit
             logger.error('2D processing for %s exited prematurely '
                          '(exit code %s). Continuing to next whichcast.',
                          i, e.code)

--- a/src/ofs_skill/visualization/plotting_2d.py
+++ b/src/ofs_skill/visualization/plotting_2d.py
@@ -26,7 +26,6 @@ Date          Author     Description
 
 import json
 import os
-import sys
 from datetime import datetime
 
 import numpy as np
@@ -113,7 +112,7 @@ def list_of_json_files(filepath, prop1, logger):
     all_files = os.listdir(filepath)
     if len(all_files) == 0:
         logger.warning('No satellite data available for stats. Skipping 2D plotting/stats.')
-        sys.exit(-1)
+        raise FileNotFoundError(f'No files found in directory {filepath}')
     spltstr = []
     files = []
     for af_name in all_files:
@@ -134,12 +133,10 @@ def list_of_json_files(filepath, prop1, logger):
                 and af_name.split('_')[0] == prop1.ofs):
                 spltstr.append(af_name.split('_')[1])  # Date info for sorting
                 files.append(filepath + '/' + af_name)  # Full file path
-    try:
-        files[0]
-    except IndexError:
-        logger.error('No JSON files found in directory %s! Exiting.',
-                     filepath)
-        sys.exit(-1)
+    if not files:
+        raise FileNotFoundError(
+            f'No matching JSON files found in directory {filepath}'
+        )
 
     # Sort file list
     tupfiles = tuple(zip(spltstr, files))
@@ -175,9 +172,8 @@ def json_to_numpy(files, logger):
         z_all.append(z)
     try:
         z_all = np.stack(z_all)
-    except ValueError:
-        logger.error("Can't stack arrays with different shapes!")
-        sys.exit(-1)
+    except ValueError as e:
+        raise ValueError("Can't stack arrays with different shapes!") from e
 
     return x, y, z_all
 
@@ -523,8 +519,7 @@ def plot_2d(prop1,logger):
             mod_files = [mod_files[i] for i in mod_ind]
             # Check pairing again to make sure
             if set(sat_dates) != set(mod_dates):
-                logger.error('Cannot pair satellite and model data! Abort!')
-                sys.exit(-1)
+                raise ValueError('Cannot pair satellite and model data!')
 
         #
         #Now convert available JSON files to numpy arrays for lat, lon, and z (sst)
@@ -551,8 +546,9 @@ def plot_2d(prop1,logger):
             and (z_sat.shape[0] == len(sat_dates))):
             time_steps = len(sat_dates)
         else:
-            logger.info('Error -- satellite and model arrays are different shapes!')
-            sys.exit(-1)
+            raise ValueError(
+                'Satellite and model arrays are different shapes!'
+            )
 
         if len(sat_dates) > 2: #skip if not enough time steps
             #Loop & do stats

--- a/src/ofs_skill/visualization/plotting_2d.py
+++ b/src/ofs_skill/visualization/plotting_2d.py
@@ -173,6 +173,7 @@ def json_to_numpy(files, logger):
     try:
         z_all = np.stack(z_all)
     except ValueError as e:
+        logger.error("Can't stack arrays with different shapes!")
         raise ValueError("Can't stack arrays with different shapes!") from e
 
     return x, y, z_all
@@ -519,6 +520,7 @@ def plot_2d(prop1,logger):
             mod_files = [mod_files[i] for i in mod_ind]
             # Check pairing again to make sure
             if set(sat_dates) != set(mod_dates):
+                logger.error('Cannot pair satellite and model data!')
                 raise ValueError('Cannot pair satellite and model data!')
 
         #
@@ -546,6 +548,7 @@ def plot_2d(prop1,logger):
             and (z_sat.shape[0] == len(sat_dates))):
             time_steps = len(sat_dates)
         else:
+            logger.error('Satellite and model arrays are different shapes!')
             raise ValueError(
                 'Satellite and model arrays are different shapes!'
             )


### PR DESCRIPTION
## Description of Changes

When running `create_2dplot.py` with multiple whichcasts (e.g. `-ws [nowcast,forecast_b]`), an error during the first whichcast prevents all subsequent whichcasts from running. Two issues:

1. **`create_2dplot.py`**: The `try/except` block wraps the entire `for` loop rather than each iteration, so any exception during nowcast kills the forecast_b iteration.

2. **`plotting_2d.py`**: `list_of_json_files()` and other functions call `sys.exit(-1)` on error. Since `SystemExit` inherits from `BaseException` (not `Exception`), the existing `except Exception` blocks cannot catch it, and the process dies.

**Fixes:**
- Move `try/except` inside the loop body so each whichcast iteration is independent. Add explicit `SystemExit` handling as a safety net.
- Replace all `sys.exit(-1)` calls in `plotting_2d.py` with proper exceptions (`FileNotFoundError`, `ValueError`) so they are catchable by the existing error handlers. Remove unused `sys` import.

## Expected Outcome of Changes

When running with `-ws [nowcast,forecast_b]`, both whichcasts produce 2D JSON output files even if one encounters an error during the plotting/stats phase.

## Developer Questions and Checklist

**Priority & Timeline?** Yes — this is blocking forecast_b 2D output in operational runs.

**Code execution changes needed?** No

**Requires deployment?** Yes — needs to be deployed to operational server to fix forecast_b output.

**Front-end changes needed?** No

**Impacts SCHISM development?** No

**Impacts ADCIRC development?** No

**Affects integration test output file count?** No

- [x] Developer name removed throughout code
- [x] Relevant PR labels added
- [x] Pylint run with acceptable score (>8)
- [x] Jobs include file checking and error handling
- [x] Logs free of critical errors/warnings

## Testing Instructions

Run the 2D pipeline with multiple whichcasts:

```bash
# Step 1: Download satellite observations
python ./bin/obs_retrieval/get_satellite_observations.py \
  -o sfbofs -p ./ -s 2026-04-07T00:00:00Z -e 2026-04-07T06:00:00Z

# Step 2: Run 2D visualization
python ./bin/visualization/create_2dplot.py \
  -o sfbofs -p ./ \
  -s 2026-04-07T00:00:00Z -e 2026-04-07T06:00:00Z \
  -ws "[nowcast,forecast_b]"
```

**Expected results:**
1. Log shows `Running scripts for whichcast = nowcast` followed by `Running scripts for whichcast = forecast_b`
2. Both nowcast and forecast_b model JSON files are written to `data/model/2d/`
3. If satellite data is unavailable or doesn't match the date range, the error is logged and the loop continues (no process crash)
4. Log ends with `Finished create_2d_plot.py!`

**Before this fix:** The process would crash after nowcast with `sys.exit(-1)` from `plotting_2d.py` and forecast_b would never run.