### PR TITLE
Add elements/nodes modes and plotting to ROMS grid shapefile converter

### DIFF
--- a/bin/utils/plot_romsgrid.py
+++ b/bin/utils/plot_romsgrid.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python
+"""Plot a ROMS grid from a NetCDF file using cartopy.
+
+Produces a depth-colored map of grid elements (quadrilateral cells built
+from psi-point corners) with cartopy coastlines and land overlay.
+
+By default the full domain is plotted.  Use --extent to zoom in, and
+--show-edges to draw individual cell edges (useful at regional scales).
+
+Dependencies
+------------
+cartopy, geopandas (optional, for --from-shapefile), matplotlib, netCDF4, numpy
+
+Examples
+--------
+  # Full domain, no cell edges
+  python plot_romsgrid.py grid.nc grid_overview.png
+
+  # Zoom to Chesapeake Bay with visible cell edges
+  python plot_romsgrid.py grid.nc chesapeake.png --extent -77.5 -75.5 36.5 39.5 --show-edges
+
+  # Include land cells
+  python plot_romsgrid.py grid.nc full_grid.png --all-cells
+"""
+
+import argparse
+import time
+
+import cartopy.crs as ccrs
+import cartopy.feature as cfeature
+import matplotlib
+import matplotlib.colors as mcolors
+import matplotlib.pyplot as plt
+import netCDF4 as nc
+import numpy as np
+from matplotlib.collections import PolyCollection
+
+
+def _load_grid(nc_file):
+    """Read key arrays from a ROMS grid NetCDF file."""
+    ds = nc.Dataset(nc_file, 'r')
+    data = {
+        'lon_psi': np.ma.filled(ds.variables['lon_psi'][:], np.nan),
+        'lat_psi': np.ma.filled(ds.variables['lat_psi'][:], np.nan),
+        'lon_rho': np.ma.filled(ds.variables['lon_rho'][:], np.nan),
+        'lat_rho': np.ma.filled(ds.variables['lat_rho'][:], np.nan),
+        'mask_rho': np.ma.filled(ds.variables['mask_rho'][:], 0),
+        'h': np.ma.filled(ds.variables['h'][:], np.nan),
+    }
+    ds.close()
+    return data
+
+
+def _build_elements(grid, water_only=True):
+    """Build polygon vertices, depths, and centre coords for interior cells.
+
+    Returns (verts, depths, centers_lon, centers_lat) where verts has shape
+    (n, 4, 2) — four corners per quadrilateral.
+    """
+    lon_psi = grid['lon_psi']
+    lat_psi = grid['lat_psi']
+    mask = grid['mask_rho']
+    h = grid['h']
+    lon_rho = grid['lon_rho']
+    lat_rho = grid['lat_rho']
+
+    neta_psi, nxi_psi = lon_psi.shape
+
+    e_range = np.arange(1, neta_psi)
+    x_range = np.arange(1, nxi_psi)
+    ee, xx = np.meshgrid(e_range, x_range, indexing='ij')
+    ee_flat = ee.ravel()
+    xx_flat = xx.ravel()
+
+    if water_only:
+        keep = mask[ee_flat, xx_flat] == 1
+        ee_flat = ee_flat[keep]
+        xx_flat = xx_flat[keep]
+
+    n = len(ee_flat)
+    verts = np.empty((n, 4, 2), dtype=np.float64)
+    verts[:, 0, 0] = lon_psi[ee_flat - 1, xx_flat - 1]
+    verts[:, 0, 1] = lat_psi[ee_flat - 1, xx_flat - 1]
+    verts[:, 1, 0] = lon_psi[ee_flat - 1, xx_flat]
+    verts[:, 1, 1] = lat_psi[ee_flat - 1, xx_flat]
+    verts[:, 2, 0] = lon_psi[ee_flat, xx_flat]
+    verts[:, 2, 1] = lat_psi[ee_flat, xx_flat]
+    verts[:, 3, 0] = lon_psi[ee_flat, xx_flat - 1]
+    verts[:, 3, 1] = lat_psi[ee_flat, xx_flat - 1]
+
+    depths = h[ee_flat, xx_flat]
+    centers_lon = lon_rho[ee_flat, xx_flat]
+    centers_lat = lat_rho[ee_flat, xx_flat]
+
+    return verts, depths, centers_lon, centers_lat
+
+
+def plot_grid(nc_file, out_file, extent=None, show_edges=False,
+              water_only=True, dpi=200, figsize=(16, 12)):
+    """Render the grid and save to *out_file*."""
+    matplotlib.use('Agg')
+
+    print('Reading grid...')
+    grid = _load_grid(nc_file)
+    verts, depths, centers_lon, centers_lat = _build_elements(
+        grid, water_only=water_only,
+    )
+    print(f'{len(verts):,} elements')
+
+    # Spatial filter when zoomed in
+    if extent is not None:
+        lon0, lon1, lat0, lat1 = extent
+        buf = 0.5
+        in_view = (
+            (centers_lon >= lon0 - buf) & (centers_lon <= lon1 + buf)
+            & (centers_lat >= lat0 - buf) & (centers_lat <= lat1 + buf)
+        )
+        verts = verts[in_view]
+        depths = depths[in_view]
+        print(f'  {len(verts):,} elements in view')
+
+    proj = ccrs.PlateCarree()
+    fig, ax = plt.subplots(figsize=figsize, subplot_kw={'projection': proj})
+
+    norm = mcolors.LogNorm(vmin=max(depths.min(), 1), vmax=depths.max())
+    cmap = plt.cm.ocean_r
+
+    edge_kw = {
+        'edgecolors': '#333333' if show_edges else 'none',
+        'linewidths': 0.3 if show_edges else 0,
+    }
+
+    t0 = time.time()
+    pc = PolyCollection(
+        verts,
+        array=depths,
+        cmap=cmap,
+        norm=norm,
+        transform=proj,
+        **edge_kw,
+    )
+    ax.add_collection(pc)
+
+    ax.add_feature(cfeature.LAND, facecolor='#d9d9d9', zorder=2)
+    ax.add_feature(cfeature.COASTLINE, linewidth=0.5, zorder=3)
+
+    if extent is not None:
+        ax.set_extent(extent, crs=proj)
+    else:
+        ax.set_extent([
+            centers_lon.min() - 1, centers_lon.max() + 1,
+            centers_lat.min() - 1, centers_lat.max() + 1,
+        ], crs=proj)
+
+    gl = ax.gridlines(draw_labels=True, linewidth=0.3, alpha=0.5)
+    gl.top_labels = False
+    gl.right_labels = False
+
+    cb = fig.colorbar(pc, ax=ax, orientation='vertical', shrink=0.7, pad=0.02)
+    cb.set_label('Depth (m)', fontsize=12)
+
+    title = f'ROMS Grid — {len(verts):,} elements (colored by depth)'
+    ax.set_title(title, fontsize=14)
+
+    fig.savefig(out_file, dpi=dpi, bbox_inches='tight')
+    plt.close(fig)
+    print(f'Saved: {out_file} ({time.time() - t0:.1f}s)')
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Plot a ROMS grid from a NetCDF file using cartopy.',
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument('nc_file', help='Input ROMS grid NetCDF file')
+    parser.add_argument('out_file', help='Output image path (e.g. grid.png)')
+    parser.add_argument(
+        '--extent', nargs=4, type=float, metavar=('LON0', 'LON1', 'LAT0', 'LAT1'),
+        help='Map extent: west east south north (decimal degrees)',
+    )
+    parser.add_argument(
+        '--show-edges', action='store_true',
+        help='Draw individual cell edges (best for zoomed-in views)',
+    )
+    parser.add_argument(
+        '--all-cells', action='store_true',
+        help='Include land cells (default: water only)',
+    )
+    parser.add_argument('--dpi', type=int, default=200, help='Output DPI (default: 200)')
+    parser.add_argument(
+        '--figsize', nargs=2, type=float, default=[16, 12], metavar=('W', 'H'),
+        help='Figure size in inches (default: 16 12)',
+    )
+
+    args = parser.parse_args()
+    plot_grid(
+        args.nc_file,
+        args.out_file,
+        extent=args.extent,
+        show_edges=args.show_edges,
+        water_only=not args.all_cells,
+        dpi=args.dpi,
+        figsize=tuple(args.figsize),
+    )
+
+
+if __name__ == '__main__':
+    main()

--- a/bin/utils/romsgrid_to_shapefile.py
+++ b/bin/utils/romsgrid_to_shapefile.py
@@ -1,62 +1,273 @@
-import netCDF4 as nc  # Import NetCDF4 for handling NetCDF files
-import numpy as np  # Import NumPy for numerical operations
-import shapefile  # Import shapefile for creating and writing Shapefiles
-from shapely.geometry import Polygon, MultiPoint, MultiLineString  # Import geometric objects from Shapely
-from scipy.spatial import ConvexHull  # Import ConvexHull for computing convex hulls
+#!/usr/bin/env python
+"""Convert a ROMS grid NetCDF file to ESRI Shapefile.
 
-def roms_grid_to_shapefile(nc_file, shp_file):
-    dataset = nc.Dataset(nc_file, 'r')  # Open the NetCDF file in read mode
-   
-    lon_rho = dataset.variables['lon_rho'][:]  # Extract longitude values
-    lat_rho = dataset.variables['lat_rho'][:]  # Extract latitude values
-    dataset.close()  # Close the dataset
-   
-    lon_rho = np.ma.filled(lon_rho, np.nan)  # Replace masked values with NaN
-    lat_rho = np.ma.filled(lat_rho, np.nan)  # Replace masked values with NaN
-   
-    mask = ~np.isnan(lon_rho) & ~np.isnan(lat_rho)  # Create a mask for valid values
-    points = np.column_stack((lon_rho[mask], lat_rho[mask]))  # Stack valid longitude and latitude values
-   
-    if points.shape[0] < 3:
-        raise ValueError("Not enough valid points to form a convex hull.")  # Ensure sufficient points for convex hull computation
-   
-    hull = ConvexHull(points)  # Compute convex hull of valid points
-    boundary = [tuple(points[i]) for i in hull.vertices]  # Extract boundary points
-    boundary.append(boundary[0])  # Close the polygon by repeating the first point
-   
-    with shapefile.Writer(shp_file, shapefile.POLYGON) as shp:
-        shp.field('ID', 'N')  # Define a numeric ID field
-        shp.poly([list(boundary)])  # Write polygon geometry to the shapefile
-        shp.record(1)  # Assign an ID to the polygon
-   
-    prj_content = """GEOGCS["WGS 84",
-    DATUM["WGS_1984",
-        SPHEROID["WGS 84",6378137,298.257223563,
-            AUTHORITY["EPSG","7030"]],
-        AUTHORITY["EPSG","6326"]],
-    PRIMEM["Greenwich",0,
-        AUTHORITY["EPSG","8901"]],
-    UNIT["degree",0.0174532925199433,
-        AUTHORITY["EPSG","9122"]],
-    AUTHORITY["EPSG","4326"]]"""
-    
-    with open(shp_file.replace('.shp', '.prj'), 'w') as prj:
-        prj.write(prj_content)  # Write projection information to a PRJ file
-   
-    print(f"Shapefile {shp_file} created successfully.")
+This utility reads a ROMS (Regional Ocean Modeling System) grid definition
+NetCDF file and produces an ESRI Shapefile in one of three output modes.
+All output is in WGS 84 / EPSG:4326 geographic coordinates.
 
-nc_file = "grid_eccofs_3km_08_b7_wtype.nc"  # Define the input NetCDF file
-shp_file = "roms_grid_7.shp"  # Define the output Shapefile name
-roms_grid_to_shapefile(nc_file, shp_file)  # Execute the conversion function
+Input
+-----
+The NetCDF file must contain the standard ROMS Arakawa-C grid variables:
+
+    lon_rho, lat_rho   Cell-centre coordinates     (eta_rho x xi_rho)
+    lon_psi, lat_psi   Cell-vertex coordinates      (eta_psi x xi_psi)
+    mask_rho            Land/water mask (1=water)    (eta_rho x xi_rho)
+    h                   Bathymetric depth (metres)   (eta_rho x xi_rho)
+
+Output modes
+------------
+boundary (default)
+    A single polygon that traces the outer perimeter of the rho grid
+    (bottom row -> right column -> top row reversed -> left column reversed).
+    Useful for clipping other datasets to the model domain.
+
+--elements
+    Every interior grid cell emitted as an individual quadrilateral polygon.
+    Vertices are taken from the psi grid, which provides the true ROMS cell
+    corners (rho points are cell centres, psi points are cell vertices).
+    Each feature carries attributes: eta, xi (grid indices), mask, depth (m),
+    lon_ctr, lat_ctr (rho-point centre of the cell).
+
+--nodes
+    Every rho-point emitted as a point feature.  Attributes: eta, xi, mask,
+    depth.
+
+The --water-only flag (applicable to --elements and --nodes) restricts output
+to features where mask_rho == 1, which substantially reduces file size for
+grids with large land areas.
+
+Dependencies
+------------
+geopandas, netCDF4, numpy, shapely >= 2.0
+
+Examples
+--------
+  # Grid perimeter boundary polygon
+  python romsgrid_to_shapefile.py grid.nc boundary.shp
+
+  # All water-cell elements as polygons (~400 MB for a 1.7M-cell grid)
+  python romsgrid_to_shapefile.py grid.nc elements.shp --elements --water-only
+
+  # All cells including land
+  python romsgrid_to_shapefile.py grid.nc elements.shp --elements
+
+  # Water rho-point nodes as points
+  python romsgrid_to_shapefile.py grid.nc nodes.shp --nodes --water-only
+"""
+
+import argparse
+import time
+
+import geopandas as gpd
+import netCDF4 as nc
+import numpy as np
+from shapely import polygons as shapely_polygons
+from shapely.geometry import Polygon
 
 
+def _read_grid(nc_file):
+    """Read and return key arrays from a ROMS grid NetCDF file."""
+    ds = nc.Dataset(nc_file, 'r')
+    data = {
+        'lon_rho': np.ma.filled(ds.variables['lon_rho'][:], np.nan),
+        'lat_rho': np.ma.filled(ds.variables['lat_rho'][:], np.nan),
+        'lon_psi': np.ma.filled(ds.variables['lon_psi'][:], np.nan),
+        'lat_psi': np.ma.filled(ds.variables['lat_psi'][:], np.nan),
+        'mask_rho': np.ma.filled(ds.variables['mask_rho'][:], 0),
+        'h': np.ma.filled(ds.variables['h'][:], np.nan),
+    }
+    ds.close()
+    return data
 
 
+def write_boundary(grid, shp_file):
+    """Write a single polygon tracing the grid perimeter (all 4 edges)."""
+    lon = grid['lon_rho']
+    lat = grid['lat_rho']
+
+    # Trace the outer perimeter of the rho grid:
+    #   bottom row (left->right), right column (bottom->top),
+    #   top row (right->left), left column (top->bottom)
+    bottom = list(zip(lon[0, :], lat[0, :]))
+    right = list(zip(lon[1:, -1], lat[1:, -1]))
+    top = list(zip(lon[-1, -2::-1], lat[-1, -2::-1]))
+    left = list(zip(lon[-2:0:-1, 0], lat[-2:0:-1, 0]))
+
+    coords = bottom + right + top + left
+    coords.append(coords[0])
+
+    poly = Polygon(coords)
+    gdf = gpd.GeoDataFrame({'ID': [1]}, geometry=[poly], crs='EPSG:4326')
+    gdf.to_file(shp_file)
+    print(f'Boundary shapefile: {shp_file}  (1 polygon, {len(coords)} vertices)')
 
 
+def write_elements(grid, shp_file, water_only=True):
+    """Write each interior grid cell as a polygon using psi-point corners.
+
+    In the ROMS Arakawa-C grid, rho-points are cell centres and psi-points
+    are cell vertices.  Interior rho cell (e, x) — for e in [1, neta_psi]
+    and x in [1, nxi_psi] — has corners at:
+
+        psi[e-1, x-1]  psi[e-1, x]
+        psi[e,   x-1]  psi[e,   x]
+    """
+    lon_psi = grid['lon_psi']
+    lat_psi = grid['lat_psi']
+    mask = grid['mask_rho']
+    h = grid['h']
+    lon_rho = grid['lon_rho']
+    lat_rho = grid['lat_rho']
+
+    neta_psi, nxi_psi = lon_psi.shape
+
+    # Interior rho indices that have full psi corner coverage:
+    # psi[e-1,x-1] .. psi[e,x] must all be valid psi indices
+    e_range = np.arange(1, neta_psi)  # 1 .. neta_psi-1
+    x_range = np.arange(1, nxi_psi)   # 1 .. nxi_psi-1
+
+    # Build (e, x) index arrays for all interior cells
+    ee, xx = np.meshgrid(e_range, x_range, indexing='ij')
+    ee_flat = ee.ravel()
+    xx_flat = xx.ravel()
+
+    if water_only:
+        keep = mask[ee_flat, xx_flat] == 1
+        ee_flat = ee_flat[keep]
+        xx_flat = xx_flat[keep]
+
+    n = len(ee_flat)
+    print(f'Building {n:,} element polygons...')
+    t0 = time.time()
+
+    # Vectorised corner coordinates — shape (n, 5, 2) for closed quads
+    coords = np.empty((n, 5, 2), dtype=np.float64)
+    # Corner 0: psi[e-1, x-1]
+    coords[:, 0, 0] = lon_psi[ee_flat - 1, xx_flat - 1]
+    coords[:, 0, 1] = lat_psi[ee_flat - 1, xx_flat - 1]
+    # Corner 1: psi[e-1, x]
+    coords[:, 1, 0] = lon_psi[ee_flat - 1, xx_flat]
+    coords[:, 1, 1] = lat_psi[ee_flat - 1, xx_flat]
+    # Corner 2: psi[e, x]
+    coords[:, 2, 0] = lon_psi[ee_flat, xx_flat]
+    coords[:, 2, 1] = lat_psi[ee_flat, xx_flat]
+    # Corner 3: psi[e, x-1]
+    coords[:, 3, 0] = lon_psi[ee_flat, xx_flat - 1]
+    coords[:, 3, 1] = lat_psi[ee_flat, xx_flat - 1]
+    # Close the polygon
+    coords[:, 4, :] = coords[:, 0, :]
+
+    # Shapely 2.x vectorised polygon creation
+    geom = shapely_polygons(coords)
+
+    gdf = gpd.GeoDataFrame(
+        {
+            'eta': ee_flat.astype(np.int32),
+            'xi': xx_flat.astype(np.int32),
+            'mask': mask[ee_flat, xx_flat].astype(np.int8),
+            'depth': h[ee_flat, xx_flat].astype(np.float32),
+            'lon_ctr': lon_rho[ee_flat, xx_flat].astype(np.float32),
+            'lat_ctr': lat_rho[ee_flat, xx_flat].astype(np.float32),
+        },
+        geometry=geom,
+        crs='EPSG:4326',
+    )
+
+    print(f'  Polygons built in {time.time() - t0:.1f}s — writing shapefile...')
+    t1 = time.time()
+    gdf.to_file(shp_file)
+    print(
+        f'Elements shapefile: {shp_file}  '
+        f'({n:,} polygons, {time.time() - t1:.1f}s write)'
+    )
 
 
+def write_nodes(grid, shp_file, water_only=True):
+    """Write each rho-point as a point feature."""
+    lon = grid['lon_rho']
+    lat = grid['lat_rho']
+    mask = grid['mask_rho']
+    h = grid['h']
+
+    neta, nxi = lon.shape
+    ee, xx = np.meshgrid(np.arange(neta), np.arange(nxi), indexing='ij')
+    ee_flat = ee.ravel()
+    xx_flat = xx.ravel()
+
+    if water_only:
+        keep = mask[ee_flat, xx_flat] == 1
+        ee_flat = ee_flat[keep]
+        xx_flat = xx_flat[keep]
+
+    n = len(ee_flat)
+    print(f'Building {n:,} node points...')
+    t0 = time.time()
+
+    lons = lon[ee_flat, xx_flat]
+    lats = lat[ee_flat, xx_flat]
+
+    from shapely import points as shapely_points
+
+    geom = shapely_points(np.column_stack([lons, lats]))
+
+    gdf = gpd.GeoDataFrame(
+        {
+            'eta': ee_flat.astype(np.int32),
+            'xi': xx_flat.astype(np.int32),
+            'mask': mask[ee_flat, xx_flat].astype(np.int8),
+            'depth': h[ee_flat, xx_flat].astype(np.float32),
+        },
+        geometry=geom,
+        crs='EPSG:4326',
+    )
+
+    print(f'  Points built in {time.time() - t0:.1f}s — writing shapefile...')
+    t1 = time.time()
+    gdf.to_file(shp_file)
+    print(
+        f'Nodes shapefile: {shp_file}  '
+        f'({n:,} points, {time.time() - t1:.1f}s write)'
+    )
 
 
+def main():
+    parser = argparse.ArgumentParser(
+        description='Convert a ROMS grid NetCDF file to ESRI Shapefile.',
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument('nc_file', help='Input ROMS grid NetCDF file')
+    parser.add_argument('shp_file', help='Output shapefile path (.shp)')
+
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument(
+        '--elements',
+        action='store_true',
+        help='Write each grid cell as a polygon (default: boundary only)',
+    )
+    mode.add_argument(
+        '--nodes',
+        action='store_true',
+        help='Write each rho-point as a point feature',
+    )
+
+    parser.add_argument(
+        '--water-only',
+        action='store_true',
+        default=False,
+        help='Only include water cells (mask_rho=1) for --elements/--nodes',
+    )
+
+    args = parser.parse_args()
+    grid = _read_grid(args.nc_file)
+
+    if args.elements:
+        write_elements(grid, args.shp_file, water_only=args.water_only)
+    elif args.nodes:
+        write_nodes(grid, args.shp_file, water_only=args.water_only)
+    else:
+        write_boundary(grid, args.shp_file)
 
 
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
### Description of Changes

Rewrites `bin/utils/romsgrid_to_shapefile.py` to support three output modes and adds a companion cartopy plotting script (`bin/utils/plot_romsgrid.py`). These are standalone utility scripts with no impact on the 1D/2D skill assessment pipelines or operational deployment.

**`romsgrid_to_shapefile.py`** changes:
- **boundary** (default): Traces the actual grid perimeter instead of computing a convex hull, which was losing concave coastline detail
- **`--elements`**: Emits each interior grid cell as a quadrilateral polygon using psi-point corners for correct ROMS Arakawa-C cell geometry. Attributes: `eta`, `xi`, `mask`, `depth`, `lon_ctr`, `lat_ctr`
- **`--nodes`**: Emits each rho-point as a point feature. Attributes: `eta`, `xi`, `mask`, `depth`
- **`--water-only`**: Filters output to `mask_rho == 1` (elements/nodes modes)
- Uses vectorized shapely 2.x polygon creation + geopandas for efficient I/O (~19s for 1.7M ECCOFS water elements)
- Adds argparse CLI (previously had hardcoded paths)

**`plot_romsgrid.py`** (new):
- Renders depth-colored grid cells from a ROMS NetCDF file with cartopy coastlines
- `--extent LON0 LON1 LAT0 LAT1` for zooming to any region
- `--show-edges` for cell edge visibility at regional scales
- `--all-cells` to include land cells
- `--dpi` and `--figsize` for output control

### Expected Outcome of Changes

No impact on the skill assessment pipelines, web application, or output files. These are offline utility scripts for grid inspection and visualization.

### Developer Questions and Checklist

**Is this a high priority PR? If yes, why and is there a date by which it needs to be merged?** No, low priority — utility scripts only.

**Are there any changes needed to how the code should be run for operational runs? (Commands, flags, job timings, etc.)** No

**Does this update need to be deployed for operational runs?** No

**Does this update require front end/web app changes? (If yes, provide documentation to Min)** No

**Does this impact code development work on adding SCHISM?** No

**Does this impact code development work on adding ADCIRC?** No

**Does this impact the expected number of output files for integration tests (i.e., will the integration test fail even though code changes result in desired change in outputs?)** No

- [x] Developer's name is removed throughout the code
- [x] Did you add relevant labels to the PR?
- [x] Have you run pylint and is the code at an acceptable pylint score (>8)?
- [x] Jobs contain the appropriate file checking and handle errors for any missing data?
- [x] Is log free of critical ERRORs or WARNINGs?

### Testing Instructions

Both scripts take a ROMS grid NetCDF file as input. Test with the ECCOFS grid file (`grid_eccofs_3km_09_b7_w2.nc`) or any ROMS grid containing `lon_rho`, `lat_rho`, `lon_psi`, `lat_psi`, `mask_rho`, and `h` variables.

**Shapefile converter:**
```bash
# Boundary polygon (default)
python bin/utils/romsgrid_to_shapefile.py grid.nc boundary.shp

# Water-cell elements as polygons
python bin/utils/romsgrid_to_shapefile.py grid.nc elements.shp --elements --water-only

# Rho-point nodes as points
python bin/utils/romsgrid_to_shapefile.py grid.nc nodes.shp --nodes --water-only
```

**Grid plotter:**
```bash
# Full domain overview
python bin/utils/plot_romsgrid.py grid.nc overview.png

# Zoomed view with cell edges visible
python bin/utils/plot_romsgrid.py grid.nc zoom.png --extent -76.5 -75.8 36.7 37.3 --show-edges
```

Expected outputs:
- `.shp`/`.shx`/`.dbf`/`.cpg`/`.prj` files with correct WGS 84 CRS
- Elements shapefile: ~1.7M polygon features for ECCOFS water cells (~400 MB)
- PNG plot files with depth-colored grid cells and cartopy coastlines

### Reminder checklist for PR reviewer

- [ ] Run PEP8 compliance tests to ensure the code follows best practices
- [ ] Check that documentation in the script is sufficient
- [ ] Validate the output values (if applicable) to make sure the calculations are correct and make scientific/physical sense; include a comment on the pull request including what validation you performed, for replicability.
- [ ] Test code both on Windows and Linux (and MacOS, if available), using several OFS as test cases
- [ ] When approving or commenting on a pull request, add information on the calls you use in case they need to be replicated or referenced.