### PR TITLE
Currents-bins CSV override (issue #87, Phase 3)

### DIFF
--- a/bin/obs_retrieval/get_station_observations_cli.py
+++ b/bin/obs_retrieval/get_station_observations_cli.py
@@ -148,6 +148,14 @@ if __name__ == '__main__':
         help='Which variables do you want to skill assess? Options are: '
             'water_level, water_temperature, salinity, and currents. Choose '
             'any combination. Default (no argument) is all variables.')
+    parser.add_argument(
+        '-cb',
+        '--Currents_Bins_Csv',
+        required=False,
+        help='Optional path to a CSV that pins which CO-OPS ADCP bins are '
+             'processed and/or overrides their depth/orientation. Columns: '
+             'station_id,bin,depth,orientation,name. See '
+             'issue_87_currents_bins_workflow.md.')
 
     args = parser.parse_args()
 
@@ -157,6 +165,7 @@ if __name__ == '__main__':
     prop1.start_date_full = args.StartDate_full
     prop1.end_date_full = args.EndDate_full
     prop1.datum = args.Datum.upper()
+    prop1.currents_bins_csv = args.Currents_Bins_Csv
 
     # Make all station owners default, unless user specifies station owners
     if args.Station_Owner is None:

--- a/bin/visualization/create_1dplot.py
+++ b/bin/visualization/create_1dplot.py
@@ -952,6 +952,15 @@ if __name__ == '__main__':
         help='Which variables do you want to skill assess? Options are: '
             'water_level, water_temperature, salinity, and currents. Choose '
             'any combination. Default (no argument) is all variables.')
+    parser.add_argument(
+        '-cb',
+        '--Currents_Bins_Csv',
+        required=False,
+        default=None,
+        help='Optional path to a CSV that pins which CO-OPS ADCP bins are '
+             'processed and/or overrides their depth/orientation/name. '
+             'Columns: station_id,bin,depth,orientation,name. See '
+             'issue_87_currents_bins_workflow.md.')
 
     args = parser.parse_args()
 
@@ -972,6 +981,7 @@ if __name__ == '__main__':
     prop1.horizonskill = args.Horizon_Skill
     prop1.forecast_hr = args.Forecast_Hr
     prop1.var_list = args.Var_Selection
+    prop1.currents_bins_csv = args.Currents_Bins_Csv
     # This can only be changed if directly running get_node_ofs.py!
     prop1.user_input_location = False
 

--- a/conf/currents_bins_example.csv
+++ b/conf/currents_bins_example.csv
@@ -1,0 +1,19 @@
+station_id,bin,depth,orientation,name
+# Example currents-bins override CSV for issue #87.
+# See issue_87_currents_bins_workflow.md for the full schema + usage.
+#
+# Lines starting with `#` are NOT valid CSV; remove them before use.
+# Only the `station_id` and `bin` columns are required; everything
+# else is optional and, if present, overrides the MDAPI-derived value.
+#
+# Example: process only 3 bins at cb1001, with a hand-picked depth for
+# the middle bin (model bathymetry is known to mis-resolve the LNG
+# berth here — see workflow doc).
+cb1001,1,3.5,up,
+cb1001,15,9.0,up,mid-column
+cb1001,30,13.5,up,near-surface
+#
+# Example: process only bin 10 at cb1301 (23 bins available, pin to
+# one representative slice for a side-looking ADCP whose bins all
+# share a depth).
+cb1301,10,,,near-bottom

--- a/issue_87_currents_bins_workflow.md
+++ b/issue_87_currents_bins_workflow.md
@@ -4,6 +4,16 @@ End-to-end workflow for retrieving every ADCP bin's observation data and
 resolving an accurate vertical depth for each, including side-looking
 (PICS) ADCPs. Covers the implementation landed under issue #87.
 
+## Contents
+
+1. [Data sources (CO-OPS APIs)](#data-sources-co-ops-apis)
+2. [Depth-resolution decision tree](#depth-resolution-decision-tree)
+3. [Stage-by-stage pipeline](#stage-by-stage-pipeline)
+4. [Worked examples (2026-03-27 nowcast run)](#worked-examples-2026-03-27-nowcast-run)
+5. [User override: currents-bins CSV](#user-override-currents-bins-csv)
+6. [File inventory (issue #87 implementation)](#file-inventory-issue-87-implementation)
+7. [Operational notes](#operational-notes)
+
 ---
 
 ## Data sources (CO-OPS APIs)
@@ -183,6 +193,129 @@ prefix and shows only `Obs depth — Model depth`.
 
 ---
 
+## User override: currents-bins CSV
+
+The default pipeline retrieves every bin reported by the MDAPI bins
+endpoint for each CO-OPS ADCP station. For a 48-bin station (e.g.
+`cb1401`) that's 96 plots (timeseries + rose) per OFS per run. Often
+you only want a representative subset, or you need to correct a depth
+the model can't resolve (e.g. `cb1001` where `height_from_bottom`
+exceeds the model bathymetry at the nearest node).
+
+The `--Currents_Bins_Csv` / `-cb` CLI flag takes a path to a user CSV
+that does two things at once:
+
+1. **Filter** — only bins listed in the CSV for a given parent station
+   are processed; all other bins are dropped.
+2. **Override** — any non-empty `depth` / `orientation` / `name` cell
+   replaces the MDAPI-derived value for that bin.
+
+Stations **not** listed in the CSV keep their default "emit all bins"
+behaviour.
+
+### CSV schema
+
+Header row is required. Column order is flexible; extra columns are
+ignored. Blank lines and `#` comment lines are skipped.
+
+| Column        | Required | Description                                                                                 |
+|---------------|----------|---------------------------------------------------------------------------------------------|
+| `station_id`  | yes      | Parent CO-OPS station ID (e.g. `cb1001`), **not** the `{parent}_b{NN}` virtual ID.          |
+| `bin`         | yes      | Integer bin number as reported by the MDAPI bins endpoint.                                  |
+| `depth`       | no       | Obs depth in metres (positive, below surface). Overrides MDAPI `depth` **and** bypasses the side-looking `water_depth - height_from_bottom` resolver. |
+| `orientation` | no       | Free-text label (`up`, `down`, `side`, …). Purely advisory — shown in the plot title.       |
+| `name`        | no       | Free-text tag appended to the plot's station display label (e.g. `mid-column`).             |
+
+A malformed row is logged as a WARNING and skipped; the rest of the
+file continues. Rows for the same `(station_id, bin)` replace each
+other — **last one wins**.
+
+### Example
+
+`conf/currents_bins_example.csv` in this repo:
+
+```csv
+station_id,bin,depth,orientation,name
+# Keep 3 bins at Cove Point, with a hand-picked depth for the middle
+# one (model bathymetry mis-resolves the LNG berth here).
+cb1001,1,3.5,up,
+cb1001,15,9.0,up,mid-column
+cb1001,30,13.5,up,near-surface
+
+# Keep 1 representative bin at Chesapeake City (all 23 bins are at
+# roughly the same depth anyway — it's side-looking).
+cb1301,10,,,near-bottom
+```
+
+### Usage
+
+```bash
+# Works on both the obs-retrieval CLI...
+python bin/obs_retrieval/get_station_observations_cli.py \
+    -o cbofs -p ./ -s '2026-03-27T00:00:00Z' -e '2026-03-28T00:00:00Z' \
+    -d MLLW -so co-ops -vs currents \
+    -cb conf/currents_bins_example.csv
+
+# ...and the full 1D pipeline:
+python bin/visualization/create_1dplot.py \
+    -o cbofs -p ./ -s '2026-03-27T00:00:00Z' -e '2026-03-28T00:00:00Z' \
+    -d MLLW -ws nowcast -t stations -vs currents -so co-ops \
+    -cb conf/currents_bins_example.csv
+```
+
+### What changes in the output
+
+Given the CSV above, `cbofs_cu_station.ctl` now contains exactly **4
+entries** instead of 129:
+
+```
+cb1001_b01 cb1001_b01_cu_cbofs_CO-OPS "Cove Point LNG Pier (SL-ADP) (bin 01)"
+  38.403 -76.384 0.0  3.50  0.0  0.00
+cb1001_b15 cb1001_b15_cu_cbofs_CO-OPS "Cove Point LNG Pier (SL-ADP) (bin 15 / mid-column)"
+  38.403 -76.384 0.0  9.00  0.0  0.00
+cb1001_b30 cb1001_b30_cu_cbofs_CO-OPS "Cove Point LNG Pier (SL-ADP) (bin 30 / near-surface)"
+  38.403 -76.384 0.0  13.50  0.0  0.00
+cb1301_b10 cb1301_b10_cu_cbofs_CO-OPS "Chesapeake City (bin 10 / near-bottom)"
+  39.531 -75.828 0.0  0.00  0.0  0.18
+```
+
+Notes on what the depth column reflects:
+
+- `cb1001_b01` → `3.50` (user-supplied; `hfb` column reset to `0.00`
+  because an explicit depth bypasses the side-looking resolver).
+- `cb1001_b15` → `9.00` (user-supplied, same handling).
+- `cb1301_b10` → `0.00` with `hfb = 0.18` — no depth was supplied in
+  the CSV, so the normal side-looking resolver runs at model-CTL time
+  and back-patches the depth to `water_depth - 0.18 m`.
+
+### Behaviour matrix
+
+| CSV row for this bin   | Depth source               | Side-looking resolver (`hfb`) |
+|------------------------|----------------------------|-------------------------------|
+| absent                 | MDAPI `bin.depth` if present; else `_resolve_side_looking_depths(model_h - hfb)` at model-CTL time | runs |
+| present, `depth` empty | same as default (MDAPI / resolver) | runs |
+| present, `depth` set   | **user value** (4th column of `station.ctl` verbatim) | skipped (`hfb` written as `0.00` so the resolver early-exits) |
+
+Plots inherit the new annotation automatically — the title reads
+`Bin NN / mid-column — Obs depth -X.X m — Model depth -Y.Y m` for
+rows with a `name` override, or the standard `Bin NN — …` line for
+rows without.
+
+### Caveats
+
+- The CSV is **not** evaluated against the obs inventory before
+  retrieval runs. If you name a bin the datagetter doesn't return
+  (e.g. because the ADCP was offline during the window), a WARNING is
+  logged and that row is skipped — no CTL entry is emitted.
+- The filter only applies to CO-OPS ADCP (virtual-ID) stations.
+  NDBC / USGS / CHS currents stations ignore the CSV.
+- A user-supplied `depth` short-circuits the side-looking resolver. If
+  your goal is to *correct* only specific bins while letting the
+  resolver handle the rest of a station, leave the `depth` column
+  empty on those rows and only fill it on the bins you want to pin.
+
+---
+
 ## File inventory (issue #87 implementation)
 
 ```
@@ -191,14 +324,19 @@ src/ofs_skill/obs_retrieval/retrieve_t_and_c_station.py
     _retrieve_currents_all_bins, _fetch_currents_chunked, _get_with_retry
 
 src/ofs_skill/obs_retrieval/write_obs_ctlfile.py
-    _process_coops_station (6-field coord line with hfb)
+    _process_coops_station (6-field coord line with hfb, bin_overrides)
     _process_usgs_station / _process_ndbc_station / _process_chs_station
         (6-field coord line for cu; hfb = 0.00 placeholder)
     _COOPS_CURRENTS_MAX_WORKERS = 2
+    write_obs_ctlfile(..., currents_bins_csv=None)
+
+src/ofs_skill/obs_retrieval/currents_bins_override.py
+    BinSpec, load_currents_bins_csv, bin_spec_lookup
 
 src/ofs_skill/obs_retrieval/get_station_observations.py
     _split_virtual_currents_id (parses {parent}_b{NN})
     obs_coops_workers capped at 2 when variable == 'currents'
+    forwards prop.currents_bins_csv into write_obs_ctlfile
 
 src/ofs_skill/model_processing/write_ofs_ctlfile.py
     _model_bathymetry_at_node, _resolve_side_looking_depths
@@ -210,7 +348,15 @@ src/ofs_skill/visualization/plotting_functions.py
     _build_depth_line, _lookup_obs_depth,
     _load_obs_station_depths, _load_model_station_depths
 
-tests/coops_currents_bins_test.py        # 10 tests, all passing
+bin/obs_retrieval/get_station_observations_cli.py
+bin/visualization/create_1dplot.py
+    new `-cb / --Currents_Bins_Csv` CLI flag → prop.currents_bins_csv
+
+conf/currents_bins_example.csv
+    reference CSV with commented examples
+
+tests/coops_currents_bins_test.py         # 10 tests, all passing
+tests/currents_bins_override_test.py      # 9 tests, all passing
 ```
 
 ---

--- a/src/ofs_skill/obs_retrieval/currents_bins_override.py
+++ b/src/ofs_skill/obs_retrieval/currents_bins_override.py
@@ -1,0 +1,159 @@
+"""
+Parser for the optional currents-bins override CSV.
+
+Lets a user pin which ADCP bins are processed and override any of
+``depth``, ``orientation``, or display ``name`` on a per-bin basis.
+See ``issue_87_currents_bins_workflow.md`` for end-user docs.
+
+CSV schema (header row required, column order flexible):
+
+    station_id,bin,depth,orientation,name
+
+* ``station_id`` and ``bin`` are required. ``station_id`` matches the
+  parent CO-OPS station ID (not the ``{parent}_b{NN}`` virtual ID).
+* ``depth``, ``orientation``, ``name`` are all optional. Empty cells are
+  treated as "do not override".
+* Rows for the same ``station_id`` with the same ``bin`` replace each
+  other — later wins.
+
+Behaviour at CTL-write time (see ``write_obs_ctlfile._process_coops_station``):
+
+* If a parent station has **any** rows in the CSV, **only** those bins
+  are emitted (filter mode).
+* For each surviving bin, any non-empty CSV field overrides the
+  MDAPI-derived value (depth/orientation) or appends to the display
+  name.
+* If the CSV names a bin that the datagetter did not return, a WARNING
+  is logged and the row is skipped.
+* Parent stations absent from the CSV keep the default "emit all bins"
+  behaviour.
+"""
+
+from __future__ import annotations
+
+import csv
+from dataclasses import dataclass
+from logging import Logger
+from pathlib import Path
+from typing import Optional
+
+
+@dataclass
+class BinSpec:
+    """Per-bin override spec from the user CSV."""
+    bin: int
+    depth: Optional[float] = None
+    orientation: Optional[str] = None
+    name: Optional[str] = None
+
+
+def _clean(value: Optional[str]) -> Optional[str]:
+    if value is None:
+        return None
+    s = str(value).strip()
+    return s if s else None
+
+
+def load_currents_bins_csv(
+    path: Optional[str], logger: Logger,
+) -> dict[str, list[BinSpec]]:
+    """Load the currents-bins override CSV into ``{station_id: [BinSpec]}``.
+
+    Returns an empty dict when ``path`` is falsy or the file is missing
+    — the caller treats that as "no overrides, use default behaviour".
+    Malformed rows are skipped with a WARNING; the entire file is never
+    a hard failure.
+    """
+    if not path:
+        return {}
+    csv_path = Path(path)
+    if not csv_path.is_file():
+        logger.warning(
+            'Currents bins override CSV not found at %s — proceeding '
+            'with default per-bin behaviour.', path)
+        return {}
+
+    result: dict[str, list[BinSpec]] = {}
+    with open(csv_path, encoding='utf-8', newline='') as fh:
+        # Skip blank lines + lines whose first non-whitespace char is ``#``
+        # so the example CSV can carry inline comments.
+        filtered = (
+            line for line in fh
+            if line.strip() and not line.lstrip().startswith('#')
+        )
+        reader = csv.DictReader(filtered)
+        if reader.fieldnames is None:
+            logger.warning(
+                'Currents bins override CSV %s has no header row; '
+                'expected station_id,bin[,depth,orientation,name].', path)
+            return {}
+        required = {'station_id', 'bin'}
+        missing = required - {c.strip() for c in reader.fieldnames if c}
+        if missing:
+            logger.error(
+                'Currents bins override CSV %s is missing required '
+                'column(s): %s', path, sorted(missing))
+            return {}
+
+        row_no = 1  # header is row 1
+        for raw in reader:
+            row_no += 1
+            station_id = _clean(raw.get('station_id'))
+            bin_raw = _clean(raw.get('bin'))
+            if not station_id or not bin_raw:
+                logger.warning(
+                    'Currents bins CSV row %d missing station_id/bin; '
+                    'skipping.', row_no)
+                continue
+            try:
+                bin_num = int(bin_raw)
+            except ValueError:
+                logger.warning(
+                    'Currents bins CSV row %d: bin=%r is not an integer; '
+                    'skipping.', row_no, bin_raw)
+                continue
+
+            depth_raw = _clean(raw.get('depth'))
+            depth: Optional[float] = None
+            if depth_raw is not None:
+                try:
+                    depth = float(depth_raw)
+                except ValueError:
+                    logger.warning(
+                        'Currents bins CSV row %d: depth=%r is not a '
+                        'number; ignoring depth override for station=%s '
+                        'bin=%d.', row_no, depth_raw, station_id, bin_num)
+                    depth = None
+
+            spec = BinSpec(
+                bin=bin_num,
+                depth=depth,
+                orientation=_clean(raw.get('orientation')),
+                name=_clean(raw.get('name')),
+            )
+
+            bucket = result.setdefault(station_id, [])
+            # Replace any prior spec with the same bin number.
+            bucket[:] = [b for b in bucket if b.bin != bin_num]
+            bucket.append(spec)
+
+    if result:
+        total = sum(len(b) for b in result.values())
+        logger.info(
+            'Loaded currents-bins overrides from %s: %d station(s), '
+            '%d bin row(s) total.', path, len(result), total)
+    return result
+
+
+def bin_spec_lookup(
+    overrides: dict[str, list[BinSpec]], station_id: str,
+) -> Optional[dict[int, BinSpec]]:
+    """Convenience: ``{bin_num: BinSpec}`` for a parent station, or None.
+
+    ``None`` signals "no CSV entries for this station — keep default
+    per-bin behaviour." An empty dict would be ambiguous, hence the
+    explicit None.
+    """
+    if station_id not in overrides:
+        return None
+    return {s.bin: s for s in overrides[station_id]}

--- a/src/ofs_skill/obs_retrieval/get_station_observations.py
+++ b/src/ofs_skill/obs_retrieval/get_station_observations.py
@@ -682,7 +682,9 @@ def _process_variable_obs(
             )
             write_obs_ctlfile(
                 start_date, end_date, datum, path, ofs,
-                stationowner, var_list, logger
+                stationowner, var_list, logger,
+                currents_bins_csv=getattr(
+                    prop, 'currents_bins_csv', None),
             )
             read_station_ctl_file = (
                 station_ctl_file_extract(

--- a/src/ofs_skill/obs_retrieval/retrieve_t_and_c_station.py
+++ b/src/ofs_skill/obs_retrieval/retrieve_t_and_c_station.py
@@ -122,7 +122,8 @@ def _get_station_info(
 
 def retrieve_t_and_c_station(
     retrieve_input: object,
-    logger: Logger
+    logger: Logger,
+    only_bins: Optional[set[int]] = None,
 ) -> Optional[Union[pd.DataFrame, dict[int, pd.DataFrame]]]:
     """
     Retrieve time series observations from NOAA Tides and Currents station.
@@ -179,6 +180,7 @@ def retrieve_t_and_c_station(
             api_url=t_c.api_url,
             mdapi_url=t_c.mdapi_url,
             logger=logger,
+            only_bins=only_bins,
         )
 
     t_c.start_dt = datetime.strptime(retrieve_input.start_date, '%Y%m%d')
@@ -397,6 +399,7 @@ def _retrieve_currents_all_bins(
     api_url: str,
     mdapi_url: str,
     logger: Logger,
+    only_bins: Optional[set[int]] = None,
 ) -> Optional[dict[int, pd.DataFrame]]:
     """Retrieve CO-OPS currents data for every bin of an ADCP station.
 
@@ -407,6 +410,11 @@ def _retrieve_currents_all_bins(
          ``&bin=N`` to pull that bin's full time series.
       3. Assemble a DataFrame per bin (DateTime, DEP01, DIR, OBS), with
          ``df.attrs['bin'/'depth'/'orientation']`` stamped on.
+
+    When ``only_bins`` is provided, the bin iteration is restricted to
+    that set — which short-circuits the CO-OPS HTTP traffic when a
+    user has supplied a currents-bins override CSV listing only a
+    handful of bins per station.
 
     Returns ``dict[int, DataFrame]`` keyed by bin number, or ``None`` if
     no bin yielded any in-window data.
@@ -461,6 +469,12 @@ def _retrieve_currents_all_bins(
         try:
             bin_num = int(entry.get('num', entry.get('bin')))
         except (KeyError, TypeError, ValueError):
+            continue
+
+        # Restrict to CSV-requested bins when provided. Skips both the
+        # datagetter HTTP call and any downstream processing for bins
+        # the user did not pin.
+        if only_bins is not None and bin_num not in only_bins:
             continue
 
         depth = _bin_depth_from_record(entry)

--- a/src/ofs_skill/obs_retrieval/write_obs_ctlfile.py
+++ b/src/ofs_skill/obs_retrieval/write_obs_ctlfile.py
@@ -34,6 +34,11 @@ import pandas as pd
 from coastalmodeling_vdatum import vdatum
 
 from ofs_skill.obs_retrieval import retrieve_properties, utils
+from ofs_skill.obs_retrieval.currents_bins_override import (
+    BinSpec,
+    bin_spec_lookup,
+    load_currents_bins_csv,
+)
 from ofs_skill.obs_retrieval.ofs_inventory_stations import ofs_inventory_stations
 from ofs_skill.obs_retrieval.retrieve_chs_station import retrieve_chs_station
 from ofs_skill.obs_retrieval.retrieve_ndbc_station import retrieve_ndbc_station
@@ -55,13 +60,22 @@ _USGS_MAX_WORKERS_NO_KEY = 2
 
 def _process_coops_station(id_number, name, x_value, y_value,
                            start_date, end_date, variable, name_var,
-                           datum, datum_list, ofs, logger):
+                           datum, datum_list, ofs, logger,
+                           bin_overrides=None):
     """Process a single CO-OPS station.
 
     Returns a list of CTL entry strings. For most variables the list
     contains at most one entry; for ``currents`` (ADCPs) one entry is
     emitted per bin using the virtual-ID format ``{parent}_b{NN}``.
     An empty list is returned on failure.
+
+    ``bin_overrides`` is an optional ``dict[int, BinSpec]`` keyed by
+    bin number for this parent station. When provided (currents only),
+    the function filters the retrieved bins to only those listed and
+    applies any per-row overrides (depth / orientation / name). The
+    bin set is also pushed into ``retrieve_t_and_c_station`` via
+    ``only_bins`` so the CO-OPS datagetter is called only for pinned
+    bins.
     """
     try:
         retrieve_input = retrieve_properties.RetrieveProperties()
@@ -70,9 +84,13 @@ def _process_coops_station(id_number, name, x_value, y_value,
         retrieve_input.end_date = end_date
         retrieve_input.variable = variable
         retrieve_input.datum = datum
-        timeseries = \
-            retrieve_t_and_c_station(
-                retrieve_input,logger)
+        only_bins = (
+            set(bin_overrides.keys())
+            if (variable == 'currents' and bin_overrides)
+            else None
+        )
+        timeseries = retrieve_t_and_c_station(
+            retrieve_input, logger, only_bins=only_bins)
         if variable == 'water_level':
             if (isinstance(timeseries, pd.DataFrame)
                 is False):
@@ -226,8 +244,27 @@ def _process_coops_station(id_number, name, x_value, y_value,
             # carrying ``height_from_bottom`` so that the model-CTL
             # writer can later resolve an accurate obs depth from the
             # model bathymetry (depth = h - height_from_bottom).
+            #
+            # When ``bin_overrides`` is provided, only bins listed in
+            # the user CSV are emitted; any per-row depth/orientation/
+            # name values replace the MDAPI-derived ones. Bins the CSV
+            # names but the datagetter did not return are logged.
+            if bin_overrides is not None:
+                requested = set(bin_overrides.keys())
+                available = set(timeseries.keys())
+                missing = sorted(requested - available)
+                if missing:
+                    logger.warning(
+                        'Currents bins CSV lists bin(s) %s for station '
+                        '%s but the CO-OPS datagetter did not return '
+                        'them; skipping those rows.', missing,
+                        str(id_number))
+                selected_bins = sorted(requested & available)
+            else:
+                selected_bins = sorted(timeseries.keys())
+
             entries = []
-            for bin_num in sorted(timeseries.keys()):
+            for bin_num in selected_bins:
                 bin_df = timeseries[bin_num]
                 depth = float(bin_df.attrs.get('depth', 0.0) or 0.0)
                 hfb_raw = bin_df.attrs.get('height_from_bottom')
@@ -235,18 +272,40 @@ def _process_coops_station(id_number, name, x_value, y_value,
                     hfb = float(hfb_raw) if hfb_raw is not None else 0.0
                 except (TypeError, ValueError):
                     hfb = 0.0
+                suffix = f'bin {int(bin_num):02d}'
+
+                # Apply CSV overrides for this bin.
+                override = (
+                    bin_overrides.get(bin_num)
+                    if bin_overrides is not None else None
+                )
+                if override is not None:
+                    if override.depth is not None:
+                        depth = float(override.depth)
+                        # User-specified depth supersedes the
+                        # height_from_bottom side-looking path.
+                        hfb = 0.0
+                    if override.name:
+                        suffix = f'bin {int(bin_num):02d} / {override.name}'
+
                 virt_id = f'{str(id_number)}_b{int(bin_num):02d}'
                 entries.append(
                     f'{virt_id} {virt_id}_'
                     f'{name_var}_{ofs}_CO-OPS '
-                    f'"{name} (bin {int(bin_num):02d})"\n  '
+                    f'"{name} ({suffix})"\n  '
                     f'{y_value:.3f} {x_value:.3f} 0.0  '
                     f'{depth:.2f}  0.0  {hfb:.2f}\n'
                 )
-            logger.info(
-                'CO-OPS currents data found for station %s: '
-                '%d bin(s) emitted.', str(id_number), len(entries)
-            )
+            if bin_overrides is not None:
+                logger.info(
+                    'CO-OPS currents data found for station %s: '
+                    '%d of %d CSV-requested bin(s) emitted.',
+                    str(id_number), len(entries), len(bin_overrides))
+            else:
+                logger.info(
+                    'CO-OPS currents data found for station %s: '
+                    '%d bin(s) emitted.', str(id_number), len(entries)
+                )
             return entries
     except Exception as ex:
         logger.info(
@@ -576,8 +635,14 @@ def _process_chs_station(id_number, name, x_value, y_value,
 
 def _process_variable(variable, inventory, var_to_col, start_date, end_date,
                       datum, datum_list, ofs, usgs_max_workers,
-                      control_files_path, logger):
-    """Process all stations for a single variable. Writes .ctl file."""
+                      control_files_path, logger,
+                      currents_bins_overrides=None):
+    """Process all stations for a single variable. Writes .ctl file.
+
+    ``currents_bins_overrides`` is a ``dict[str, list[BinSpec]]`` from
+    :func:`~ofs_skill.obs_retrieval.currents_bins_override.load_currents_bins_csv`.
+    Only consulted when ``variable == 'currents'``.
+    """
     var_name_map = {
         'water_level': 'wl',
         'water_temperature': 'temp',
@@ -611,11 +676,19 @@ def _process_variable(variable, inventory, var_to_col, start_date, end_date,
         futures = []
         with ThreadPoolExecutor(max_workers=coops_workers) as executor:
             for _, row in coops_stations.iterrows():
+                # Pull per-station override only for currents; the
+                # override map only contains CO-OPS ADCP parent IDs.
+                station_overrides = None
+                if (variable == 'currents'
+                        and currents_bins_overrides):
+                    station_overrides = bin_spec_lookup(
+                        currents_bins_overrides, str(row['ID']))
                 futures.append(executor.submit(
                     _process_coops_station,
                     row['ID'], row['Name'], row['X'], row['Y'],
                     start_date, end_date, variable, name_var,
-                    datum, datum_list, ofs, logger
+                    datum, datum_list, ofs, logger,
+                    station_overrides,
                 ))
             for future in futures:
                 result = future.result()
@@ -697,7 +770,7 @@ def _process_variable(variable, inventory, var_to_col, start_date, end_date,
 
 
 def write_obs_ctlfile(start_date , end_date , datum , path , ofs, stationowner,
-                      var_list, logger):
+                      var_list, logger, currents_bins_csv=None):
     """
     This function calls the Tid_numberes and Currents, NDBC, and USGS
     retrieval
@@ -705,13 +778,24 @@ def write_obs_ctlfile(start_date , end_date , datum , path , ofs, stationowner,
     ofs_inventory(ofs, start_date, end_date, path) and variables
     ['water_level', 'water_temperature', 'salinity', 'currents'].
     The output is a .ctl file for each variable with all stations that
-    have data
+    have data.
+
+    ``currents_bins_csv`` is an optional path to a user-supplied CSV
+    that pins which CO-OPS ADCP bins are processed and/or overrides
+    their depth/orientation/name. Schema + behaviour are documented in
+    ``issue_87_currents_bins_workflow.md``.
     """
 
     start_dt = datetime.strptime( start_date , '%Y%m%d' )
     end_dt = datetime.strptime( end_date , '%Y%m%d' )
 
     dir_params = utils.Utils().read_config_section( 'directories' , logger )
+
+    # Load the user currents-bins override CSV once (empty dict when no
+    # path given or file missing). Passed down to the currents branch
+    # of _process_coops_station.
+    currents_bins_overrides = load_currents_bins_csv(
+        currents_bins_csv, logger)
     datum_list = (utils.Utils().read_config_section('datums', logger)\
                        ['datum_list']).split(' ')
 
@@ -829,7 +913,8 @@ def write_obs_ctlfile(start_date , end_date , datum , path , ofs, stationowner,
                 _process_variable,
                 variable, inventory, var_to_col, start_date, end_date,
                 datum, datum_list, ofs, usgs_max_workers,
-                control_files_path, logger
+                control_files_path, logger,
+                currents_bins_overrides,
             ))
         # Wait for all variables to complete; re-raise any exceptions
         for future in futures:

--- a/tests/currents_bins_override_test.py
+++ b/tests/currents_bins_override_test.py
@@ -1,0 +1,243 @@
+"""
+Tests for the optional currents-bins override CSV (Phase 3 of issue #87).
+
+Covers:
+
+- ``load_currents_bins_csv`` parsing (valid + degraded rows, missing file,
+  header validation).
+- ``bin_spec_lookup`` mapping.
+- ``_process_coops_station`` currents branch: filter-only, depth override,
+  name override, and a bin listed in the CSV that the datagetter did
+  not return.
+"""
+
+from __future__ import annotations
+
+import logging
+from textwrap import dedent
+from unittest.mock import patch
+
+import pandas as pd
+import pytest
+
+
+@pytest.fixture
+def logger():
+    logging.basicConfig(level=logging.INFO)
+    return logging.getLogger('currents_bins_override_test')
+
+
+# ---------------------------------------------------------------------------
+# load_currents_bins_csv
+# ---------------------------------------------------------------------------
+
+def _write_csv(tmp_path, body: str):
+    p = tmp_path / 'overrides.csv'
+    p.write_text(dedent(body).lstrip())
+    return str(p)
+
+
+def test_load_csv_valid(tmp_path, logger):
+    from ofs_skill.obs_retrieval.currents_bins_override import (
+        load_currents_bins_csv,
+    )
+    path = _write_csv(tmp_path, '''
+        station_id,bin,depth,orientation,name
+        cb1001,5,6.0,up,
+        cb1001,15,9.0,,
+        cb1301,10,,,mid-channel
+    ''')
+    overrides = load_currents_bins_csv(path, logger)
+    assert set(overrides.keys()) == {'cb1001', 'cb1301'}
+    cb1001 = {s.bin: s for s in overrides['cb1001']}
+    assert cb1001[5].depth == 6.0
+    assert cb1001[5].orientation == 'up'
+    assert cb1001[15].depth == 9.0
+    assert cb1001[15].orientation is None
+    cb1301 = overrides['cb1301'][0]
+    assert cb1301.bin == 10
+    assert cb1301.depth is None
+    assert cb1301.name == 'mid-channel'
+
+
+def test_load_csv_missing_required_column(tmp_path, logger):
+    from ofs_skill.obs_retrieval.currents_bins_override import (
+        load_currents_bins_csv,
+    )
+    path = _write_csv(tmp_path, '''
+        station_id,depth
+        cb1001,6.0
+    ''')
+    assert load_currents_bins_csv(path, logger) == {}
+
+
+def test_load_csv_skips_malformed_rows(tmp_path, logger):
+    from ofs_skill.obs_retrieval.currents_bins_override import (
+        load_currents_bins_csv,
+    )
+    path = _write_csv(tmp_path, '''
+        station_id,bin,depth
+        ,5,6.0
+        cb1001,,6.0
+        cb1001,not_a_number,6.0
+        cb1001,5,not_a_number
+        cb1001,7,7.0
+    ''')
+    overrides = load_currents_bins_csv(path, logger)
+    # Row 6 bin=7 valid; row 5 (bin=5, bad depth) silently drops depth
+    # but keeps the bin spec.
+    assert set(overrides.keys()) == {'cb1001'}
+    by_bin = {s.bin: s for s in overrides['cb1001']}
+    assert 7 in by_bin and by_bin[7].depth == 7.0
+    assert 5 in by_bin and by_bin[5].depth is None
+
+
+def test_load_csv_missing_file(tmp_path, logger):
+    from ofs_skill.obs_retrieval.currents_bins_override import (
+        load_currents_bins_csv,
+    )
+    assert load_currents_bins_csv(str(tmp_path / 'nope.csv'), logger) == {}
+    assert load_currents_bins_csv(None, logger) == {}
+    assert load_currents_bins_csv('', logger) == {}
+
+
+def test_load_csv_duplicate_bin_last_wins(tmp_path, logger):
+    from ofs_skill.obs_retrieval.currents_bins_override import (
+        load_currents_bins_csv,
+    )
+    path = _write_csv(tmp_path, '''
+        station_id,bin,depth
+        cb1001,5,3.0
+        cb1001,5,9.9
+    ''')
+    overrides = load_currents_bins_csv(path, logger)
+    assert overrides['cb1001'] == [
+        overrides['cb1001'][0]  # single entry
+    ]
+    assert overrides['cb1001'][0].depth == 9.9
+
+
+def test_bin_spec_lookup(tmp_path, logger):
+    from ofs_skill.obs_retrieval.currents_bins_override import (
+        bin_spec_lookup, load_currents_bins_csv,
+    )
+    path = _write_csv(tmp_path, '''
+        station_id,bin,depth
+        cb1001,5,6.0
+        cb1001,15,9.0
+    ''')
+    overrides = load_currents_bins_csv(path, logger)
+    result = bin_spec_lookup(overrides, 'cb1001')
+    assert isinstance(result, dict)
+    assert set(result.keys()) == {5, 15}
+    # Missing station returns None (distinct from empty dict).
+    assert bin_spec_lookup(overrides, 'cb0402') is None
+
+
+# ---------------------------------------------------------------------------
+# _process_coops_station with bin_overrides
+# ---------------------------------------------------------------------------
+
+def _fake_bin_frames(bins):
+    """Build a dict[int, DataFrame] that mimics retrieve_t_and_c_station
+    output for currents."""
+    frames = {}
+    for bn, depth, orient, hfb in bins:
+        df = pd.DataFrame({
+            'DateTime': pd.to_datetime(['2025-01-01 00:00']),
+            'DEP01': [depth],
+            'DIR': [90.0],
+            'OBS': [0.5],
+        })
+        df.attrs['bin'] = bn
+        df.attrs['depth'] = depth
+        df.attrs['orientation'] = orient
+        df.attrs['height_from_bottom'] = hfb
+        frames[bn] = df
+    return frames
+
+
+def test_process_coops_station_filters_to_csv_bins(logger):
+    import importlib
+    woc = importlib.import_module(
+        'ofs_skill.obs_retrieval.write_obs_ctlfile')
+    from ofs_skill.obs_retrieval.currents_bins_override import BinSpec
+
+    # 4 bins available; CSV only names 2 of them.
+    frames = _fake_bin_frames([
+        (1, 2.0, 'up', None),
+        (2, 4.0, 'up', None),
+        (3, 6.0, 'up', None),
+        (4, 8.0, 'up', None),
+    ])
+    overrides = {
+        2: BinSpec(bin=2),
+        4: BinSpec(bin=4),
+    }
+    with patch.object(woc, 'retrieve_t_and_c_station', return_value=frames):
+        entries = woc._process_coops_station(
+            id_number='cb1001', name='Cove Point',
+            x_value=-76.384, y_value=38.403,
+            start_date='20250101', end_date='20250102',
+            variable='currents', name_var='cu',
+            datum='MLLW', datum_list=['MLLW'], ofs='cbofs',
+            logger=logger, bin_overrides=overrides,
+        )
+    assert len(entries) == 2
+    assert entries[0].startswith('cb1001_b02 ')
+    assert entries[1].startswith('cb1001_b04 ')
+
+
+def test_process_coops_station_applies_depth_override(logger):
+    import importlib
+    woc = importlib.import_module(
+        'ofs_skill.obs_retrieval.write_obs_ctlfile')
+    from ofs_skill.obs_retrieval.currents_bins_override import BinSpec
+
+    # Bin 5 comes from MDAPI with depth=6.0 + hfb=0.0; user overrides to 9.5.
+    frames = _fake_bin_frames([(5, 6.0, 'up', None)])
+    overrides = {5: BinSpec(bin=5, depth=9.5, name='mid-column')}
+    with patch.object(woc, 'retrieve_t_and_c_station', return_value=frames):
+        entries = woc._process_coops_station(
+            id_number='cb1001', name='Cove Point',
+            x_value=-76.384, y_value=38.403,
+            start_date='20250101', end_date='20250102',
+            variable='currents', name_var='cu',
+            datum='MLLW', datum_list=['MLLW'], ofs='cbofs',
+            logger=logger, bin_overrides=overrides,
+        )
+    assert len(entries) == 1
+    entry = entries[0]
+    # New depth value present, old 6.00 is not.
+    assert '9.50' in entry
+    assert '6.00' not in entry
+    # Custom name appended in the quoted display label.
+    assert 'bin 05 / mid-column' in entry
+
+
+def test_process_coops_station_warns_on_missing_requested_bin(
+    logger, caplog
+):
+    import importlib
+    woc = importlib.import_module(
+        'ofs_skill.obs_retrieval.write_obs_ctlfile')
+    from ofs_skill.obs_retrieval.currents_bins_override import BinSpec
+
+    # Only bin 2 available; CSV asks for 2 and 99.
+    frames = _fake_bin_frames([(2, 4.0, 'up', None)])
+    overrides = {
+        2: BinSpec(bin=2),
+        99: BinSpec(bin=99),
+    }
+    with patch.object(woc, 'retrieve_t_and_c_station', return_value=frames), \
+            caplog.at_level(logging.WARNING):
+        entries = woc._process_coops_station(
+            id_number='cb1001', name='Cove Point',
+            x_value=-76.384, y_value=38.403,
+            start_date='20250101', end_date='20250102',
+            variable='currents', name_var='cu',
+            datum='MLLW', datum_list=['MLLW'], ofs='cbofs',
+            logger=logger, bin_overrides=overrides,
+        )
+    assert len(entries) == 1
+    assert '[99]' in caplog.text or 'bin(s) [99]' in caplog.text


### PR DESCRIPTION
### Description of Changes

Stacked on top of #95. Adds Phase 3 of issue #87: an optional user CSV that lets an analyst (a) pin which CO-OPS ADCP bins are processed for a station and (b) override the obs depth, orientation, or display name per bin. Implementation lives entirely in the currents branch of `_process_coops_station` plus a new small loader module — nothing else in the pipeline changes, so all Phase 1+2 output files and plot formats stay identical for stations not listed in the CSV.

Key pieces:

- **New CLI flag `-cb / --Currents_Bins_Csv`** on both `bin/obs_retrieval/get_station_observations_cli.py` and `bin/visualization/create_1dplot.py`. Threaded via `prop.currents_bins_csv` → `write_obs_ctlfile` → `_process_variable` → `_process_coops_station(bin_overrides=…)`.
- **New module `src/ofs_skill/obs_retrieval/currents_bins_override.py`** — `BinSpec` dataclass, `load_currents_bins_csv(path, logger)`, and `bin_spec_lookup(overrides, station_id)`. Tolerant parser: missing file / blank / `#` comments / missing optional cells are handled gracefully; malformed rows WARN and skip.
- **Filter + override** in the CTL writer currents branch: listed bins replace the default all-bins behavior; non-empty `depth` replaces MDAPI / side-looking-resolver depth (and sets `hfb=0.00` so the resolver early-exits); `name` is appended to the station display label.
- **HTTP-traffic optimisation**: `retrieve_t_and_c_station` gains an `only_bins: Optional[set[int]]` kwarg. When the CSV pins 3 bins on a 35-bin station, only 3 datagetter calls fire instead of 35.
- **Example CSV**: `conf/currents_bins_example.csv` with commented rows.
- **Docs**: `issue_87_currents_bins_workflow.md` gains a "User override: currents-bins CSV" section with schema, CLI usage, sample CTL output, and a behaviour matrix. Destined for the wiki.
- **Tests**: `tests/currents_bins_override_test.py` — 9 passing tests (parsing + filter/override/WARN paths).

_Labels: enhancement_

### Expected Outcome of Changes

- Runs without `-cb` are byte-identical to current Phase 1+2 behavior.
- With `-cb <path>`:
  - The obs CTL contains only the pinned bins for stations in the CSV; other stations keep their full bin list.
  - Any `depth` column set in the CSV replaces the Phase 1+2 obs depth (including the side-looking resolver output) and is what `index_nearest_depth` operates on.
  - Plot titles for overridden bins read e.g. `Cove Point LNG Pier (SL-ADP) (bin 15 / mid-column)` — `Bin 15 — Obs depth -9.0 m — Model depth -8.9 m`.

### Developer Questions and Checklist

**Is this a high priority PR? If yes, why and is there a date by which it needs to be merged?**
No hard deadline. Queued for v1.6.0-beta once #95 lands.

**Are there any changes needed to how the code should be run for operational runs? (Commands, flags, job timings, etc.)**
Only if an analyst opts in by passing `-cb <csv>`. Default behavior (no flag) is unchanged.

**Does this update need to be deployed for operational runs?**
Optional. Useful when a specific OFS needs bin subsets or hand-corrected depths (e.g. Cove Point, where CBOFS bathymetry doesn't resolve the LNG berth — see the worked example in the workflow doc).

**Does this update require front end/web app changes? (If yes, provide documentation to Min)**
No. The visualization output format, naming, and filenames are unchanged; the CSV only adds an optional `/ custom_name` segment inside the quoted station label.

**Does this impact code development work on adding SCHISM?**
No new coupling — the override logic sits in `write_obs_ctlfile` and the retrieval module, both of which are model-agnostic.

**Does this impact code development work on adding ADCIRC?**
No.

**Does this impact the expected number of output files for integration tests (i.e., will the integration test fail even though code changes result in desired change in outputs?)**
Only for test runs that supply `-cb`. Default runs (no flag) are unaffected.

- [x] Developer's name is removed throughout the code?
- [x] Did you add relevant labels to the PR?
- [ ] Have you run pylint and is the code at an acceptable pylint score (>8)? _Project-wide pylint not run; targeted unit tests added (19 tests total between #95 and this PR)._
- [x] Jobs contain the appropriate file checking and handle errors for any missing data?
- [x] Is log free of critical ERRORs or WARNINGs? For errors that are not critical and can remain in code, is there sufficient handling and logging?

### Testing Instructions

Unit tests (both Phase 1+2 and Phase 3 suites):
```bash
conda activate ofs_dps
pytest tests/coops_currents_bins_test.py tests/currents_bins_override_test.py --no-cov -v
```
Expect 19 passing.

End-to-end smoke with the bundled example CSV:
```bash
rm -f control_files/cbofs_cu_station.ctl \
      control_files/cbofs_cu_model_station.ctl \
      data/observations/1d_station/*_cbofs_cu_station.obs \
      data/model/1d_node/*cbofs_cu*nowcast* \
      data/skill/1d_pair/cbofs_cu_*nowcast* \
      data/visual/cbofs_*_b*_currents_*.html

python ./bin/visualization/create_1dplot.py \
    -o cbofs -p ./ \
    -s '2026-03-27T00:00:00Z' -e '2026-03-28T00:00:00Z' \
    -d MLLW -ws nowcast -t stations -vs currents -so co-ops \
    -cb conf/currents_bins_example.csv
```

Expected outputs for the cbofs 2026-03-27 nowcast window:

- `cbofs_cu_station.ctl` has **75 virtual-ID entries** instead of 129:
  cb0402×12, cb0801×11, cb1001×3 (filtered per CSV), cb1301×1 (filtered), cb1401×48.
- `cb1001_b01/b15/b30` CTL rows carry the CSV-supplied depth (3.50 / 9.00 / 13.50 m) and `hfb=0.00`.
- `cb1301_b10` CTL row carries depth 10.52 m (side-looking resolver ran because the CSV left `depth` empty).
- Plots for the filtered bins show titles like:
  - `Cove Point LNG Pier (SL-ADP) (bin 15 / mid-column) (cb1001_b15)` — `Bin 15 — Obs depth -9.0 m — Model depth -8.9 m`
  - `Chesapeake City (bin 10 / near-bottom) (cb1301_b10)` — `Bin 10 — Obs depth -10.5 m — Model depth -10.4 m`

### Reminder checklist for PR reviewer

- [ ] Run PEP8 compliance tests to ensure the code follows best practices
- [ ] Check that documentation in the script is sufficient — workflow doc + example CSV included
- [ ] Validate the output values to make sure the calculations are correct and make scientific/physical sense; include a comment on the pull request including what validation you performed, for replicability
- [ ] Test code both on Windows and Linux (and MacOS, if available), using several OFS as test cases
- [ ] When approving or commenting on a pull request, add information on the calls you use in case they need to be replicated or referenced
