### PR TITLE
NECOFS vdatum updates

### DIFF
--- a/bin/visualization/create_1dplot.py
+++ b/bin/visualization/create_1dplot.py
@@ -199,8 +199,12 @@ def _process_station_plot(
                 serieskey = pd.read_csv(filepath)
                 serieskey['DateTime'] = pd.to_datetime(
                     serieskey['DateTime'])
-                paired_data = pd.merge(
-                    paired_data, serieskey, on='DateTime', how='inner')
+                if len(paired_data) == len(serieskey):
+                    paired_data = pd.merge(
+                        paired_data, serieskey, on='DateTime', how='inner')
+                else:
+                    logger.warning('Filename key and time series have different '
+                                   'lengths!')
             except FileNotFoundError:
                 logger.error(
                     'No model series filename key found! Skipping')

--- a/src/ofs_skill/model_processing/get_datum_offset.py
+++ b/src/ofs_skill/model_processing/get_datum_offset.py
@@ -452,11 +452,21 @@ def get_datum_offset(prop: Any, node: int, model: xr.Dataset,
 
     # Set water levels to user-specified datum
     if prop.ofs not in ['leofs', 'lmhofs', 'loofs', 'lsofs', 'loofs2']:
+        if prop.ofs == 'necofs':
+            try:
+                datum_field1 = vdatums['navd88tomsl']
+                datum_field2 = vdatums[f'{prop.datum.lower()}tomsl']
+                datum_field = datum_field1 + datum_field2
+            except Exception as e_x:
+                logger.error(f'Datum conversion error: {e_x}')
+                return -9991
         # Deal with SSCOFS separately
-        if prop.ofs == 'sscofs':
+        elif prop.ofs == 'sscofs':
             # First get from model-0 to xgeoid -- the ofs-wide offset is
             # 0.23 m, where xgeoid is 0.23 cm above model-0.
             # Then convert from xgeoid to other datums.
+            if prop.datum.lower() == 'xgeoid20b':
+                return 0.23
             try:
                 datum_field1 = vdatums['xgeoid20btomsl']
                 if prop.datum.lower() == 'msl':

--- a/src/ofs_skill/model_processing/get_datum_offset.py
+++ b/src/ofs_skill/model_processing/get_datum_offset.py
@@ -455,8 +455,11 @@ def get_datum_offset(prop: Any, node: int, model: xr.Dataset,
         if prop.ofs == 'necofs':
             try:
                 datum_field1 = vdatums['navd88tomsl']
-                datum_field2 = vdatums[f'{prop.datum.lower()}tomsl']
-                datum_field = datum_field1 + datum_field2
+                if prop.datum.lower() == 'navd88':
+                    datum_field = datum_field1
+                else:
+                    datum_field2 = vdatums[f'{prop.datum.lower()}tomsl']
+                    datum_field = (-datum_field1 + datum_field2)
             except Exception as e_x:
                 logger.error(f'Datum conversion error: {e_x}')
                 return -9991
@@ -469,7 +472,7 @@ def get_datum_offset(prop: Any, node: int, model: xr.Dataset,
                 return 0.23
             try:
                 datum_field1 = vdatums['xgeoid20btomsl']
-                if prop.datum.lower() == 'msl':
+                if prop.datum.lower() == 'msl': #TODO -- check this
                     datum_field = 0.23 - datum_field1
                 else:
                     datum_field2 = vdatums[f'{prop.datum.lower()}tomsl']
@@ -514,8 +517,11 @@ def get_datum_offset(prop: Any, node: int, model: xr.Dataset,
                 # Gotta search with lat/lon here...
                 vlonlat = np.around(np.array([vdatums[
                     'longitude'], vdatums['latitude']]), 3)
+                lon_adjustment = 360
+                if 'necofs' in prop.ofs:
+                    lon_adjustment = 0
                 target = np.around(
-                    np.array([[model['lon'][0, node] - 360],
+                    np.array([[model['lon'][0, node] - lon_adjustment],
                               [model['lat'][0, node]]]), 3)
                 moddistances = np.linalg.norm(vlonlat - target,
                                               axis=0)

--- a/src/ofs_skill/model_processing/get_node_ofs.py
+++ b/src/ofs_skill/model_processing/get_node_ofs.py
@@ -95,7 +95,7 @@ def get_time_step(prop, logger):
     # Define your expected frequency in minutes (e.g. 6 minutes)
     exp_freq = 6
     if prop.ofsfiletype == 'fields':
-        if prop.ofs in ['gomofs', 'wcofs', 'ngofs2', 'necofs']:
+        if prop.ofs in ['gomofs', 'wcofs', 'ngofs2']:
             exp_freq = 180
         else:
             exp_freq = 60
@@ -401,7 +401,7 @@ def format_temp_salt(prop, model, ofs_ctlfile, model_var, i, precomputed=None):
             model_obs[invalid_mask] = np.nan
     elif prop.model_source == 'adcirc':
         if prop.ofs == 'stofs_2d_glo':
-            # We raise en exception here for STOFS-2D-Global because it does 
+            # We raise en exception here for STOFS-2D-Global because it does
             # not have temp/sal data, and logic elsewhere should steer users
             # away from calling this function with STOFS-2D-Global.
             raise ValueError('Temperature and salinity data are not available for STOFS-2D-Global.')
@@ -577,7 +577,7 @@ def format_currents(prop, model, ofs_ctlfile, i, precomputed=None):
             mfp.model_ang[invalid_mask] = np.nan
     elif prop.model_source == 'adcirc':
         if prop.ofs == 'stofs_2d_glo':
-            # We raise en exception here for STOFS-2D-Global because it does 
+            # We raise en exception here for STOFS-2D-Global because it does
             # not have current data, and logic elsewhere should steer users
             # away from calling this function with STOFS-2D-Global.
             raise ValueError('Current data are not available for STOFS-2D-Global.')
@@ -839,7 +839,7 @@ def parameter_validation(prop, dir_params, logger):
                            'Removing other variables from list.')
             prop.var_list = ['water_level']
             # I think we can alter its state here, but maybe there's a reason not to?
-            
+
 
 def get_node_ofs(prop, logger, model_dataset=None):
     """

--- a/src/ofs_skill/model_processing/indexing.py
+++ b/src/ofs_skill/model_processing/indexing.py
@@ -142,7 +142,7 @@ def index_nearest_node(
                     )
                     dist.append(dvalue)
 
-                index_min_dist.append(int(nearby_nodes[dist.index(min(dist))]))
+                index_min_dist.append(int(nearby_nodes[dist.index(min(dist))].item()))
                 logger.info(
                     f'Nearest node found: station {obs_p + 1} of {len(ctl_file_extract)}'
                 )
@@ -334,7 +334,7 @@ def index_nearest_node(
 
     elif model_source == 'adcirc':
         raise NotImplementedError('ADCIRC indexing not yet implemented.')
-    
+
     else:
         raise ValueError(f'Unknown model source: {model_source}')
 
@@ -592,17 +592,17 @@ def index_nearest_depth(
                         index_min_depth.append(0)
                         depth_value.append(0.0)
                         logger.info(
-                            'Nearest depth found: node %s of %s', 
+                            'Nearest depth found: node %s of %s',
                             idx + 1, len(index_min_dist)
                         )
                     else:
-                        # We raise en exception here for STOFS-2D-Global non-water level variables 
+                        # We raise en exception here for STOFS-2D-Global non-water level variables
                         # because it does not have depth-wise data, and logic elsewhere should steer users
                         # away from calling this function with STOFS-2D-Global and other variables.
                         raise ValueError('STOFS-2D-Global does not have depth-resolved data, cannot find nearest depth')
                 else:
                     raise NotImplementedError('ADCIRC depth indexing not yet implemented for models other than STOFS-2D-Global.')
-                
+
     elif prop.ofsfiletype == 'stations':
         if 'stofs' in prop.ofs:
             return [], []
@@ -637,7 +637,7 @@ def index_nearest_depth(
                             )
                             continue
                         else:
-                            # We raise en exception here for STOFS-2D-Global non-water level variables 
+                            # We raise en exception here for STOFS-2D-Global non-water level variables
                             # because it does not have depth-wise data, and logic elsewhere should steer users
                             # away from calling this function with STOFS-2D-Global and other variables.
                             raise ValueError('STOFS-2D-Global does not have depth-resolved data, cannot find nearest depth')

--- a/src/ofs_skill/model_processing/write_ofs_ctlfile.py
+++ b/src/ofs_skill/model_processing/write_ofs_ctlfile.py
@@ -297,6 +297,9 @@ def write_ofs_ctlfile(prop: Any, model: Any, logger: Logger) -> Any:
                     continue
                 length = len(list_of_nearest_node)
                 if prop.model_source=='fvcom':
+                    lon_wrap = 360
+                    if 'necofs' in prop.ofs:
+                        lon_wrap = 0
                     for i in range(0, length):
                         if not np.isnan(list_of_nearest_node[i]):
                             if prop.ofsfiletype == 'fields':
@@ -305,7 +308,7 @@ def write_ofs_ctlfile(prop: Any, model: Any, logger: Logger) -> Any:
                                         f'{list_of_nearest_node[i]} '
                                         f'{list_of_nearest_layer[i]} '
                                         f"{model['latc'][list_of_nearest_node[i]].data.compute():.3f}  "
-                                        f"{model['lonc'][list_of_nearest_node[i]].data.compute() - 360:.3f}  "
+                                        f"{model['lonc'][list_of_nearest_node[i]].data.compute() - lon_wrap:.3f}  "
                                         f'{station_id[i]}  {list_of_depths[i]:.1f}\n'
                                         )
                                 else:
@@ -313,7 +316,7 @@ def write_ofs_ctlfile(prop: Any, model: Any, logger: Logger) -> Any:
                                         f'{list_of_nearest_node[i]} '
                                         f'{list_of_nearest_layer[i]} '
                                         f"{model['lat'][list_of_nearest_node[i]].data.compute():.3f}  "
-                                        f"{model['lon'][list_of_nearest_node[i]].data.compute() - 360:.3f}  "
+                                        f"{model['lon'][list_of_nearest_node[i]].data.compute() - lon_wrap:.3f}  "
                                         f'{station_id[i]}  {list_of_depths[i]:.1f}\n'
                                         )
                             else:
@@ -321,7 +324,7 @@ def write_ofs_ctlfile(prop: Any, model: Any, logger: Logger) -> Any:
                                     f'{list_of_nearest_node[i]} '
                                     f'{list_of_nearest_layer[i]} '
                                     f"{model['lat'][0,list_of_nearest_node[i]].data.compute():.3f}  "
-                                    f"{model['lon'][0,list_of_nearest_node[i]].data.compute() - 360:.3f}  "
+                                    f"{model['lon'][0,list_of_nearest_node[i]].data.compute() - lon_wrap:.3f}  "
                                     f'{station_id[i]}  {list_of_depths[i]:.1f}\n'
                                 )
                         else:
@@ -448,7 +451,7 @@ def write_ofs_ctlfile(prop: Any, model: Any, logger: Logger) -> Any:
                         else:
                             logger.info('No matching model station found for '
                                         'obs station %s.', station_id[i])
-                                
+
                 elif prop.model_source == 'adcirc':
                     if prop.ofs == 'stofs_2d_glo':
                         for i in range(length):
@@ -465,8 +468,8 @@ def write_ofs_ctlfile(prop: Any, model: Any, logger: Logger) -> Any:
                                 logger.info('No matching model station found for '
                                             'obs station %s.', station_id[i])
                     else:
-                        # STOFS-2D-Global is the only ADCIRC implemented, so it's 
-                        # not clear how someone would even get here, but we raise 
+                        # STOFS-2D-Global is the only ADCIRC implemented, so it's
+                        # not clear how someone would even get here, but we raise
                         # an exception just in case.
                         raise NotImplementedError('ADCIRC control file writing not yet implemented for models other than STOFS-2D-Global.')
 


### PR DESCRIPTION
### Description of Changes

This PR enhances vertical datum handling across the skill assessment system with improved support for NECOFS, including refined datum conversion logic, longitude coordinate adjustments, and code quality improvements. 

#### Enhanced Datum Conversion for NECOFS (`src/ofs_skill/model_processing/get_datum_offset.py`)

**New NECOFS Datum Support**
- Added dedicated datum conversion logic for NECOFS (Northeast Coastal OFS)
- Implements NAVD88-to-MSL conversion pathway using vdatum lookup tables
- Supports conversion to all standard datums (MLLW, MLW, MHW, NAVD88, etc.)
- Properly handles the two-step conversion process for non-NAVD88 target datums

### Expected Outcome of Changes

Accurate water level skill assessment for NECOFS.

### Developer Questions and Checklist
**Is this a high priority PR? If yes, why and is there a date by which it needs to be merged?**
No.

**Are there any changes needed to how the code should be run on the server? (Commands, flags, job timings, etc.)**
No.

**Does this update need to be installed on the server?**
yes.

**Does this update require front end/web app changes? (If yes, provide documentation to Min)**
No.

**Does this impact code development work on adding SCHISM? (If yes, tag Atieh)**
No.

**Does this impact code development work on adding ADCIRC?**
_No/Yes + tag Jack if yes_
No.

**Does this impact the expected number of output files for integration tests (i.e., will the integration test fail even though code changes result in desired change in the number of outputs?)**
No.

- [ ] Developer's name is removed throughout the code?
- [ ] Did you add relevant labels to the PR?
- [ ] Have you run pylint and is the code at an acceptable pylint score? (>8.0)
- [ ] Jobs contain the appropriate file checking and handle errors for any missing data?
- [ ] Is log free of critical ERRORs or WARNINGs? For errors that are not critical and can remain in code, is there sufficient handling and logging?

### Testing Instructions

Run the package for NECOFS on the main branch. Save the output. 

Then run NECOFS using this branch using both station and field files. Verify 
1) water level agreement between model and observations is much better compared to the results from main branch;
2) Station and field output from this branch are consistent (except for time resolution).

### Reminder checklist for PR reviewer:
- [x] Run PEP8 compliance tests to ensure the code follows best practices
- [x] Check that documentation in the script is sufficient
- [x] Validate the output values (if applicable) to make sure the calculations are correct and make scientific/physical sense; include a comment on the pull request including what validation you performed, for replicability.
- [x] Test code both locally and on the linux server, using several OFS as test cases
- [x] **Test for all ‘cast’ options: forecast_a, forecast_b, and nowcast**
- [x] When approving or commenting on a pull request, add information on the calls you use in case they need to be replicated.
