### PR TITLE
Fix ice overview filename

### DIFF
--- a/bin/skill_assessment/make_OM_view_ice.py
+++ b/bin/skill_assessment/make_OM_view_ice.py
@@ -204,7 +204,7 @@ def make_bar_plots(df1, df2, prop, cast, logger):
     # prop.stat = prop.stat.rstrip('*')
     output_file = (
         f'{prop.om_files}/bars_ice_{cast}_'
-        f'_all_GLOFS'
+        f'all_GLOFS'
         )
     fig_config = {
     'toImageButtonOptions': {


### PR DESCRIPTION
### Description of Changes

An ice overview filename had a double-underscore, which caused problems on the web app. This PR changes the double-underscore to a single-underscore. 

### Expected Outcome of Changes

Functionality for the ice overview web app dashboard. 

### Developer Questions and Checklist
**Is this a high priority PR? If yes, why and is there a date by which it needs to be merged?**
No.

**Are there any changes needed to how the code should be run on the server? (Commands, flags, job timings, etc.)**
No.

**Does this update need to be installed on the server?**
Yes.

**Does this update require front end/web app changes? (If yes, provide documentation to Min)**
No.

**Does this impact code development work on adding SCHISM? (If yes, tag Atieh)**
No.

**Does this impact code development work on adding ADCIRC?**
_No/Yes + tag Jack if yes_
No.

**Does this impact the expected number of output files for integration tests (i.e., will the integration test fail even though code changes result in desired change in the number of outputs?)**
No.

- [ ] Developer's name is removed throughout the code?
- [ ] Did you add relevant labels to the PR?
- [ ] Have you run pylint and is the code at an acceptable pylint score? (>8.0)
- [ ] Jobs contain the appropriate file checking and handle errors for any missing data?
- [ ] Is log free of critical ERRORs or WARNINGs? For errors that are not critical and can remain in code, is there sufficient handling and logging?

### Testing Instructions

No testing needed! Just a filename change.

### Reminder checklist for PR reviewer:
- [ ] Run PEP8 compliance tests to ensure the code follows best practices
- [ ] Check that documentation in the script is sufficient
- [ ] Validate the output values (if applicable) to make sure the calculations are correct and make scientific/physical sense; include a comment on the pull request including what validation you performed, for replicability.
- [ ] Test code both locally and on the linux server, using several OFS as test cases
- [ ] **Test for all ‘cast’ options: forecast_a, forecast_b, and nowcast**
- [ ] When approving or commenting on a pull request, add information on the calls you use in case they need to be replicated.
