### PR TITLE
Fix NAVD datum handling and CO-OPS resilience

### DIFF
--- a/bin/obs_retrieval/get_station_observations_cli.py
+++ b/bin/obs_retrieval/get_station_observations_cli.py
@@ -161,7 +161,7 @@ if __name__ == '__main__':
     # Make all station owners default, unless user specifies station owners
     if args.Station_Owner is None:
         prop1.stationowner = 'co-ops,ndbc,usgs,chs'
-    elif args.FileType is not None:
+    elif args.Station_Owner is not None:
         prop1.stationowner = args.Station_Owner.lower()
 
     #Handle variable selection

--- a/src/ofs_skill/obs_retrieval/get_station_observations.py
+++ b/src/ofs_skill/obs_retrieval/get_station_observations.py
@@ -396,6 +396,7 @@ def _fetch_and_format_station(
                         'CO-OPS %s data for '
                         'station %s', variable,
                         str(station_id))
+                    return None
                 else:
                     timeseries = timeseries[timeseries['OBS'].notna()]
 

--- a/src/ofs_skill/obs_retrieval/inventory_t_c_station.py
+++ b/src/ofs_skill/obs_retrieval/inventory_t_c_station.py
@@ -48,7 +48,7 @@ def get_inventory(
     try:
         with urllib.request.urlopen(station_url) as url:
             inventory = json.load(url)
-    except urllib.error.HTTPError as ex:
+    except (urllib.error.URLError, urllib.error.HTTPError) as ex:
         logger.error(
             'CO-OPS station %s data download failed at %s -- %s.',
             variable,

--- a/src/ofs_skill/obs_retrieval/retrieve_t_and_c_station.py
+++ b/src/ofs_skill/obs_retrieval/retrieve_t_and_c_station.py
@@ -38,12 +38,12 @@ from ofs_skill.obs_retrieval import t_and_c_properties, utils
 # ---------------------------------------------------------------------------
 # Module-level HTTP session with connection pooling (Task 2)
 # ---------------------------------------------------------------------------
-_session = None
+_session = None  # pylint: disable=invalid-name
 
 
 def _get_session():
     """Lazily create and return a shared requests.Session with connection pooling."""
-    global _session
+    global _session  # pylint: disable=invalid-name,global-statement
     if _session is None:
         _session = requests.Session()
         adapter = HTTPAdapter(pool_connections=10, pool_maxsize=10)
@@ -74,7 +74,7 @@ _COOPS_CONCURRENCY_LIMIT = 2
 _COOPS_MIN_REQUEST_GAP_SEC = 0.5
 _coops_request_semaphore = threading.Semaphore(_COOPS_CONCURRENCY_LIMIT)
 _coops_pacing_lock = threading.Lock()
-_coops_last_request_time = 0.0
+_coops_last_request_time = 0.0  # pylint: disable=invalid-name
 
 
 def _rate_limited_get(url: str, timeout: int = 120) -> requests.Response:
@@ -86,7 +86,7 @@ def _rate_limited_get(url: str, timeout: int = 120) -> requests.Response:
     ``_COOPS_MIN_REQUEST_GAP_SEC``. Retry backoff sleeps outside both
     locks so waiting threads do not starve the pool.
     """
-    global _coops_last_request_time
+    global _coops_last_request_time  # pylint: disable=invalid-name,global-statement
     with _coops_request_semaphore:
         with _coops_pacing_lock:
             now = time.monotonic()

--- a/src/ofs_skill/obs_retrieval/retrieve_t_and_c_station.py
+++ b/src/ofs_skill/obs_retrieval/retrieve_t_and_c_station.py
@@ -5,13 +5,19 @@ This module provides functions to retrieve tidal observations, water level,
 temperature, salinity, currents, and other oceanographic data from NOAA CO-OPS
 stations, as well as tidal predictions and nearest station finding capabilities.
 
-The retrieval is performed in 30-day chunks to handle API limitations, with
-automatic retry logic for temperature and salinity using backup URLs.
+The retrieval is performed in 30-day chunks to handle API limitations. Every
+CO-OPS HTTP call is gated by a module-level semaphore (see
+``_rate_limited_get``) so upstream parallelization cannot exceed a safe
+concurrent-request ceiling, and transient errors are handled with
+full-jitter exponential backoff (see ``_get_with_retry``). Water temperature
+and salinity additionally fall back to a ``PHYSOCEAN`` backup URL when the
+primary endpoint exhausts retries.
 """
 
 import json
 import math
 import random
+import threading
 import time
 from datetime import datetime, timedelta
 from logging import Logger
@@ -39,6 +45,33 @@ def _get_session():
         _session.mount('https://', adapter)
         _session.mount('http://', adapter)
     return _session
+
+
+# ---------------------------------------------------------------------------
+# Global CO-OPS concurrency cap (issue #98)
+# ---------------------------------------------------------------------------
+# CO-OPS throttles aggressively when many historical datagetter requests
+# come from one IP at once. ``write_obs_ctlfile`` parallelizes across
+# variables (4) and stations (up to 6), so without a process-wide cap an
+# OFS run can fire ~24 concurrent GETs at CO-OPS, trigger IP-level 403s,
+# and then synchronize retries into a thundering herd. Every CO-OPS HTTP
+# call in this module acquires this semaphore before issuing the GET,
+# decoupling HTTP pressure from upstream ThreadPoolExecutor sizing.
+_COOPS_CONCURRENCY_LIMIT = 4
+_coops_request_semaphore = threading.Semaphore(_COOPS_CONCURRENCY_LIMIT)
+
+
+def _rate_limited_get(url: str, timeout: int = 120) -> requests.Response:
+    """GET ``url`` through the shared session, gated by the CO-OPS semaphore.
+
+    The semaphore caps concurrent in-flight CO-OPS requests across every
+    worker thread in the process. Callers still get the shared connection
+    pool; only the HTTP round-trip itself counts against the concurrency
+    budget. Retry backoff sleeps outside this lock so waiting threads do
+    not starve the pool.
+    """
+    with _coops_request_semaphore:
+        return _get_session().get(url, timeout=timeout)
 
 
 # ---------------------------------------------------------------------------
@@ -71,7 +104,7 @@ def _get_station_depth(station_id, mdapi_url, logger):
 
     url = f'{mdapi_url}/webapi/stations/{station_id}/bins.json?units=metric'
     try:
-        response = _get_session().get(url, timeout=120)
+        response = _rate_limited_get(url, timeout=120)
         response.raise_for_status()
         depth_data = response.json()
         logger.info(
@@ -88,19 +121,29 @@ def _get_station_depth(station_id, mdapi_url, logger):
 
 # CO-OPS occasionally rate-limits or returns transient 5xx when a long
 # historical window forces many 30-day chunk requests per station; retry
-# a small number of times with exponential backoff + jitter before giving
-# up. Kept in sync with the per-bin retry helper on issue-87-currents-bins
-# so both paths share the same backoff profile.
+# a small number of times with full-jitter exponential backoff before
+# giving up. Kept in sync with the per-bin retry helper on
+# issue-87-currents-bins so both paths share the same backoff profile.
 _RETRY_STATUSES = (403, 408, 429, 500, 502, 503, 504)
 _RETRY_MAX_ATTEMPTS = 6
-_RETRY_BASE_DELAY = 2.0  # seconds; exponential backoff per attempt
-_RETRY_JITTER_MAX = 0.5  # seconds; random jitter added on top of exponential backoff
+# Base delay is the upper bound of the first retry. CO-OPS throttle
+# windows for burst IP traffic are typically tens of seconds, so starting
+# at 5s lets the first retry clear even short bans instead of re-hitting
+# the ceiling. Delay grows as random.uniform(0, _BASE * 2**(attempt-1)).
+_RETRY_BASE_DELAY = 5.0
 
 
 def _backoff_delay(attempt: int) -> float:
-    """Return seconds to sleep before the next retry attempt."""
-    return (_RETRY_BASE_DELAY * (2 ** (attempt - 1))
-            + random.uniform(0, _RETRY_JITTER_MAX))
+    """Return seconds to sleep before the next retry attempt.
+
+    Full-jitter exponential backoff: ``uniform(0, base * 2^(attempt-1))``.
+    Randomizing the entire delay (rather than adding a small jitter on top
+    of a fixed backoff) decorrelates retry timing across threads that all
+    hit the rate limiter in the same instant. Without this, every worker
+    that got a 403 together would also retry together, keeping the herd
+    effect alive through the full retry budget.
+    """
+    return random.uniform(0, _RETRY_BASE_DELAY * (2 ** (attempt - 1)))
 
 
 def _get_with_retry(
@@ -125,7 +168,7 @@ def _get_with_retry(
     last_exc = None
     for attempt in range(1, _RETRY_MAX_ATTEMPTS + 1):
         try:
-            response = _get_session().get(url, timeout=120)
+            response = _rate_limited_get(url, timeout=120)
         except (requests.exceptions.ConnectionError,
                 requests.exceptions.Timeout) as ex:
             last_exc = ex
@@ -504,7 +547,7 @@ def retrieve_tidal_predictions(
         )
 
         try:
-            response = _get_session().get(t_c.station_url, timeout=120)
+            response = _rate_limited_get(t_c.station_url, timeout=120)
             response.raise_for_status()
             obs = response.json()
             logger.info(
@@ -630,7 +673,7 @@ def retrieve_harmonic_constants(
     )
 
     try:
-        resp = _get_session().get(harcon_url, timeout=TIMEOUT_SEC)
+        resp = _rate_limited_get(harcon_url, timeout=TIMEOUT_SEC)
         resp.raise_for_status()
         response = resp.json()
         logger.info(
@@ -747,7 +790,7 @@ def find_nearest_tidal_stations(
     stations_url = f'{mdapi_url}/webapi/stations.json?type=tidepredictions'
 
     try:
-        response = _get_session().get(stations_url, timeout=120)
+        response = _rate_limited_get(stations_url, timeout=120)
         response.raise_for_status()
         stations_data = response.json()
     except Exception as ex:

--- a/src/ofs_skill/obs_retrieval/retrieve_t_and_c_station.py
+++ b/src/ofs_skill/obs_retrieval/retrieve_t_and_c_station.py
@@ -48,29 +48,47 @@ def _get_session():
 
 
 # ---------------------------------------------------------------------------
-# Global CO-OPS concurrency cap (issue #98)
+# Global CO-OPS concurrency cap + pacing (issue #98)
 # ---------------------------------------------------------------------------
 # CO-OPS throttles aggressively when many historical datagetter requests
-# come from one IP at once. ``write_obs_ctlfile`` parallelizes across
-# variables (4) and stations (up to 6), so without a process-wide cap an
-# OFS run can fire ~24 concurrent GETs at CO-OPS, trigger IP-level 403s,
-# and then synchronize retries into a thundering herd. Every CO-OPS HTTP
-# call in this module acquires this semaphore before issuing the GET,
-# decoupling HTTP pressure from upstream ThreadPoolExecutor sizing.
-_COOPS_CONCURRENCY_LIMIT = 4
+# come from one IP at once. Two measures guard against this:
+#
+#   1. Semaphore caps concurrent in-flight CO-OPS GETs process-wide,
+#      decoupling HTTP pressure from upstream ThreadPoolExecutor sizing
+#      (``write_obs_ctlfile`` otherwise fans out 4 vars x 6 stations = 24
+#      concurrent workers).
+#   2. Minimum inter-request gap paces the START of each GET so the
+#      sustained request rate stays below CO-OPS's per-IP threshold.
+#      This is what lets long historical windows retrieve 100% of
+#      chunks; relying on backoff alone to recover AFTER a 403 doesn't
+#      work when CO-OPS's throttle window outlasts the retry budget.
+#
+# Tuned against a 14-month stofs_3d_atl run where the earlier settings
+# (concurrency=4, no pacing) still dropped ~1.6% of chunks to exhaustion.
+_COOPS_CONCURRENCY_LIMIT = 2
+_COOPS_MIN_REQUEST_GAP_SEC = 0.5
 _coops_request_semaphore = threading.Semaphore(_COOPS_CONCURRENCY_LIMIT)
+_coops_pacing_lock = threading.Lock()
+_coops_last_request_time = 0.0
 
 
 def _rate_limited_get(url: str, timeout: int = 120) -> requests.Response:
-    """GET ``url`` through the shared session, gated by the CO-OPS semaphore.
+    """GET ``url`` through the shared session, gated by the CO-OPS semaphore
+    and paced by a minimum inter-request gap.
 
-    The semaphore caps concurrent in-flight CO-OPS requests across every
-    worker thread in the process. Callers still get the shared connection
-    pool; only the HTTP round-trip itself counts against the concurrency
-    budget. Retry backoff sleeps outside this lock so waiting threads do
-    not starve the pool.
+    Concurrency semaphore caps in-flight requests across all threads;
+    pacing lock serializes request STARTS so no two GETs fire within
+    ``_COOPS_MIN_REQUEST_GAP_SEC``. Retry backoff sleeps outside both
+    locks so waiting threads do not starve the pool.
     """
+    global _coops_last_request_time
     with _coops_request_semaphore:
+        with _coops_pacing_lock:
+            now = time.monotonic()
+            wait = _COOPS_MIN_REQUEST_GAP_SEC - (now - _coops_last_request_time)
+            if wait > 0:
+                time.sleep(wait)
+            _coops_last_request_time = time.monotonic()
         return _get_session().get(url, timeout=timeout)
 
 
@@ -125,25 +143,32 @@ def _get_station_depth(station_id, mdapi_url, logger):
 # giving up. Kept in sync with the per-bin retry helper on
 # issue-87-currents-bins so both paths share the same backoff profile.
 _RETRY_STATUSES = (403, 408, 429, 500, 502, 503, 504)
-_RETRY_MAX_ATTEMPTS = 6
-# Base delay is the upper bound of the first retry. CO-OPS throttle
-# windows for burst IP traffic are typically tens of seconds, so starting
-# at 5s lets the first retry clear even short bans instead of re-hitting
-# the ceiling. Delay grows as random.uniform(0, _BASE * 2**(attempt-1)).
-_RETRY_BASE_DELAY = 5.0
+# Observed with stofs_3d_atl + 14-month historical window: CO-OPS throttles
+# hard enough that unpaced requests still drop chunks even with backoff.
+# The pacing gap above prevents most 403s from ever firing; these retry
+# settings are the safety net for the few that still slip through.
+# Worst-case total wait per chunk with full-jitter and cap=120s:
+# 10+20+40+80 + 5*120 = 750s = 12.5min, expected ~375s.
+_RETRY_MAX_ATTEMPTS = 10
+_RETRY_BASE_DELAY = 10.0
+# Cap per-attempt delay so late retries don't run away to 20+ minute waits
+# (base * 2^9 = ~85min otherwise at attempt 10). 120s is long enough to
+# clear typical CO-OPS throttle windows, short enough to keep total
+# wall-clock bounded when an individual chunk is having a bad day.
+_RETRY_DELAY_CAP = 120.0
 
 
 def _backoff_delay(attempt: int) -> float:
     """Return seconds to sleep before the next retry attempt.
 
-    Full-jitter exponential backoff: ``uniform(0, base * 2^(attempt-1))``.
-    Randomizing the entire delay (rather than adding a small jitter on top
-    of a fixed backoff) decorrelates retry timing across threads that all
-    hit the rate limiter in the same instant. Without this, every worker
-    that got a 403 together would also retry together, keeping the herd
-    effect alive through the full retry budget.
+    Full-jitter exponential backoff capped at ``_RETRY_DELAY_CAP``:
+    ``uniform(0, min(base * 2^(attempt-1), cap))``. Full jitter
+    decorrelates retry timing across threads that hit the limiter
+    together; the cap keeps late-attempt waits bounded.
     """
-    return random.uniform(0, _RETRY_BASE_DELAY * (2 ** (attempt - 1)))
+    max_delay = min(_RETRY_BASE_DELAY * (2 ** (attempt - 1)),
+                    _RETRY_DELAY_CAP)
+    return random.uniform(0, max_delay)
 
 
 def _get_with_retry(

--- a/src/ofs_skill/obs_retrieval/retrieve_t_and_c_station.py
+++ b/src/ofs_skill/obs_retrieval/retrieve_t_and_c_station.py
@@ -11,6 +11,8 @@ automatic retry logic for temperature and salinity using backup URLs.
 
 import json
 import math
+import random
+import time
 from datetime import datetime, timedelta
 from logging import Logger
 from typing import Optional
@@ -82,6 +84,94 @@ def _get_station_depth(station_id, mdapi_url, logger):
 
     _depth_cache[station_id] = depth_data
     return depth_data
+
+
+# CO-OPS occasionally rate-limits or returns transient 5xx when a long
+# historical window forces many 30-day chunk requests per station; retry
+# a small number of times with exponential backoff + jitter before giving
+# up. Kept in sync with the per-bin retry helper on issue-87-currents-bins
+# so both paths share the same backoff profile.
+_RETRY_STATUSES = (403, 408, 429, 500, 502, 503, 504)
+_RETRY_MAX_ATTEMPTS = 6
+_RETRY_BASE_DELAY = 2.0  # seconds; exponential backoff per attempt
+_RETRY_JITTER_MAX = 0.5  # seconds; random jitter added on top of exponential backoff
+
+
+def _get_with_retry(
+    url: str,
+    station_id: str,
+    variable: str,
+    logger: Logger,
+) -> Optional[dict]:
+    """GET ``url`` with retries for transient CO-OPS errors.
+
+    Retries only on network-level failures (ConnectionError, Timeout) or
+    HTTP status codes in ``_RETRY_STATUSES``. Permanent HTTP errors such
+    as 400 (bad station/date combo — CO-OPS "no data") or 404 fail
+    immediately without burning the retry budget.
+
+    Returns the parsed JSON payload on success, ``None`` when the call
+    hits a non-retryable error or all retries are exhausted.
+    """
+    last_exc = None
+    for attempt in range(1, _RETRY_MAX_ATTEMPTS + 1):
+        try:
+            response = _get_session().get(url, timeout=120)
+        except (requests.exceptions.ConnectionError,
+                requests.exceptions.Timeout) as ex:
+            # Network-level failure: retry.
+            last_exc = ex
+            if attempt < _RETRY_MAX_ATTEMPTS:
+                delay = _RETRY_BASE_DELAY * (2 ** (attempt - 1))
+                delay += random.uniform(0, _RETRY_JITTER_MAX)
+                logger.warning(
+                    'CO-OPS %s station=%s network error (attempt %d/%d): '
+                    '%s; retrying in %.1fs', variable, station_id,
+                    attempt, _RETRY_MAX_ATTEMPTS, ex, delay)
+                time.sleep(delay)
+                continue
+            break
+        except requests.exceptions.RequestException as ex:
+            # Some other non-retryable request-layer error.
+            logger.warning(
+                'CO-OPS %s station=%s non-retryable request error: %s',
+                variable, station_id, ex)
+            return None
+
+        status = response.status_code
+        if status in _RETRY_STATUSES and attempt < _RETRY_MAX_ATTEMPTS:
+            delay = _RETRY_BASE_DELAY * (2 ** (attempt - 1))
+            delay += random.uniform(0, _RETRY_JITTER_MAX)
+            logger.warning(
+                'CO-OPS %s station=%s HTTP %d (attempt %d/%d); '
+                'retrying in %.1fs', variable, station_id, status,
+                attempt, _RETRY_MAX_ATTEMPTS, delay)
+            time.sleep(delay)
+            continue
+
+        if status >= 400:
+            # Non-retryable 4xx/5xx (400, 401, 404, etc.) or exhausted
+            # retries on retryable codes: fail without consuming more
+            # attempts. CO-OPS returns 400 with "No data was found" for
+            # stations that have no observations in the requested window
+            # — retrying won't change that.
+            logger.info(
+                'CO-OPS %s station=%s HTTP %d — not retrying',
+                variable, station_id, status)
+            return None
+
+        try:
+            return response.json()
+        except ValueError as ex:
+            logger.warning(
+                'CO-OPS %s station=%s returned non-JSON body: %s',
+                variable, station_id, ex)
+            return None
+
+    logger.error(
+        'CO-OPS %s retrieval failed for station %s after %d attempts: %s',
+        variable, station_id, _RETRY_MAX_ATTEMPTS, last_exc)
+    return None
 
 
 def retrieve_t_and_c_station(
@@ -202,54 +292,34 @@ def retrieve_t_and_c_station(
             )
 
         if variable in {'water_temperature', 'salinity'}:
-            try:
-                response = _get_session().get(t_c.station_url, timeout=120)
-                response.raise_for_status()
-                obs = response.json()
+            obs = _get_with_retry(
+                t_c.station_url, str(retrieve_input.station), variable,
+                logger)
+            if obs is not None:
                 logger.info(
                     'CO-OPS station %s contacted for %s retrieval.',
                     retrieve_input.station, variable)
-            except requests.exceptions.RequestException as ex_1:
-                logger.error(
-                    'CO-OPS %s observation retrieval failed for station %s! '
-                    '%s',
-                    variable, retrieve_input.station, ex_1
-                )
-                logger.error('Exception caught: %s', ex_1)
-                try:
-                    response_2 = _get_session().get(
-                        t_c.station_url_2, timeout=120)
-                    response_2.raise_for_status()
-                    obs = response_2.json()
+            else:
+                obs = _get_with_retry(
+                    t_c.station_url_2, str(retrieve_input.station),
+                    variable, logger)
+                if obs is not None:
                     logger.info(
-                        'CO-OPS backup station %s contacted for %s retrieval.',
-                        retrieve_input.station, variable)
-                except requests.exceptions.RequestException as ex_2:
-                    logger.error(
-                        'Backup CO-OPS %s observation retrieval failed for '
-                        'station %s! %s',
-                        variable, retrieve_input.station, ex_2
-                    )
-                    logger.error('Exception caught: %s', ex_2)
+                        'CO-OPS backup station %s contacted for %s '
+                        'retrieval.', retrieve_input.station, variable)
+                else:
                     t_c.start_dt += t_c.delta
                     continue
         else:
-            try:
-                response = _get_session().get(t_c.station_url, timeout=120)
-                response.raise_for_status()
-                obs = response.json()
-                logger.info(
-                    'CO-OPS station %s contacted for %s retrieval.',
-                    retrieve_input.station, variable)
-            except requests.exceptions.RequestException as ex:
-                logger.error(
-                    'CO-OPS %s observation retrieval failed for station %s! '
-                    '%s',
-                    variable, retrieve_input.station, ex
-                )
-                logger.error('Exception caught: %s', ex)
+            obs = _get_with_retry(
+                t_c.station_url, str(retrieve_input.station), variable,
+                logger)
+            if obs is None:
                 t_c.start_dt += t_c.delta
                 continue
+            logger.info(
+                'CO-OPS station %s contacted for %s retrieval.',
+                retrieve_input.station, variable)
 
         t_c.date, t_c.var, t_c.drt = [], [], []
         if 'data' in obs.keys():

--- a/src/ofs_skill/obs_retrieval/retrieve_t_and_c_station.py
+++ b/src/ofs_skill/obs_retrieval/retrieve_t_and_c_station.py
@@ -283,7 +283,7 @@ def _fetch_with_backup(
     station_id: str,
     variable: str,
     logger: Logger,
-) -> Optional[dict]:
+) -> tuple[Optional[dict], bool]:
     """Fetch the primary URL with retry; fall back to ``backup_url`` when set.
 
     The water_temperature / salinity backup URL points at the
@@ -292,26 +292,35 @@ def _fetch_with_backup(
     cadence. Mixing the two resolutions silently degrades skill metrics
     that assume uniform sampling, so log a WARNING whenever the backup
     produces data so operators notice the resolution change.
+
+    Returns
+    -------
+    tuple[Optional[dict], bool]
+        ``(obs, used_backup)`` where ``obs`` is the parsed JSON payload
+        (or ``None`` when both endpoints fail / no backup is configured)
+        and ``used_backup`` is ``True`` only when the hourly backup URL
+        actually produced the returned payload. Callers use the flag to
+        count cadence-mixed chunks in end-of-run summaries.
     """
     obs = _get_with_retry(primary_url, station_id, variable, logger)
     if obs is not None:
         logger.info(
             'CO-OPS station %s contacted for %s retrieval.',
             station_id, variable)
-        return obs
+        return obs, False
 
     if backup_url is None:
-        return None
+        return None, False
 
     obs = _get_with_retry(backup_url, station_id, variable, logger)
     if obs is None:
-        return None
+        return None, False
     logger.warning(
         'CO-OPS backup endpoint used for station %s %s - this chunk '
         'returns hourly samples (interval=6) rather than the primary 6-min '
         'cadence; downstream skill metrics may be affected.',
         station_id, variable)
-    return obs
+    return obs, True
 
 
 def get_station_info(
@@ -428,6 +437,14 @@ def retrieve_t_and_c_station(
     t_c.delta = timedelta(days=30)
     t_c.total_date, t_c.total_var, t_c.total_dir = [], [], []
 
+    # Chunk accounting for end-of-run summary (issue: silent data loss
+    # and hourly-backup usage were only visible via scattered WARNING
+    # lines before). Counters are grep'd from operator logs via the
+    # 'CO-OPS retrieval summary' prefix emitted below.
+    chunks_attempted = 0
+    chunks_dropped = 0
+    chunks_hourly_backup = 0
+
     while t_c.start_dt <= t_c.end_dt:
         date_i = (
             t_c.start_dt.strftime('%Y') +
@@ -489,10 +506,14 @@ def retrieve_t_and_c_station(
         backup_url = (t_c.station_url_2
                       if variable in {'water_temperature', 'salinity'}
                       else None)
-        obs = _fetch_with_backup(
+        chunks_attempted += 1
+        obs, used_backup = _fetch_with_backup(
             t_c.station_url, backup_url, str(retrieve_input.station),
             variable, logger)
+        if used_backup:
+            chunks_hourly_backup += 1
         if obs is None:
+            chunks_dropped += 1
             t_c.start_dt += t_c.delta
             continue
 
@@ -522,6 +543,24 @@ def retrieve_t_and_c_station(
                 t_c.total_dir.append(t_c.drt)
 
         t_c.start_dt += t_c.delta
+
+    # End-of-run summary so operators notice silent chunk drops or
+    # cadence mixing without scanning every WARNING. Severity escalates
+    # when any data was dropped or any chunk used the hourly backup.
+    summary_msg = (
+        'CO-OPS retrieval summary station=%s variable=%s '
+        'date_range=%s-%s chunks_attempted=%d chunks_dropped=%d '
+        'chunks_hourly_backup=%d'
+    )
+    summary_args = (
+        str(retrieve_input.station), variable,
+        retrieve_input.start_date, retrieve_input.end_date,
+        chunks_attempted, chunks_dropped, chunks_hourly_backup,
+    )
+    if chunks_dropped > 0 or chunks_hourly_backup > 0:
+        logger.warning(summary_msg, *summary_args)
+    else:
+        logger.info(summary_msg, *summary_args)
 
     # Non-currents variables report a single depth per station; currents
     # returns per-bin frames via ``_retrieve_currents_all_bins`` (dispatched

--- a/src/ofs_skill/obs_retrieval/retrieve_t_and_c_station.py
+++ b/src/ofs_skill/obs_retrieval/retrieve_t_and_c_station.py
@@ -203,6 +203,21 @@ def _get_with_retry(
     for attempt in range(1, _RETRY_MAX_ATTEMPTS + 1):
         try:
             response = _rate_limited_get(url, timeout=120)
+        except (requests.exceptions.SSLError,
+                requests.exceptions.InvalidURL,
+                requests.exceptions.MissingSchema,
+                requests.exceptions.InvalidSchema) as ex:
+            # SSL validation or URL-construction failures indicate a
+            # configuration problem (or MITM risk) rather than "no
+            # data". Escalate to ERROR so operators notice; still
+            # return None so retrieval soft-fails instead of crashing
+            # the whole run. NOTE: SSLError subclasses ConnectionError,
+            # so this branch MUST come before the ConnectionError catch
+            # below or it will be masked.
+            logger.error(
+                'CO-OPS %s station=%s SSL/URL error (not retried): %s',
+                context, station_id, ex)
+            return None
         except (requests.exceptions.ConnectionError,
                 requests.exceptions.Timeout) as ex:
             last_exc = ex

--- a/src/ofs_skill/obs_retrieval/retrieve_t_and_c_station.py
+++ b/src/ofs_skill/obs_retrieval/retrieve_t_and_c_station.py
@@ -97,18 +97,27 @@ _RETRY_BASE_DELAY = 2.0  # seconds; exponential backoff per attempt
 _RETRY_JITTER_MAX = 0.5  # seconds; random jitter added on top of exponential backoff
 
 
+def _backoff_delay(attempt: int) -> float:
+    """Return seconds to sleep before the next retry attempt."""
+    return (_RETRY_BASE_DELAY * (2 ** (attempt - 1))
+            + random.uniform(0, _RETRY_JITTER_MAX))
+
+
 def _get_with_retry(
     url: str,
     station_id: str,
-    variable: str,
+    context: str,
     logger: Logger,
 ) -> Optional[dict]:
     """GET ``url`` with retries for transient CO-OPS errors.
 
     Retries only on network-level failures (ConnectionError, Timeout) or
     HTTP status codes in ``_RETRY_STATUSES``. Permanent HTTP errors such
-    as 400 (bad station/date combo — CO-OPS "no data") or 404 fail
+    as 400 (bad station/date combo - CO-OPS "no data") or 404 fail
     immediately without burning the retry budget.
+
+    ``context`` is a free-form label (variable name, bin number, etc.)
+    included in log messages so parallel workers can be disambiguated.
 
     Returns the parsed JSON payload on success, ``None`` when the call
     hits a non-retryable error or all retries are exhausted.
@@ -119,45 +128,47 @@ def _get_with_retry(
             response = _get_session().get(url, timeout=120)
         except (requests.exceptions.ConnectionError,
                 requests.exceptions.Timeout) as ex:
-            # Network-level failure: retry.
             last_exc = ex
             if attempt < _RETRY_MAX_ATTEMPTS:
-                delay = _RETRY_BASE_DELAY * (2 ** (attempt - 1))
-                delay += random.uniform(0, _RETRY_JITTER_MAX)
+                delay = _backoff_delay(attempt)
                 logger.warning(
                     'CO-OPS %s station=%s network error (attempt %d/%d): '
-                    '%s; retrying in %.1fs', variable, station_id,
+                    '%s; retrying in %.1fs', context, station_id,
                     attempt, _RETRY_MAX_ATTEMPTS, ex, delay)
                 time.sleep(delay)
                 continue
             break
         except requests.exceptions.RequestException as ex:
-            # Some other non-retryable request-layer error.
             logger.warning(
                 'CO-OPS %s station=%s non-retryable request error: %s',
-                variable, station_id, ex)
+                context, station_id, ex)
             return None
 
         status = response.status_code
-        if status in _RETRY_STATUSES and attempt < _RETRY_MAX_ATTEMPTS:
-            delay = _RETRY_BASE_DELAY * (2 ** (attempt - 1))
-            delay += random.uniform(0, _RETRY_JITTER_MAX)
-            logger.warning(
-                'CO-OPS %s station=%s HTTP %d (attempt %d/%d); '
-                'retrying in %.1fs', variable, station_id, status,
-                attempt, _RETRY_MAX_ATTEMPTS, delay)
-            time.sleep(delay)
-            continue
+        if status in _RETRY_STATUSES:
+            if attempt < _RETRY_MAX_ATTEMPTS:
+                delay = _backoff_delay(attempt)
+                logger.warning(
+                    'CO-OPS %s station=%s HTTP %d (attempt %d/%d); '
+                    'retrying in %.1fs', context, station_id, status,
+                    attempt, _RETRY_MAX_ATTEMPTS, delay)
+                time.sleep(delay)
+                continue
+            logger.error(
+                'CO-OPS %s station=%s HTTP %d - retries exhausted '
+                'after %d attempts; dropping chunk',
+                context, station_id, status, _RETRY_MAX_ATTEMPTS)
+            return None
 
         if status >= 400:
-            # Non-retryable 4xx/5xx (400, 401, 404, etc.) or exhausted
-            # retries on retryable codes: fail without consuming more
-            # attempts. CO-OPS returns 400 with "No data was found" for
-            # stations that have no observations in the requested window
-            # — retrying won't change that.
-            logger.info(
-                'CO-OPS %s station=%s HTTP %d — not retrying',
-                variable, station_id, status)
+            # Non-retryable 4xx/5xx (400, 401, 404, etc.) - fail fast.
+            # CO-OPS returns 400 "No data was found" for stations with
+            # no observations in the requested window; retrying won't
+            # change that. Logged at WARNING because the chunk is
+            # dropped silently and operators should notice.
+            logger.warning(
+                'CO-OPS %s station=%s HTTP %d - not retrying '
+                '(dropping chunk)', context, station_id, status)
             return None
 
         try:
@@ -165,13 +176,50 @@ def _get_with_retry(
         except ValueError as ex:
             logger.warning(
                 'CO-OPS %s station=%s returned non-JSON body: %s',
-                variable, station_id, ex)
+                context, station_id, ex)
             return None
 
     logger.error(
         'CO-OPS %s retrieval failed for station %s after %d attempts: %s',
-        variable, station_id, _RETRY_MAX_ATTEMPTS, last_exc)
+        context, station_id, _RETRY_MAX_ATTEMPTS, last_exc)
     return None
+
+
+def _fetch_with_backup(
+    primary_url: str,
+    backup_url: Optional[str],
+    station_id: str,
+    variable: str,
+    logger: Logger,
+) -> Optional[dict]:
+    """Fetch the primary URL with retry; fall back to ``backup_url`` when set.
+
+    The water_temperature / salinity backup URL points at the
+    ``NOS.COOPS.TAC.PHYSOCEAN`` endpoint with ``interval=6``, which
+    returns HOURLY observations rather than the primary's 6-minute
+    cadence. Mixing the two resolutions silently degrades skill metrics
+    that assume uniform sampling, so log a WARNING whenever the backup
+    produces data so operators notice the resolution change.
+    """
+    obs = _get_with_retry(primary_url, station_id, variable, logger)
+    if obs is not None:
+        logger.info(
+            'CO-OPS station %s contacted for %s retrieval.',
+            station_id, variable)
+        return obs
+
+    if backup_url is None:
+        return None
+
+    obs = _get_with_retry(backup_url, station_id, variable, logger)
+    if obs is None:
+        return None
+    logger.warning(
+        'CO-OPS backup endpoint used for station %s %s - this chunk '
+        'returns hourly samples (interval=6) rather than the primary 6-min '
+        'cadence; downstream skill metrics may be affected.',
+        station_id, variable)
+    return obs
 
 
 def retrieve_t_and_c_station(
@@ -291,35 +339,15 @@ def retrieve_t_and_c_station(
                 f'gmt&units=metric&format=json'
             )
 
-        if variable in {'water_temperature', 'salinity'}:
-            obs = _get_with_retry(
-                t_c.station_url, str(retrieve_input.station), variable,
-                logger)
-            if obs is not None:
-                logger.info(
-                    'CO-OPS station %s contacted for %s retrieval.',
-                    retrieve_input.station, variable)
-            else:
-                obs = _get_with_retry(
-                    t_c.station_url_2, str(retrieve_input.station),
-                    variable, logger)
-                if obs is not None:
-                    logger.info(
-                        'CO-OPS backup station %s contacted for %s '
-                        'retrieval.', retrieve_input.station, variable)
-                else:
-                    t_c.start_dt += t_c.delta
-                    continue
-        else:
-            obs = _get_with_retry(
-                t_c.station_url, str(retrieve_input.station), variable,
-                logger)
-            if obs is None:
-                t_c.start_dt += t_c.delta
-                continue
-            logger.info(
-                'CO-OPS station %s contacted for %s retrieval.',
-                retrieve_input.station, variable)
+        backup_url = (t_c.station_url_2
+                      if variable in {'water_temperature', 'salinity'}
+                      else None)
+        obs = _fetch_with_backup(
+            t_c.station_url, backup_url, str(retrieve_input.station),
+            variable, logger)
+        if obs is None:
+            t_c.start_dt += t_c.delta
+            continue
 
         t_c.date, t_c.var, t_c.drt = [], [], []
         if 'data' in obs.keys():

--- a/src/ofs_skill/obs_retrieval/write_obs_ctlfile.py
+++ b/src/ofs_skill/obs_retrieval/write_obs_ctlfile.py
@@ -64,6 +64,7 @@ def _process_coops_station(id_number, name, x_value, y_value,
             retrieve_t_and_c_station(
                 retrieve_input,logger)
         if variable == 'water_level':
+            datum_found = None
             if (isinstance(timeseries, pd.DataFrame)
                 is False):
                 all_datums = ['NAVD','MSL','MLLW',
@@ -125,6 +126,15 @@ def _process_coops_station(id_number, name, x_value, y_value,
                             ) from ex
             else:
                 datum_found = datum
+            if not datum_found:
+                logger.info(
+                    'After trying multiple '
+                    'datums, no water '
+                    'level data found for '
+                    'station %s.',
+                    str(id_number)
+                    )
+                return None
             if ofs not in [
                     'leofs',
                     'lmhofs',
@@ -137,6 +147,8 @@ def _process_coops_station(id_number, name, x_value, y_value,
                       str(datum_found).upper() in
                       datum_list):
                     ldatum = datum.lower()
+                    if ldatum == 'navd':
+                        ldatum = 'navd88'
                     dummyval = 10
                     _,_,z = vdatum.convert(
                         str(datum_found).lower(),
@@ -272,6 +284,8 @@ def _process_usgs_station(id_number, name, x_value, y_value,
                             ) == 'NAVD88' and
                             datum != 'NAVD88'):
                         ldatum = datum.lower()
+                        if ldatum == 'navd':
+                            ldatum = 'navd88'
                         dummyval = 10
                         _,_,z = vdatum.convert(
                             timeseries['Datum'][1].lower(),
@@ -371,6 +385,8 @@ def _process_ndbc_station(id_number, name, x_value, y_value,
                     ) == 'MLLW' and
                     datum != 'MLLW'):
                 ldatum = datum.lower()
+                if ldatum == 'navd':
+                    ldatum = 'navd88'
                 dummyval = 10
                 _,_,z = vdatum.convert(
                     data_station['Datum'][1].lower(),
@@ -468,6 +484,8 @@ def _process_chs_station(id_number, name, x_value, y_value,
                     zdiff = 0
                 else:
                     ldatum = datum.lower()
+                    if ldatum == 'navd':
+                        ldatum = 'navd88'
                     dummyval = 10
                     _,_,z = vdatum.convert(
                         data_station['Datum'][1].lower(),

--- a/src/ofs_skill/obs_retrieval/write_obs_ctlfile.py
+++ b/src/ofs_skill/obs_retrieval/write_obs_ctlfile.py
@@ -56,6 +56,21 @@ _USGS_MAX_WORKERS_WITH_KEY = 4
 _USGS_MAX_WORKERS_NO_KEY = 2
 
 
+def _normalize_vdatum_name(name: str) -> str:
+    """Canonicalize short datum aliases to the full names expected downstream.
+
+    The CO-OPS API accepts ``'NAVD'`` as shorthand for NAVD88, but downstream
+    readers (``plotting_scalar.py``, ``write_ofs_ctlfile.py``) key off the
+    canonical ``'NAVD88'`` label. Returns the input unchanged unless it is a
+    known short alias.
+    """
+    if name is None:
+        return name
+    if str(name).upper() == 'NAVD':
+        return 'NAVD88'
+    return name
+
+
 def _emit_coops_currents_entries(
     id_number, name, x_value, y_value, ofs, name_var,
     timeseries, bin_overrides, logger,
@@ -207,10 +222,8 @@ def _process_coops_station(id_number, name, x_value, y_value,
                         if ((isinstance(timeseries, pd.DataFrame) is \
                             True) and
                             (all_datums[data] in accepted_datums)):
-                            datum_found = \
-                                all_datums [data]
-                            if str(datum_found) == 'NAVD':
-                                datum_found = 'NAVD88'
+                            datum_found = _normalize_vdatum_name(
+                                all_datums [data])
                             # if str(datum_found) == 'IGLD':
                             #     datum_found = 'IGLD85'
                             logger.info(
@@ -235,7 +248,7 @@ def _process_coops_station(id_number, name, x_value, y_value,
                             'data!'
                             ) from ex
             else:
-                datum_found = datum
+                datum_found = _normalize_vdatum_name(datum)
             if not datum_found:
                 logger.info(
                     'After trying multiple '
@@ -251,14 +264,17 @@ def _process_coops_station(id_number, name, x_value, y_value,
                     'loofs',
                     'lsofs'
                     ]:
-                if (str(datum_found).upper() == datum):
+                # Compare canonical names so the happy-path short-circuit
+                # (zdiff=0) triggers even when the request used the CO-OPS
+                # short alias 'NAVD' and ``datum_found`` was canonicalized
+                # to 'NAVD88'.
+                datum_canonical = _normalize_vdatum_name(datum).upper()
+                if (str(datum_found).upper() == datum_canonical):
                     zdiff = 0
-                elif (str(datum_found).upper() != datum and
+                elif (str(datum_found).upper() != datum_canonical and
                       str(datum_found).upper() in
                       datum_list):
-                    ldatum = datum.lower()
-                    if ldatum == 'navd':
-                        ldatum = 'navd88'
+                    ldatum = _normalize_vdatum_name(datum).lower()
                     dummyval = 10
                     _,_,z = vdatum.convert(
                         str(datum_found).lower(),
@@ -389,9 +405,7 @@ def _process_usgs_station(id_number, name, x_value, y_value,
                             timeseries ['Datum'][1]
                             ) == 'NAVD88' and
                             datum != 'NAVD88'):
-                        ldatum = datum.lower()
-                        if ldatum == 'navd':
-                            ldatum = 'navd88'
+                        ldatum = _normalize_vdatum_name(datum).lower()
                         dummyval = 10
                         _,_,z = vdatum.convert(
                             timeseries['Datum'][1].lower(),
@@ -494,9 +508,7 @@ def _process_ndbc_station(id_number, name, x_value, y_value,
                     data_station['Datum'][1]
                     ) == 'MLLW' and
                     datum != 'MLLW'):
-                ldatum = datum.lower()
-                if ldatum == 'navd':
-                    ldatum = 'navd88'
+                ldatum = _normalize_vdatum_name(datum).lower()
                 dummyval = 10
                 _,_,z = vdatum.convert(
                     data_station['Datum'][1].lower(),
@@ -598,9 +610,7 @@ def _process_chs_station(id_number, name, x_value, y_value,
                         ).upper() == datum):
                     zdiff = 0
                 else:
-                    ldatum = datum.lower()
-                    if ldatum == 'navd':
-                        ldatum = 'navd88'
+                    ldatum = _normalize_vdatum_name(datum).lower()
                     dummyval = 10
                     _,_,z = vdatum.convert(
                         data_station['Datum'][1].lower(),


### PR DESCRIPTION
### Description of Changes

This PR fixes critical bugs in NAVD (North American Vertical Datum) handling and improves resilience for CO-OPS API interactions. The changes address issues with datum conversion initialization, graceful error handling, and concurrency management when retrieving water level and temperature/salinity observations from NOAA's CO-OPS stations.

#### 1. NAVD Datum Handling
The datum conversion logic was not properly initialized before use, causing failures when converting water level data to NAVD88. The code now ensures `datum_found` is explicitly set to `None` before the datum loop and checks if a valid datum was found before proceeding.

#### 2. Datum Abbreviation Mapping
NAVD was being passed directly to vdatum conversion functions expecting 'navd88'. Added explicit conversion of 'navd' → 'navd88' in all station processing functions (CO-OPS, USGS, NDBC, CHS).

#### 3. CO-OPS API Resilience
- Added module-level concurrency control (semaphore) to prevent overwhelming CO-OPS servers when many historical data requests run in parallel
- Implemented full-jitter exponential backoff for transient HTTP errors (403, 408, 429, 5xx)
- Added per-request pacing to enforce minimum gaps between CO-OPS requests
- Refined error handling to distinguish between retryable and permanent failures

#### 4. Network Error Handling
Added `urllib.error.URLError` to exception handling in inventory retrieval for better coverage of network-level failures.

#### 5. Empty Response Handling
Added early return when CO-OPS water level data retrieval returns empty results, preventing downstream processing of invalid data.

#### 6. CLI Argument Validation Bug
Fixed incorrect condition checking `args.FileType` instead of `args.Station_Owner` when parsing station owner arguments.

### Expected Outcome of Changes

-Successful retrieval of historical CO-OPS observations for all stations.
-Error-free NAVD88 datum conversions.

### Developer Questions and Checklist
**Is this a high priority PR? If yes, why and is there a date by which it needs to be merged?**
No.

**Are there any changes needed to how the code should be run on the server? (Commands, flags, job timings, etc.)**
No.

**Does this update need to be installed on the server?**
Yes.

**Does this update require front end/web app changes? (If yes, provide documentation to Min)**
No.

**Does this impact code development work on adding SCHISM? (If yes, tag Atieh)**
No.

**Does this impact code development work on adding ADCIRC?**
_No/Yes + tag Jack if yes_
No.

**Does this impact the expected number of output files for integration tests (i.e., will the integration test fail even though code changes result in desired change in the number of outputs?)**
No.

- [x] Developer's name is removed throughout the code?
- [x] Did you add relevant labels to the PR?
- [x] Have you run pylint and is the code at an acceptable pylint score? (>8.0)
- [x] Jobs contain the appropriate file checking and handle errors for any missing data?
- [x] Is log free of critical ERRORs or WARNINGs? For errors that are not critical and can remain in code, is there sufficient handling and logging?

### Testing Instructions
- [x] Test long-duration (14+ month) skill assessments with multiple stations
- [x] Verify NAVD88 datum conversions work across all observation providers
- [x] Monitor for CO-OPS throttling errors (should be minimal now)
- [x] Test with poor network conditions to verify retry logic

### Reminder checklist for PR reviewer:
- [x] Run PEP8 compliance tests to ensure the code follows best practices
- [x] Check that documentation in the script is sufficient
- [x] Validate the output values (if applicable) to make sure the calculations are correct and make scientific/physical sense; include a comment on the pull request including what validation you performed, for replicability.
- [x] Test code both locally and on the linux server, using several OFS as test cases
- [x] **Test for all ‘cast’ options: forecast_a, forecast_b, and nowcast**
- [x] When approving or commenting on a pull request, add information on the calls you use in case they need to be replicated.
