### PR TITLE
Fix forecast_a loading wrong cycle in list_of_files

### DIFF
--- a/src/ofs_skill/model_processing/list_of_files.py
+++ b/src/ofs_skill/model_processing/list_of_files.py
@@ -902,7 +902,11 @@ def list_of_files(prop: Any, dir_list: list[str], logger: Logger) -> list[str]:
                     continue
                 files = []
                 hr_cyc_day = []
-                cycle_z = a_start[-2:] + 'z'
+                # Use prop.forecast_hr (set canonically by get_skill before
+                # this runs) — prop.startdate has the hour stripped by
+                # get_node_ofs, so a_start[-2:] is always '00' and would
+                # match the wrong cycle regardless of the user's -f flag.
+                cycle_z = prop.forecast_hr.lower()
                 skipped_files = []
                 for af_name in all_files:
                     try:

--- a/src/ofs_skill/skill_assessment/get_skill.py
+++ b/src/ofs_skill/skill_assessment/get_skill.py
@@ -29,6 +29,40 @@ from ofs_skill.skill_assessment.make_skill_maps import make_skill_maps
 from ofs_skill.tidal_analysis.extremes import extract_water_level_extrema
 
 
+def _cache_key(prop):
+    """Fields that uniquely determine the model dataset loaded by get_node_ofs.
+
+    When any of these change on `prop`, the cached dataset is stale and must
+    not be reused (it was built from a different set of source files).
+    """
+    return (
+        getattr(prop, 'ofs', None),
+        getattr(prop, 'whichcast', None),
+        getattr(prop, 'forecast_hr', None),
+        getattr(prop, 'start_date_full', None),
+        getattr(prop, 'end_date_full', None),
+        getattr(prop, 'ofsfiletype', None),
+    )
+
+
+def _get_valid_cached_model(prop):
+    """Return the cached model only if it was loaded under the current key."""
+    cached = getattr(prop, '_cached_model', None)
+    if cached is None:
+        return None
+    if getattr(prop, '_cached_model_key', None) != _cache_key(prop):
+        return None
+    return cached
+
+
+def _set_cached_model(prop, dataset):
+    """Stamp the dataset with the current key when caching."""
+    if dataset is None:
+        return
+    prop._cached_model = dataset
+    prop._cached_model_key = _cache_key(prop)
+
+
 def ofs_ctlfile_extract(prop, name_var, logger, model_dataset=None):
     """
     Extract info from model control files. If control file does not exist,
@@ -46,16 +80,14 @@ def ofs_ctlfile_extract(prop, name_var, logger, model_dataset=None):
         if not os.path.isfile(ctl_path):
             result = get_node_ofs(prop, logger,
                                   model_dataset=model_dataset)
-            if result is not None:
-                prop._cached_model = result
+            _set_cached_model(prop, result)
     elif prop.ofsfiletype == 'stations':
         ctl_path = os.path.join(prop.control_files_path,
                             str(prop.ofs+'_'+name_var+'_model_station.ctl'))
         if not os.path.isfile(ctl_path):
             result = get_node_ofs(prop, logger,
                                   model_dataset=model_dataset)
-            if result is not None:
-                prop._cached_model = result
+            _set_cached_model(prop, result)
 
     try:
         if os.path.getsize(ctl_path) > 0:
@@ -172,11 +204,10 @@ def prepare_series(read_station_ctl_file, read_ofs_ctl_file, prop,
                     'Calling OFS module for %s',
                     prop.whichcast,
                 )
-                cached = getattr(prop, '_cached_model', None)
+                cached = _get_valid_cached_model(prop)
                 result = get_node_ofs(prop, logger,
                                       model_dataset=cached)
-                if result is not None:
-                    prop._cached_model = result
+                _set_cached_model(prop, result)
 
             ofs_df = pd.read_csv(prd_path,
                 sep=r'\s+',
@@ -792,11 +823,13 @@ def get_skill(prop, logger):
         # Ensure model ctl file exists (depends on station ctl file)
         logger.info('Searching for the %s %s model control files',
                     p.ofs, variable)
-        cached_model = getattr(p, '_cached_model', None)
+        cached_model = _get_valid_cached_model(p)
         read_ofs_ctl_file = ofs_ctlfile_extract(
             p, name_var, logger, model_dataset=cached_model
         )  # lines, nodes, depths, shifts, ids
-        cached_model = getattr(p, '_cached_model', cached_model)
+        refreshed = _get_valid_cached_model(p)
+        if refreshed is not None:
+            cached_model = refreshed
 
         if read_ofs_ctl_file is None:
             logger.info('Model ctl file for %s and %s is empty.',
@@ -816,15 +849,13 @@ def get_skill(prop, logger):
                     copy.copy(p), name_var, logger, cached_model)
                 obs_future.result()
                 cached_model = prd_future.result()
-                if cached_model is not None:
-                    p._cached_model = cached_model
+                _set_cached_model(p, cached_model)
         else:
             # Sequential: check obs files, then prd files
             _ensure_obs_files(read_station_ctl_file, p, name_var, logger)
             cached_model = _ensure_prd_files(
                 read_ofs_ctl_file, p, name_var, logger, cached_model)
-            if cached_model is not None:
-                p._cached_model = cached_model
+            _set_cached_model(p, cached_model)
 
         if read_ofs_ctl_file is not None:
             skill_results = skill(

--- a/tests/get_skill_cache_test.py
+++ b/tests/get_skill_cache_test.py
@@ -1,0 +1,118 @@
+"""
+Unit tests for the provenance-tagged model cache in get_skill.
+
+Validates that _cache_key / _get_valid_cached_model / _set_cached_model
+correctly invalidate the cache when any loader input on prop changes,
+preventing nowcast data from leaking into forecast_b .prd files (and vice
+versa) across multi-whichcast runs.
+"""
+
+import pytest
+
+from ofs_skill.skill_assessment.get_skill import (
+    _cache_key,
+    _get_valid_cached_model,
+    _set_cached_model,
+)
+
+
+class MockProps:
+    """Minimal prop object carrying only the fields the cache key reads."""
+
+    def __init__(self, ofs='cbofs', whichcast='nowcast',
+                 forecast_hr=None, start_date_full='2026-03-28T00:00:00Z',
+                 end_date_full='2026-03-28T23:00:00Z',
+                 ofsfiletype='stations'):
+        self.ofs = ofs
+        self.whichcast = whichcast
+        self.forecast_hr = forecast_hr
+        self.start_date_full = start_date_full
+        self.end_date_full = end_date_full
+        self.ofsfiletype = ofsfiletype
+
+
+@pytest.fixture
+def props():
+    return MockProps()
+
+
+def _sentinel(tag):
+    """Distinguishable stand-in for an xarray.Dataset."""
+    return {'_sentinel': tag}
+
+
+def test_cache_reused_when_key_matches(props):
+    ds = _sentinel('nowcast-ds')
+    _set_cached_model(props, ds)
+    assert _get_valid_cached_model(props) is ds
+
+
+def test_cache_invalidated_on_whichcast_change(props):
+    _set_cached_model(props, _sentinel('nowcast-ds'))
+    props.whichcast = 'forecast_b'
+    assert _get_valid_cached_model(props) is None
+
+
+def test_cache_invalidated_on_forecast_hr_change(props):
+    props.whichcast = 'forecast_a'
+    props.forecast_hr = '06z'
+    _set_cached_model(props, _sentinel('fa-06z-ds'))
+    props.forecast_hr = '12z'
+    assert _get_valid_cached_model(props) is None
+
+
+def test_cache_invalidated_on_start_date_change(props):
+    _set_cached_model(props, _sentinel('ds'))
+    props.start_date_full = '2026-04-01T00:00:00Z'
+    assert _get_valid_cached_model(props) is None
+
+
+def test_cache_invalidated_on_end_date_change(props):
+    _set_cached_model(props, _sentinel('ds'))
+    props.end_date_full = '2026-04-01T23:00:00Z'
+    assert _get_valid_cached_model(props) is None
+
+
+def test_cache_invalidated_on_ofsfiletype_change(props):
+    _set_cached_model(props, _sentinel('stations-ds'))
+    props.ofsfiletype = 'fields'
+    assert _get_valid_cached_model(props) is None
+
+
+def test_cache_invalidated_on_ofs_change(props):
+    _set_cached_model(props, _sentinel('cbofs-ds'))
+    props.ofs = 'sfbofs'
+    assert _get_valid_cached_model(props) is None
+
+
+def test_set_cached_model_ignores_none(props):
+    _set_cached_model(props, None)
+    assert not hasattr(props, '_cached_model')
+    assert not hasattr(props, '_cached_model_key')
+
+
+def test_no_key_attribute_treated_as_miss(props):
+    # Simulate a prop that has _cached_model from some pre-helper code path
+    # but no _cached_model_key stamp. Must be treated as a miss so the
+    # provenance contract holds.
+    props._cached_model = _sentinel('untagged-ds')
+    assert _get_valid_cached_model(props) is None
+
+
+def test_cache_key_is_tuple_of_six_fields(props):
+    key = _cache_key(props)
+    assert isinstance(key, tuple)
+    assert len(key) == 6
+    assert key == ('cbofs', 'nowcast', None,
+                   '2026-03-28T00:00:00Z', '2026-03-28T23:00:00Z',
+                   'stations')
+
+
+def test_round_trip_after_invalidation_and_reset(props):
+    """After invalidation, re-stamping under the new key should hit again."""
+    _set_cached_model(props, _sentinel('nowcast-ds'))
+    props.whichcast = 'forecast_b'
+    assert _get_valid_cached_model(props) is None
+    new_ds = _sentinel('forecast_b-ds')
+    _set_cached_model(props, new_ds)
+    assert _get_valid_cached_model(props) is new_ds

--- a/tests/get_skill_multi_whichcast_test.py
+++ b/tests/get_skill_multi_whichcast_test.py
@@ -1,0 +1,205 @@
+"""
+Integration tests for the multi-whichcast bug fix in get_skill.
+
+These tests exercise the real cache-consumption path in
+`ofs_ctlfile_extract` (the first thing `_skill_for_variable` calls) and
+mirror the caller pattern in `_skill_for_variable` itself. They prove that
+after a whichcast mutation on `prop`, the next call to get_node_ofs
+receives `model_dataset=None` so that a fresh intake_model runs against
+the new file list — fixing the reported bug where forecast_b .prd files
+were written from nowcast data.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ofs_skill.skill_assessment.get_skill import (
+    _get_valid_cached_model,
+    _set_cached_model,
+    ofs_ctlfile_extract,
+)
+
+
+class MockLogger:
+    def info(self, *a, **k): pass
+    def warning(self, *a, **k): pass
+    def error(self, *a, **k): pass
+    def debug(self, *a, **k): pass
+
+
+class MockProps:
+    def __init__(self, whichcast='nowcast', ofsfiletype='stations',
+                 forecast_hr=None,
+                 start_date_full='2026-03-28T00:00:00Z',
+                 end_date_full='2026-03-28T23:00:00Z'):
+        self.ofs = 'cbofs'
+        self.whichcast = whichcast
+        self.ofsfiletype = ofsfiletype
+        self.forecast_hr = forecast_hr
+        self.start_date_full = start_date_full
+        self.end_date_full = end_date_full
+        self.control_files_path = '/fake/control_files'
+
+
+@pytest.fixture
+def logger():
+    return MockLogger()
+
+
+def _sentinel(tag):
+    return MagicMock(name=f'dataset-{tag}', spec=['__class__'])
+
+
+# ---------------------------------------------------------------------------
+# Direct caller-pattern tests: exercise the exact sequence _skill_for_variable
+# uses, without needing to run the full get_skill orchestrator.
+# ---------------------------------------------------------------------------
+
+def test_nowcast_then_forecast_b_re_invokes_intake(logger):
+    """The reported bug: switching whichcast must not pass a stale cache."""
+    prop = MockProps(whichcast='nowcast')
+
+    # Load 1: nowcast
+    cached = _get_valid_cached_model(prop)
+    assert cached is None, 'no cache on first call'
+    nowcast_ds = _sentinel('nowcast')
+    _set_cached_model(prop, nowcast_ds)
+
+    # Caller mutates whichcast (as create_1dplot.py:119 does)
+    prop.whichcast = 'forecast_b'
+
+    # Load 2: forecast_b — caller queries cache again
+    cached = _get_valid_cached_model(prop)
+    assert cached is None, (
+        'stale nowcast cache must NOT be returned for forecast_b — '
+        'this is the bug'
+    )
+
+    # Simulate the forecast_b intake returning a new dataset
+    forecast_b_ds = _sentinel('forecast_b')
+    _set_cached_model(prop, forecast_b_ds)
+    assert _get_valid_cached_model(prop) is forecast_b_ds
+
+
+def test_same_whichcast_reuses_cache(logger):
+    """Guard against over-invalidation — same whichcast must hit."""
+    prop = MockProps(whichcast='nowcast')
+    ds = _sentinel('nowcast')
+    _set_cached_model(prop, ds)
+
+    # Second lookup under the same state — must reuse.
+    assert _get_valid_cached_model(prop) is ds
+
+
+def test_forecast_a_cycle_change_invalidates(logger):
+    """forecast_a with different forecast_hr must re-load."""
+    prop = MockProps(whichcast='forecast_a', forecast_hr='06z')
+    _set_cached_model(prop, _sentinel('fa-06z'))
+    prop.forecast_hr = '12z'
+    assert _get_valid_cached_model(prop) is None
+
+
+def test_date_range_change_invalidates(logger):
+    """A different run date range must re-load even at same whichcast."""
+    prop = MockProps(whichcast='nowcast')
+    _set_cached_model(prop, _sentinel('march-28'))
+    prop.start_date_full = '2026-03-29T00:00:00Z'
+    prop.end_date_full = '2026-03-29T23:00:00Z'
+    assert _get_valid_cached_model(prop) is None
+
+
+# ---------------------------------------------------------------------------
+# ofs_ctlfile_extract integration: real function, mocked filesystem +
+# get_node_ofs. Proves the helpers land correctly in production code.
+# ---------------------------------------------------------------------------
+
+@patch('ofs_skill.skill_assessment.get_skill.os.path.getsize', return_value=0)
+@patch('ofs_skill.skill_assessment.get_skill.os.path.isfile',
+       return_value=False)
+@patch('ofs_skill.skill_assessment.get_skill.get_node_ofs')
+def test_ofs_ctlfile_extract_caches_then_reuses(
+        mock_get_node_ofs, mock_isfile, mock_getsize, logger):
+    """First call triggers get_node_ofs; cache is stamped; second call
+    under same whichcast reuses the stamped dataset."""
+    nowcast_ds = _sentinel('nowcast')
+    mock_get_node_ofs.return_value = nowcast_ds
+
+    prop = MockProps(whichcast='nowcast', ofsfiletype='stations')
+
+    # First pass: cache is empty, caller reads with _get_valid_cached_model.
+    cached = _get_valid_cached_model(prop)
+    ofs_ctlfile_extract(prop, 'wl', logger, model_dataset=cached)
+
+    assert mock_get_node_ofs.call_count == 1
+    assert mock_get_node_ofs.call_args.kwargs['model_dataset'] is None
+    assert _get_valid_cached_model(prop) is nowcast_ds
+
+
+@patch('ofs_skill.skill_assessment.get_skill.os.path.getsize', return_value=0)
+@patch('ofs_skill.skill_assessment.get_skill.os.path.isfile',
+       return_value=False)
+@patch('ofs_skill.skill_assessment.get_skill.get_node_ofs')
+def test_ofs_ctlfile_extract_rejects_stale_cache_across_whichcasts(
+        mock_get_node_ofs, mock_isfile, mock_getsize, logger):
+    """Direct reproducer: nowcast run stamps cache, then caller switches
+    to forecast_b. The caller's _get_valid_cached_model must return None,
+    so get_node_ofs is invoked fresh and writes forecast_b-sourced .prd."""
+    nowcast_ds = _sentinel('nowcast')
+    forecast_b_ds = _sentinel('forecast_b')
+    mock_get_node_ofs.side_effect = [nowcast_ds, forecast_b_ds]
+
+    prop = MockProps(whichcast='nowcast', ofsfiletype='stations')
+
+    # ---- Round 1: nowcast ----
+    cached = _get_valid_cached_model(prop)
+    ofs_ctlfile_extract(prop, 'wl', logger, model_dataset=cached)
+
+    # ---- Driver mutates whichcast (matches create_1dplot.py:119) ----
+    prop.whichcast = 'forecast_b'
+
+    # ---- Round 2: forecast_b ----
+    cached = _get_valid_cached_model(prop)
+    # This is the critical assertion: the caller receives None, NOT the
+    # stale nowcast dataset. Previously this returned nowcast_ds, which
+    # was forwarded into get_node_ofs and skipped intake_model, causing
+    # the bug.
+    assert cached is None, (
+        'stale nowcast cache leaked into forecast_b — this is the bug'
+    )
+    ofs_ctlfile_extract(prop, 'wl', logger, model_dataset=cached)
+
+    # get_node_ofs called twice, second call with model_dataset=None.
+    assert mock_get_node_ofs.call_count == 2
+    first_call_kwargs = mock_get_node_ofs.call_args_list[0].kwargs
+    second_call_kwargs = mock_get_node_ofs.call_args_list[1].kwargs
+    assert first_call_kwargs['model_dataset'] is None
+    assert second_call_kwargs['model_dataset'] is None
+
+    # Cache now holds the forecast_b dataset stamped with forecast_b key.
+    assert _get_valid_cached_model(prop) is forecast_b_ds
+
+
+@patch('ofs_skill.skill_assessment.get_skill.os.path.getsize', return_value=0)
+@patch('ofs_skill.skill_assessment.get_skill.os.path.isfile',
+       return_value=False)
+@patch('ofs_skill.skill_assessment.get_skill.get_node_ofs')
+def test_ofs_ctlfile_extract_passes_fresh_cache_within_same_whichcast(
+        mock_get_node_ofs, mock_isfile, mock_getsize, logger):
+    """When caller passes a cached dataset AND the key still matches,
+    get_node_ofs receives it and short-circuits intake_model."""
+    ds = _sentinel('nowcast')
+    mock_get_node_ofs.return_value = ds
+
+    prop = MockProps(whichcast='nowcast', ofsfiletype='stations')
+
+    # First call populates cache.
+    ofs_ctlfile_extract(prop, 'wl', logger,
+                        model_dataset=_get_valid_cached_model(prop))
+    # Second call: caller reads cache and forwards.
+    cached = _get_valid_cached_model(prop)
+    assert cached is ds
+    ofs_ctlfile_extract(prop, 'salt', logger, model_dataset=cached)
+
+    assert mock_get_node_ofs.call_count == 2
+    assert mock_get_node_ofs.call_args_list[1].kwargs['model_dataset'] is ds

--- a/tests/list_of_files_forecast_a_cycle_test.py
+++ b/tests/list_of_files_forecast_a_cycle_test.py
@@ -1,0 +1,192 @@
+"""
+Unit tests for the forecast_a cycle filter in list_of_files().
+
+Regression protection for the bug where `list_of_files.py` derived the
+forecast cycle from `prop.startdate[-2:]` — a value that is always '00'
+because `get_node_ofs.py:914-916` strips the hour. The filter therefore
+matched t00z files regardless of the user's -f flag.
+
+The fix reads `prop.forecast_hr` directly, which is set canonically by
+`get_skill.py:555-556` before any list_of_files call on the forecast_a
+path and is validated non-None at `get_skill.py:634`.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from ofs_skill.model_processing.list_of_files import list_of_files
+
+
+class MockLogger:
+    def __init__(self):
+        self.infos = []
+        self.warnings = []
+        self.errors = []
+        self.debugs = []
+
+    def info(self, msg, *args, **kwargs):
+        self.infos.append(msg % args if args else msg)
+
+    def warning(self, msg, *args, **kwargs):
+        self.warnings.append(msg % args if args else msg)
+
+    def error(self, msg, *args, **kwargs):
+        self.errors.append(msg % args if args else msg)
+
+    def debug(self, msg, *args, **kwargs):
+        self.debugs.append(msg % args if args else msg)
+
+
+class MockProps:
+    """Minimal ModelProperties mock for list_of_files.
+
+    Note `startdate` always ends in '00' to match the real-world behavior
+    from get_node_ofs.py:914-916 — the fix must not depend on this being
+    anything else.
+    """
+
+    def __init__(self, whichcast='forecast_a', ofsfiletype='stations',
+                 forecast_hr='06z', ofs='cbofs',
+                 startdate='2026032800', enddate='2026032823'):
+        self.ofs = ofs
+        self.whichcast = whichcast
+        self.ofsfiletype = ofsfiletype
+        self.forecast_hr = forecast_hr
+        self.startdate = startdate
+        self.enddate = enddate
+        self.config_file = None
+
+
+@pytest.fixture
+def logger():
+    return MockLogger()
+
+
+def _all_cycle_station_files():
+    """Directory contents spanning all 4 standard cbofs forecast cycles."""
+    return [
+        'cbofs.t00z.20260328.stations.f001.nc',
+        'cbofs.t06z.20260328.stations.f001.nc',
+        'cbofs.t12z.20260328.stations.f001.nc',
+        'cbofs.t18z.20260328.stations.f001.nc',
+    ]
+
+
+def _all_cycle_fields_files():
+    """Directory contents spanning all 4 cycles for fields ofsfiletype."""
+    return [
+        'cbofs.t00z.20260328.fields.f001.nc',
+        'cbofs.t06z.20260328.fields.f001.nc',
+        'cbofs.t12z.20260328.fields.f001.nc',
+        'cbofs.t18z.20260328.fields.f001.nc',
+    ]
+
+
+@patch('ofs_skill.model_processing.list_of_files.utils')
+@patch('os.path.exists', return_value=True)
+@patch('ofs_skill.model_processing.list_of_files.listdir')
+def test_forecast_a_filters_by_forecast_hr_not_startdate(
+        mock_listdir, mock_exists, mock_utils, logger):
+    """Bug reproducer: prop.startdate ends in '00' but user asked for 06z.
+
+    Pre-fix, this returned the t00z file (wrong). Post-fix, only the
+    t06z file is returned because `cycle_z = prop.forecast_hr.lower()`.
+    """
+    mock_utils.Utils.return_value.read_config_section.return_value = {
+        'use_s3_fallback': 'False'
+    }
+    mock_listdir.return_value = _all_cycle_station_files()
+
+    props = MockProps(
+        whichcast='forecast_a',
+        ofsfiletype='stations',
+        forecast_hr='06z',
+        startdate='2026032800',  # Hour stripped by get_node_ofs — the bug input.
+    )
+
+    result = list_of_files(props, ['/fake/dir'], logger)
+    filenames = [f.split('/')[-1] for f in result]
+
+    assert len(filenames) == 1, (
+        f'expected exactly one file matching the 06z cycle, got {filenames}'
+    )
+    assert 't06z' in filenames[0]
+    assert 't00z' not in filenames[0]
+
+
+@pytest.mark.parametrize('cycle_hour', ['00', '06', '12', '18'])
+@patch('ofs_skill.model_processing.list_of_files.utils')
+@patch('os.path.exists', return_value=True)
+@patch('ofs_skill.model_processing.list_of_files.listdir')
+def test_forecast_a_selects_each_cycle_correctly(
+        mock_listdir, mock_exists, mock_utils, cycle_hour, logger):
+    """Every cycle — including 00z — must be selectable via -f."""
+    mock_utils.Utils.return_value.read_config_section.return_value = {
+        'use_s3_fallback': 'False'
+    }
+    mock_listdir.return_value = _all_cycle_station_files()
+
+    props = MockProps(
+        whichcast='forecast_a',
+        ofsfiletype='stations',
+        forecast_hr=f'{cycle_hour}z',
+        startdate='2026032800',  # Always '00' — the bug input.
+    )
+
+    result = list_of_files(props, ['/fake/dir'], logger)
+    filenames = [f.split('/')[-1] for f in result]
+
+    assert len(filenames) == 1
+    assert f't{cycle_hour}z' in filenames[0]
+
+
+@patch('ofs_skill.model_processing.list_of_files.utils')
+@patch('os.path.exists', return_value=True)
+@patch('ofs_skill.model_processing.list_of_files.listdir')
+def test_forecast_a_fields_filter_uses_forecast_hr(
+        mock_listdir, mock_exists, mock_utils, logger):
+    """Same filter applies to the fields ofsfiletype branch (line 944)."""
+    mock_utils.Utils.return_value.read_config_section.return_value = {
+        'use_s3_fallback': 'False'
+    }
+    mock_listdir.return_value = _all_cycle_fields_files()
+
+    props = MockProps(
+        whichcast='forecast_a',
+        ofsfiletype='fields',
+        forecast_hr='12z',
+        startdate='2026032800',
+    )
+
+    result = list_of_files(props, ['/fake/dir'], logger)
+    filenames = [f.split('/')[-1] for f in result]
+
+    assert len(filenames) == 1
+    assert 't12z' in filenames[0]
+    assert 'fields.f001' in filenames[0]
+
+
+@patch('ofs_skill.model_processing.list_of_files.utils')
+@patch('os.path.exists', return_value=True)
+@patch('ofs_skill.model_processing.list_of_files.listdir')
+def test_forecast_a_uppercase_forecast_hr_normalized(
+        mock_listdir, mock_exists, mock_utils, logger):
+    """Defensive: the fix uses `.lower()`, so uppercase -f survives."""
+    mock_utils.Utils.return_value.read_config_section.return_value = {
+        'use_s3_fallback': 'False'
+    }
+    mock_listdir.return_value = _all_cycle_station_files()
+
+    props = MockProps(
+        whichcast='forecast_a',
+        ofsfiletype='stations',
+        forecast_hr='06Z',  # uppercase
+        startdate='2026032800',
+    )
+
+    result = list_of_files(props, ['/fake/dir'], logger)
+    filenames = [f.split('/')[-1] for f in result]
+
+    assert len(filenames) == 1
+    assert 't06z' in filenames[0]


### PR DESCRIPTION
### Description of Changes

`list_of_files.py` forecast_a branch derived the cycle filter from `prop.startdate[-2:]`, but `prop.startdate` is built by `get_node_ofs.py:914-916` via `strftime('%Y%m%d') + '00'` — the hour is always `'00'`. So `cycle_z` was always `'00z'` regardless of the user's `-f` flag, and `cycle_z in af_name` silently matched `t00z` files on a `-f 06z` run (or `-f 12z`, `-f 18z` — all picked t00z).

**Fix**: read the cycle from `prop.forecast_hr` instead, which is set canonically in `'XXz'` format by `get_skill.py:555-556` before any `get_node_ofs` call, and validated non-None at `get_skill.py:634`. One-line change plus a comment explaining why the obvious `prop.startdate[-2:]` doesn't work.

**Why this matters**: the forecast_a code path has been latent-broken since `get_node_ofs.py:914-916`'s hour-stripping was written. It's masked today only because a separate TypeError in `create_1dplot.py:457-459` (being fixed on `origin/fix-forecast-a` by plimbernoaa, commit `5015b2b`) blocks `-ws forecast_a` at the driver layer. Once that lands, this bug would produce silently-wrong skill outputs — every `.prd`, skill CSV, and plot for a `-f 06z` run would be extracted from `t00z` files.

Discovered during PR #111 (`fix-whichcast-cache-leak`) E2E testing.

Labels: `bug`, `forecast_a`

### Expected Outcome of Changes

- `-ws forecast_a -f {cycle}z` will load the cycle the user actually requested. Specifically: `cbofs_forecast_a_filename_key.csv` will reference `t{cycle}z` files instead of `t00z`.
- `.prd`, skill CSVs, and plots will reflect the correct forecast cycle's model data.
- No behavioral change for nowcast, forecast_b, or hindcast paths — they don't hit the modified code branch (`list_of_files.py:889-968` forecast_a-only).
- No change to the `prop.startdate` / `prop.enddate` format; the underlying hour-dropping in `get_node_ofs.py:914-916` remains and is tracked separately (see `forecast_a_bugs_in_1dplot_issue.md` at repo root).

### Developer Questions and Checklist

**Is this a high priority PR? If yes, why and is there a date by which it needs to be merged?**
Medium-high. Should merge close to or alongside `origin/fix-forecast-a` (TypeError fix) to prevent exposing silently-wrong forecast_a output on main.

**Are there any changes needed to how the code should be run for operational runs? (Commands, flags, job timings, etc.)**
No. Same CLI, same flags.

**Does this update need to be deployed for operational runs?**
Yes, for any forecast_a run.

**Does this update require front end/web app changes?**
No.

**Does this impact code development work on adding SCHISM?**
No.

**Does this impact the expected number of output files for integration tests?**
No — same file count; the files now correspond to the correct cycle.

- [x] Developer's name is removed throughout the code?
- [x] Did you add relevant labels to the PR?
- [x] Have you run pylint and is the code at an acceptable pylint score (>8)? — `list_of_files.py` pylint 8.87/10 (up from 8.74 pre-fix); new test module 10.00/10 (fatal+error categories).
- [x] Jobs contain the appropriate file checking and handle errors for any missing data? — no new job surface; `prop.forecast_hr` is guaranteed non-None on this code path per `get_skill.py:634`.
- [x] Is log free of critical ERRORs or WARNINGs? — no new log lines.

### Testing Instructions

**Unit tests:**
```bash
pytest tests/list_of_files_forecast_a_cycle_test.py -v
```
Expect 7 passed (1 direct reproducer, 4 parametrized cycle sweep, 1 fields-branch, 1 uppercase-defensive).

**Full suite:**
```bash
pytest --no-cov -q
```
Expect 455 passed (448 baseline + 7 new).

**End-to-end reproducer** (requires `origin/fix-forecast-a` merged first, OR use the direct harness described below):

1. Prep: download cbofs forecast_a files for 2026-03-28 06z:
   ```bash
   python ./bin/utils/get_model_data.py -o cbofs -p ./ -s 2026-03-28T00:00:00Z -e 2026-03-28T23:00:00Z -t stations -ws forecast_b
   ```
   (The `forecast_b` download brings all-cycle forecast files, including t06z.)
2. Clean slate + run:
   ```bash
   rm -rf data/ control_files/
   python ./bin/visualization/create_1dplot.py -o cbofs -p ./ -s 2026-03-28T00:00:00Z -e 2026-03-28T23:00:00Z -d MLLW -ws forecast_a -f 06z -t stations -vs water_level -so CO-OPS
   ```
3. Assert:
   ```bash
   grep -c "t06z" data/model/1d_node/cbofs_forecast_a_filename_key.csv     # expect > 0 (was 0 pre-fix)
   grep -cE "t00z|t12z|t18z" data/model/1d_node/cbofs_forecast_a_filename_key.csv   # expect 0 (was 481 pre-fix)
   ```

**Direct harness** (works independently of the TypeError blocker): see `/tmp/e2e_fa_direct_pr112.py` (template) — seed state via a nowcast `create_1dplot.py` run, then call `get_node_ofs` directly with `prop.whichcast='forecast_a'`, `prop.forecast_hr='06z'`, and the reshuffled dates. Verified locally: 481/481 rows reference `t06z`, zero reference other cycles.

### Reviewer notes

- This PR stacks on PR #111 (`fix-whichcast-cache-leak`). Base is `main`; if #111 hasn't merged yet, a stacked-merge is straightforward (no file overlap between PRs — #111 touches `get_skill.py` + new tests; this PR touches `list_of_files.py` + new tests).
- `origin/fix-forecast-a` (plimbernoaa, commit `5015b2b`, unmerged) fixes the complementary `get_fcst_dates` 4-arg TypeError in `create_1dplot.py:457-459`. Once both PRs land, `-ws forecast_a -f {cycle}z` works end-to-end for the first time since 2026-03-18.