### PR TITLE
Fix #120: detect partial GOES SST downloads + harden concat/mask pipeline

### DIFF
--- a/bin/obs_retrieval/get_satellite_observations.py
+++ b/bin/obs_retrieval/get_satellite_observations.py
@@ -75,6 +75,18 @@ from ofs_skill.obs_retrieval import utils
 # observed in the wild land at ~48 KB. 1 MB is comfortably above the
 # pathological band and well below any legitimate file.
 _RAW_SAT_MIN_BYTES = 1 * 1024 * 1024
+# Upper bound — defends against a misbehaving upstream serving an
+# unbounded response (HTML error page, gzip bomb, mirror serving a
+# different giant product). SPoRT global L4 raw can be ~30–100 MB,
+# so 500 MB is comfortably above any plausible legitimate product
+# while still catching disk-fill scenarios within seconds.
+_RAW_SAT_MAX_BYTES = 500 * 1024 * 1024
+# Per-request timeout (seconds) for urlopen. Long enough to fetch a
+# legitimate ~8 MB file over a slow connection, short enough that a
+# slow-loris upstream cannot pin a ThreadPoolExecutor worker forever.
+_DOWNLOAD_TIMEOUT_SECONDS = 60
+# Streaming chunk size for download writes.
+_DOWNLOAD_CHUNK_BYTES = 64 * 1024
 # Trimmed per-hour file (most variables dropped) is smaller; threshold
 # tuned to flag obviously-empty writes without rejecting legitimate output.
 _TRIMMED_SAT_MIN_BYTES = 50 * 1024
@@ -655,6 +667,47 @@ def _safe_remove(path, logger):
         logger.warning('Failed to remove %s: %s', path, ex)
 
 
+def _download_with_limits(url, dest, logger):
+    """
+    Download ``url`` to ``dest`` with a per-request timeout and a
+    cumulative byte cap.
+
+    Replaces ``urllib.request.urlretrieve`` (which has no timeout kwarg
+    and no streaming size limit). Streams the response in fixed-size
+    chunks; aborts immediately if cumulative bytes exceed
+    ``_RAW_SAT_MAX_BYTES`` so a misbehaving upstream cannot fill the
+    disk. Cleans up the partial file on any failure path.
+
+    Returns True on success, False on any failure (logged at WARNING).
+    Never raises — the caller treats False as "skip this hour."
+    """
+    bytes_written = 0
+    try:
+        with urllib.request.urlopen(
+            url, timeout=_DOWNLOAD_TIMEOUT_SECONDS,
+        ) as response, open(dest, 'wb') as out:
+            while True:
+                chunk = response.read(_DOWNLOAD_CHUNK_BYTES)
+                if not chunk:
+                    break
+                bytes_written += len(chunk)
+                if bytes_written > _RAW_SAT_MAX_BYTES:
+                    logger.warning(
+                        'Download for %s exceeded %d-byte cap '
+                        '(read %d bytes); aborting',
+                        url, _RAW_SAT_MAX_BYTES, bytes_written,
+                    )
+                    out.close()
+                    _safe_remove(dest, logger)
+                    return False
+                out.write(chunk)
+        return True
+    except (URLError, OSError) as ex:
+        logger.warning('Download failed for %s: %s', url, ex)
+        _safe_remove(dest, logger)
+        return False
+
+
 def _download_single_file(sat_dat, obs2d_dir, logger, sat_type):
     """
     Download, trim, and save a single satellite file.
@@ -708,14 +761,8 @@ def _download_single_file(sat_dat, obs2d_dir, logger, sat_type):
 
     raw_path = os.path.join(obs2d_dir, f'{sat_dat}'.split('/')[-1])
 
-    # --- Network fetch (narrow except for deterministic cleanup) ---
-    # URLError covers HTTPError; OSError covers ConnectionError, TimeoutError,
-    # and socket.timeout (which is an alias for TimeoutError since 3.10).
-    try:
-        urllib.request.urlretrieve(sat_dat, raw_path)
-    except (URLError, OSError) as ex:
-        logger.warning('Download failed for %s: %s', sat_dat, ex)
-        _safe_remove(raw_path, logger)
+    # --- Network fetch (timeout + size cap; cleanup on any failure) ---
+    if not _download_with_limits(sat_dat, raw_path, logger):
         return None
 
     # --- Validate raw download size before trying to parse it ---

--- a/bin/obs_retrieval/get_satellite_observations.py
+++ b/bin/obs_retrieval/get_satellite_observations.py
@@ -62,7 +62,7 @@ import urllib.request
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime, timedelta
 from pathlib import Path
-from urllib.error import HTTPError
+from urllib.error import URLError
 
 import geopandas as gpd
 import regionmask
@@ -70,6 +70,25 @@ import xarray as xr
 
 from ofs_skill.model_processing import model_properties
 from ofs_skill.obs_retrieval import utils
+
+# Healthy raw GOES/SPoRT hourly SST files are ~8 MB. Truncated downloads
+# observed in the wild land at ~48 KB. 1 MB is comfortably above the
+# pathological band and well below any legitimate file.
+_RAW_SAT_MIN_BYTES = 1 * 1024 * 1024
+# Trimmed per-hour file (most variables dropped) is smaller; threshold
+# tuned to flag obviously-empty writes without rejecting legitimate output.
+_TRIMMED_SAT_MIN_BYTES = 50 * 1024
+# Concat cache short-circuit threshold — heuristic for "this looks like a
+# real, multi-hour concat we already produced". Matches the historical
+# 1 MB cache-skip threshold so existing caches stay valid.
+_CONCAT_CACHE_MIN_KB = 1000
+# Concat post-write verify — only meant to detect phantom-path returns
+# (zero-byte or near-empty writes). A legitimate single-hour concat may
+# fall well under the cache threshold; this lower bound lets a 1-hour
+# smoke test pass while still catching the bug we set out to fix.
+_CONCAT_VERIFY_MIN_KB = 50
+# Masked OFS-clipped output threshold, matches existing freshness check.
+_MASKED_MIN_KB = 50
 
 
 def hours_range(start_date, end_date):
@@ -627,6 +646,15 @@ def _should_download(sat_fname, sat_type):
         return sat_fname.find('SPoRT') > -1
 
 
+def _safe_remove(path, logger):
+    """Best-effort file removal; never raises."""
+    try:
+        if path and os.path.exists(path):
+            os.remove(path)
+    except OSError as ex:
+        logger.warning('Failed to remove %s: %s', path, ex)
+
+
 def _download_single_file(sat_dat, obs2d_dir, logger, sat_type):
     """
     Download, trim, and save a single satellite file.
@@ -635,8 +663,12 @@ def _download_single_file(sat_dat, obs2d_dir, logger, sat_type):
     the parallel ThreadPoolExecutor path in ``get_sat()``.
 
     Returns the cleaned output path on success, or None on skip/failure.
+    Per-hour failures (network errors, undersized downloads, undersized
+    cached files) return None so the caller drops the hour and continues
+    — the missing hour shows up as a gap in the concat output rather
+    than aborting the run.
     """
-    sat_fname = os.path.join(Path.cwd(), Path(obs2d_dir))
+    sat_fname = obs2d_dir
 
     subdir = _resolve_sat_subdir(sat_dat)
     if subdir is not None:
@@ -655,21 +687,50 @@ def _download_single_file(sat_dat, obs2d_dir, logger, sat_type):
 
     # --- File already exists on disk ---
     if os.path.exists(sat_fname):
-        logger.info('%s exists', sat_fname)
-        if _should_download(sat_fname, sat_type):
-            return sat_fname
-        return None
-
-    # --- Need to download ---
-    try:
         if not _should_download(sat_fname, sat_type):
             return None
+        cached_size = os.path.getsize(sat_fname)
+        if cached_size >= _TRIMMED_SAT_MIN_BYTES:
+            logger.info('%s exists', sat_fname)
+            return sat_fname
+        # Cached file is corrupt/truncated — discard and re-download below.
+        logger.warning(
+            'Cached file %s is undersized (%d bytes < %d); '
+            'removing and re-downloading',
+            sat_fname, cached_size, _TRIMMED_SAT_MIN_BYTES,
+        )
+        _safe_remove(sat_fname, logger)
 
-        logger.info('Downloading satellite data: %s', sat_dat)
+    if not _should_download(sat_fname, sat_type):
+        return None
 
-        raw_path = obs2d_dir + r'/' + f'{sat_dat}'.split('/')[-1]
+    logger.info('Downloading satellite data: %s', sat_dat)
+
+    raw_path = os.path.join(obs2d_dir, f'{sat_dat}'.split('/')[-1])
+
+    # --- Network fetch (narrow except for deterministic cleanup) ---
+    # URLError covers HTTPError; OSError covers ConnectionError, TimeoutError,
+    # and socket.timeout (which is an alias for TimeoutError since 3.10).
+    try:
         urllib.request.urlretrieve(sat_dat, raw_path)
+    except (URLError, OSError) as ex:
+        logger.warning('Download failed for %s: %s', sat_dat, ex)
+        _safe_remove(raw_path, logger)
+        return None
 
+    # --- Validate raw download size before trying to parse it ---
+    if (not os.path.exists(raw_path)
+            or os.path.getsize(raw_path) < _RAW_SAT_MIN_BYTES):
+        actual = os.path.getsize(raw_path) if os.path.exists(raw_path) else 0
+        logger.warning(
+            'Skipping undersized download for %s: %d bytes < %d',
+            sat_dat, actual, _RAW_SAT_MIN_BYTES,
+        )
+        _safe_remove(raw_path, logger)
+        return None
+
+    # --- Parse + trim ---
+    try:
         drop_variables = [
             'quality_level',
             'l2p_flags',
@@ -689,42 +750,55 @@ def _download_single_file(sat_dat, obs2d_dir, logger, sat_type):
             engine='netcdf4',
             decode_times=False,
         )
-
         data_set.to_netcdf(sat_fname, mode='w')
         data_set.close()
-        os.remove(raw_path)
-
-        return sat_fname
-
-    except (ValueError, HTTPError, Exception) as ex:
+    except (ValueError, OSError, RuntimeError) as ex:
         if 'G16' in sat_dat:
-            g16date = datetime.strptime(
-                sat_fname.split('-')[0][-14:-1],
-                '%Y%m%d%H%M%S',
-            )
-            g16end = datetime.strptime(
-                '20250407210000', '%Y%m%d%H%M%S')
-            if g16date > g16end:
-                error_message = (
-                    f'Error: {str(ex)}. '
-                    f'Oops! GOES-16 does not exist for '
-                    f'{sat_fname.split("-")[0][-14:-1]}. '
-                    f'It is replaced by GOES-19.'
+            try:
+                g16date = datetime.strptime(
+                    sat_fname.split('-')[0][-14:-1],
+                    '%Y%m%d%H%M%S',
                 )
-                logger.error(error_message)
-            else:
-                error_message = (
-                    f'Error: {str(ex)}. '
-                    f'Failed downloading files {sat_dat}!!'
+                g16end = datetime.strptime(
+                    '20250407210000', '%Y%m%d%H%M%S')
+                if g16date > g16end:
+                    logger.error(
+                        'Error: %s. Oops! GOES-16 does not exist for %s. '
+                        'It is replaced by GOES-19.',
+                        ex, sat_fname.split('-')[0][-14:-1],
+                    )
+                else:
+                    logger.error(
+                        'Error: %s. Failed downloading files %s!!',
+                        ex, sat_dat,
+                    )
+            except ValueError:
+                logger.error(
+                    'Error: %s. Failed downloading files %s!!',
+                    ex, sat_dat,
                 )
-                logger.error(error_message)
         else:
-            error_message = (
-                f'Error: {str(ex)}. '
-                f'Failed downloading files {sat_dat}!!'
+            logger.error(
+                'Error: %s. Failed downloading files %s!!', ex, sat_dat,
             )
-            logger.error(error_message)
+        _safe_remove(raw_path, logger)
+        _safe_remove(sat_fname, logger)
         return None
+
+    _safe_remove(raw_path, logger)
+
+    # --- Validate trimmed output before declaring success ---
+    if (not os.path.exists(sat_fname)
+            or os.path.getsize(sat_fname) < _TRIMMED_SAT_MIN_BYTES):
+        actual = os.path.getsize(sat_fname) if os.path.exists(sat_fname) else 0
+        logger.warning(
+            'Trimmed file %s is undersized (%d bytes < %d); discarding',
+            sat_fname, actual, _TRIMMED_SAT_MIN_BYTES,
+        )
+        _safe_remove(sat_fname, logger)
+        return None
+
+    return sat_fname
 
 
 def get_sat(list_of_urls, obs2d_dir, logger, sat_type):
@@ -777,15 +851,41 @@ def get_sat(list_of_urls, obs2d_dir, logger, sat_type):
     return list_of_files
 
 
+def _purge_undersized_sat_files(directory, min_bytes, logger):
+    """
+    Sweep ``directory`` for trimmed per-hour SAT files smaller than
+    ``min_bytes`` and remove them. Best-effort — failures are logged
+    and do not raise. Used as a safety net for caches populated by
+    pre-fix runs that predate the download-time size validation.
+    """
+    if not directory or not os.path.isdir(directory):
+        return
+    for filename in os.listdir(directory):
+        if not filename.endswith('_sst.nc'):
+            continue
+        file_path = os.path.join(directory, filename)
+        try:
+            if (os.path.isfile(file_path)
+                    and os.path.getsize(file_path) < min_bytes):
+                logger.warning(
+                    'Purging undersized cached SAT file: %s', file_path,
+                )
+                os.remove(file_path)
+        except OSError as ex:
+            logger.warning('Failed to inspect/remove %s: %s', file_path, ex)
+
+
 def concat_sat(list_of_files, obs2d_dir, logger, prop1):
     """
     Concatenates the satellite files on
     list_of_files into once single file,
     deletes the files in list_of_files
+
+    Concat output is the only artifact downstream stages depend on, so
+    write failures here abort the run rather than continuing with a gap.
     """
     try:
         save_path = (
-            Path(__file__).parent.parent.parent /
             Path(obs2d_dir) /
             str(
                 f'{list_of_files[0]}'.split(
@@ -809,61 +909,110 @@ def concat_sat(list_of_files, obs2d_dir, logger, prop1):
         sys.exit(-1)
 
     logger.info(f'Checking for concatenated file: {save_path}')
-    if os.path.exists(save_path) and os.path.getsize(save_path)/1024 > 1000:
+    if (os.path.exists(save_path)
+            and os.path.getsize(save_path) / 1024 > _CONCAT_CACHE_MIN_KB):
         logger.info('Valid concatenated file found - skipping concatenation')
-        # if os.path.getsize(save_path)/1024 > 1000:
-        #   logger.info(f"{save_path} is valid - skipping concatenation ")
-    else:
-        try:
-            logger.info('No global concatenated file found ')
-            logger.info('Begining concatenating of the satellite data ... ')
-            nc_list = []
+        return str(save_path)
 
-            for file in list_of_files:
-                if os.path.exists(file):
-                    nc_list.append(
-                        xr.open_dataset(
-                            file,
-                            chunks='auto',
-                            decode_times=False,
-                            lock=False,
-                        ),
-                    )
-            nc_item = xr.concat(
-                nc_list,
-                dim='time',
-                data_vars='minimal',
-            )
+    # Sweep any leftover undersized per-hour caches from pre-fix runs
+    # so they don't pollute this concat.
+    sat_subdir = os.path.dirname(list_of_files[0])
+    _purge_undersized_sat_files(sat_subdir, _TRIMMED_SAT_MIN_BYTES, logger)
 
-            logger.info('Concatenation complete!')
-        except Exception as ex:
-            logger.error(f'Error happened at Concatenation: {str(ex)}')
-            sys.exit(-1)
+    try:
+        logger.info('No global concatenated file found ')
+        logger.info('Begining concatenating of the satellite data ... ')
+        nc_list = []
 
-        # nc_item = xr.concat([xr.open_dataset(i) for i in list_of_files],
-        #                     dim="time",
-        #                     data_vars="minimal"
-        #                    )
+        for file in list_of_files:
+            if os.path.exists(file):
+                nc_list.append(
+                    xr.open_dataset(
+                        file,
+                        chunks='auto',
+                        decode_times=False,
+                        lock=False,
+                    ),
+                )
+        nc_item = xr.concat(
+            nc_list,
+            dim='time',
+            data_vars='minimal',
+        )
 
-        try:
-            logger.info(f'Writing concatenated file to {save_path} ... ')
-            nc_item.to_netcdf(
-                save_path,
-                mode='w',
-                format='NETCDF4',
-                engine='netcdf4',
-                # encoding={"chunksizes": 1000},
-                # computer=False
-            )
+        logger.info('Concatenation complete!')
+    except Exception as ex:
+        logger.error(f'Error happened at Concatenation: {str(ex)}')
+        sys.exit(-1)
 
-            logger.info('Finished writing the concatenated satellite file ')
-        except MemoryError as ex:
-            logger.error(
-                f'Error happened at saving file {save_path} -- {str(ex)}')
-            sys.exit(-1)
-        except KeyboardInterrupt:
-            logger.error('Keyboard interupt by user, abandoning save ... ')
+    try:
+        logger.info(f'Writing concatenated file to {save_path} ... ')
+        nc_item.to_netcdf(
+            save_path,
+            mode='w',
+            format='NETCDF4',
+            engine='netcdf4',
+        )
+
+        logger.info('Finished writing the concatenated satellite file ')
+    except MemoryError as ex:
+        logger.error(
+            f'Error happened at saving file {save_path} -- {str(ex)}')
+        sys.exit(-1)
+    except (OSError, RuntimeError) as ex:
+        logger.error(
+            f'Error happened at saving file {save_path} -- {str(ex)}')
+        sys.exit(-1)
+    except KeyboardInterrupt:
+        logger.error('Keyboard interrupt by user, abandoning save ... ')
+        # Re-raise so the caller doesn't proceed with a phantom path.
+        raise
+
+    # Verify the write actually produced a usable file. If the file is
+    # missing or undersized despite no exception, downstream masksat
+    # would only surface this as a cryptic HDF5 trace.
+    if (not os.path.exists(save_path)
+            or os.path.getsize(save_path) / 1024 < _CONCAT_VERIFY_MIN_KB):
+        actual = (
+            os.path.getsize(save_path) / 1024 if os.path.exists(save_path) else 0
+        )
+        logger.error(
+            'Concat write completed but %s is missing or undersized '
+            '(%.1f KiB < %d KiB)', save_path, actual, _CONCAT_VERIFY_MIN_KB,
+        )
+        sys.exit(-1)
+
     return str(save_path)
+
+
+def _masked_file_is_fresh(masked_sat_path):
+    """
+    True iff ``masked_sat_path`` exists, is younger than 1 hour, and is
+    larger than ``_MASKED_MIN_KB``. Drives the decision to skip vs.
+    rebuild the OFS-clipped output.
+    """
+    if not os.path.exists(masked_sat_path):
+        return False
+    age_seconds = time.time() - os.path.getmtime(masked_sat_path)
+    if age_seconds >= 3600:
+        return False
+    return os.path.getsize(masked_sat_path) / 1024 > _MASKED_MIN_KB
+
+
+def _verify_masked_output(path, logger):
+    """
+    Verify a masked OFS-clipped output landed on disk and is at least
+    ``_MASKED_MIN_KB``. Aborts the run on failure — masked outputs are
+    consumed by downstream skill assessment, so silent corruption here
+    surfaces as confusing errors much later.
+    """
+    if not os.path.exists(path) or os.path.getsize(path) / 1024 < _MASKED_MIN_KB:
+        actual = os.path.getsize(path) / 1024 if os.path.exists(path) else 0
+        logger.error(
+            'Masked output %s missing or undersized (%.1f KiB < %d KiB). Abort!',
+            path, actual, _MASKED_MIN_KB,
+        )
+        sys.exit(-1)
 
 
 def masksat_by_ofs(sat_path, shape_file):
@@ -955,8 +1104,13 @@ def parameter_dir_validation(prop, dir_params, logger):
         )
         logger.error(error_message)
         sys.exit(-1)
+    # Resolve once to absolute so download / concat / mask stages all
+    # agree on the directory regardless of cwd. Resolving an already-
+    # absolute path is a no-op, preserving orchestration callers that
+    # pass an absolute prop.path.
+    resolved_prop_path = str(Path(prop.path).resolve())
     prop.data_observations_2d_satellite_path = os.path.join(
-        prop.path,
+        resolved_prop_path,
         dir_params['data_dir'],
         dir_params['observations_dir'],
         dir_params['2d_satellite_dir'],
@@ -1078,6 +1232,25 @@ def get_satellite(prop, logger):
         )
 
         logger.info('Satellite data downloaded')
+
+        # Coverage summary — flags silent partial concats so downstream
+        # skill metrics aren't computed on biased subsamples without a
+        # warning. Counts by sat_type so a SPoRT outage doesn't get
+        # masked by GOES success (or vice versa).
+        n_hours_requested = len(hours)
+        n_goes_urls = len([u for u in list_of_urls if 'ABI_G' in u])
+        n_sport_urls = len([u for u in list_of_urls if 'SPoRT' in u])
+        coverage_log = logger.info
+        if (n_goes_urls and len(list_of_files_goes) < n_goes_urls) or \
+                (n_sport_urls and len(list_of_files_sport) < n_sport_urls):
+            coverage_log = logger.warning
+        coverage_log(
+            'Satellite hour-coverage summary: requested %d hours; '
+            'GOES %d/%d files retrieved; SPoRT %d/%d files retrieved',
+            n_hours_requested,
+            len(list_of_files_goes), n_goes_urls,
+            len(list_of_files_sport), n_sport_urls,
+        )
     except ValueError as ex:
         error_message = f'Error: {str(ex)}. Failed downloading files. Abort!'
         logger.error(error_message)
@@ -1112,30 +1285,28 @@ def get_satellite(prop, logger):
             shape_file = f'{prop.ofs_extents_path}/{prop.ofs}.shp'
 
             masked_sat_path = (
-                Path(__file__).parent.parent.parent /
                 Path(prop.data_observations_2d_satellite_path) /
                 str(prop.ofs + '.nc')
             ).resolve()
 
-            if os.path.exists(masked_sat_path):
-                file_age = time.time() - os.path.getmtime(masked_sat_path)
-                if (file_age < 3600 and
-                    os.path.getsize(masked_sat_path)/1024 > 50):
-                    logger.info(
-                        'Recent valid masked file found - skipping clipping')
-
+            if _masked_file_is_fresh(masked_sat_path):
+                logger.info(
+                    'Recent valid masked file found - skipping clipping')
             else:
-                logger.info('No recent masked file found ')
+                logger.info(
+                    'No fresh masked file found — rebuilding clipped output')
                 logger.info('Begin clipping satellite data for %s', prop.ofs)
 
                 if len(concated_sat_goes) > 0:
                     masked_sat_goes = masksat_by_ofs(
                         concated_sat_goes, shape_file)
 
-                    masked_sat_goes.to_netcdf(
-                        f'{prop.data_observations_2d_satellite_path}/'
-                        f'{args.ofs}.nc', mode='w',
+                    goes_out = os.path.join(
+                        prop.data_observations_2d_satellite_path,
+                        f'{prop.ofs}.nc',
                     )
+                    masked_sat_goes.to_netcdf(goes_out, mode='w')
+                    _verify_masked_output(goes_out, logger)
 
                 # Temporarily commented out 6/11/25 to avoid filling up server
                 # disk space
@@ -1145,10 +1316,12 @@ def get_satellite(prop, logger):
                         shape_file,
                     )
 
-                    masked_sat_sport.to_netcdf(
-                        f'{prop.data_observations_2d_satellite_path}/'
-                        f'{args.ofs}_sport.nc', mode='w',
+                    sport_out = os.path.join(
+                        prop.data_observations_2d_satellite_path,
+                        f'{prop.ofs}_sport.nc',
                     )
+                    masked_sat_sport.to_netcdf(sport_out, mode='w')
+                    _verify_masked_output(sport_out, logger)
 
                 logger.info(
                     'Finished clipping satellite data for %s', prop.ofs)

--- a/bin/obs_retrieval/get_satellite_observations.py
+++ b/bin/obs_retrieval/get_satellite_observations.py
@@ -77,15 +77,24 @@ from ofs_skill.obs_retrieval import utils
 _RAW_SAT_MIN_BYTES = 1 * 1024 * 1024
 # Upper bound — defends against a misbehaving upstream serving an
 # unbounded response (HTML error page, gzip bomb, mirror serving a
-# different giant product). SPoRT global L4 raw can be ~30–100 MB,
-# so 500 MB is comfortably above any plausible legitimate product
-# while still catching disk-fill scenarios within seconds.
-_RAW_SAT_MAX_BYTES = 500 * 1024 * 1024
-# Per-request timeout (seconds) for urlopen. Long enough to fetch a
-# legitimate ~8 MB file over a slow connection, short enough that a
-# slow-loris upstream cannot pin a ThreadPoolExecutor worker forever.
+# different giant product). SPoRT global L4 raw is documented at
+# ~30–100 MB; GOES L3C is ~8 MB. 200 MB gives 2x headroom over the
+# largest plausible legitimate product while keeping disk-fill
+# blast radius small.
+_RAW_SAT_MAX_BYTES = 200 * 1024 * 1024
+# Socket-level (per-read) timeout used by urlopen. Long enough to
+# tolerate a slow connection, short enough to abort a stalled read.
 _DOWNLOAD_TIMEOUT_SECONDS = 60
-# Streaming chunk size for download writes.
+# Wall-clock cap for an entire single-file download. The socket
+# timeout above only fires when a read blocks; a slow-loris upstream
+# trickling bytes every <60s can otherwise dribble up to
+# _RAW_SAT_MAX_BYTES across many minutes. This total cap converts
+# that pathological case into a deterministic abort. Set generously
+# above normal completion times (seconds for ~8 MB on a healthy link).
+_DOWNLOAD_TOTAL_TIMEOUT_SECONDS = 300
+# Streaming chunk size for download writes — matches the
+# shutil.copyfileobj default and balances syscall overhead against
+# how often the cumulative-size and wall-clock checks are evaluated.
 _DOWNLOAD_CHUNK_BYTES = 64 * 1024
 # Trimmed per-hour file (most variables dropped) is smaller; threshold
 # tuned to flag obviously-empty writes without rejecting legitimate output.
@@ -669,24 +678,46 @@ def _safe_remove(path, logger):
 
 def _download_with_limits(url, dest, logger):
     """
-    Download ``url`` to ``dest`` with a per-request timeout and a
-    cumulative byte cap.
+    Download ``url`` to ``dest`` with three independent bounds:
 
-    Replaces ``urllib.request.urlretrieve`` (which has no timeout kwarg
-    and no streaming size limit). Streams the response in fixed-size
-    chunks; aborts immediately if cumulative bytes exceed
-    ``_RAW_SAT_MAX_BYTES`` so a misbehaving upstream cannot fill the
-    disk. Cleans up the partial file on any failure path.
+    1. Per-read socket timeout (``_DOWNLOAD_TIMEOUT_SECONDS``) so a
+       blocked recv aborts.
+    2. Cumulative byte cap (``_RAW_SAT_MAX_BYTES``) so an unbounded
+       response cannot fill the disk.
+    3. Wall-clock cap (``_DOWNLOAD_TOTAL_TIMEOUT_SECONDS``) so a
+       slow-loris upstream that trickles bytes within the per-read
+       timeout still aborts in bounded time.
 
-    Returns True on success, False on any failure (logged at WARNING).
-    Never raises — the caller treats False as "skip this hour."
+    Replaces ``urllib.request.urlretrieve`` (which has no timeout
+    kwarg and no streaming size limit). Streams the response in
+    fixed-size chunks and cleans up the partial file on any failure
+    path.
+
+    Returns True on success, False on any failure (logged at
+    WARNING). The ``(URLError, OSError)`` catch covers all expected
+    network/filesystem errors; the caller treats False as "skip this
+    hour." Unexpected exceptions (e.g. ``MemoryError``,
+    ``KeyboardInterrupt``) propagate.
     """
     bytes_written = 0
+    deadline = time.monotonic() + _DOWNLOAD_TOTAL_TIMEOUT_SECONDS
     try:
         with urllib.request.urlopen(
             url, timeout=_DOWNLOAD_TIMEOUT_SECONDS,
         ) as response, open(dest, 'wb') as out:
             while True:
+                if time.monotonic() > deadline:
+                    logger.warning(
+                        'Download for %s exceeded %d-second total '
+                        'wall-clock budget (read %d bytes); aborting',
+                        url, _DOWNLOAD_TOTAL_TIMEOUT_SECONDS,
+                        bytes_written,
+                    )
+                    # Close before unlink: required on Windows, where
+                    # os.remove on an open file raises PermissionError.
+                    out.close()
+                    _safe_remove(dest, logger)
+                    return False
                 chunk = response.read(_DOWNLOAD_CHUNK_BYTES)
                 if not chunk:
                     break
@@ -697,6 +728,8 @@ def _download_with_limits(url, dest, logger):
                         '(read %d bytes); aborting',
                         url, _RAW_SAT_MAX_BYTES, bytes_written,
                     )
+                    # Close before unlink: required on Windows, where
+                    # os.remove on an open file raises PermissionError.
                     out.close()
                     _safe_remove(dest, logger)
                     return False

--- a/bin/obs_retrieval/get_satellite_observations.py
+++ b/bin/obs_retrieval/get_satellite_observations.py
@@ -112,6 +112,32 @@ _CONCAT_VERIFY_MIN_KB = 50
 _MASKED_MIN_KB = 50
 
 
+def _silence_hdf5_errors():
+    """
+    Disable HDF5's automatic stderr printer on the calling thread.
+
+    netCDF4's ``Dataset(path, mode='w')`` (driving ``xr.Dataset.to_netcdf``)
+    probes whether ``path`` already exists as HDF5 before writing. On a
+    first-time write the probe raises ENOENT inside the HDF5 C library,
+    which prints a multi-line ``HDF5-DIAG`` trace to stderr. The probe
+    failure is non-fatal — the write succeeds — but the trace is alarming
+    and obscures real log lines under the parallel download path. HDF5's
+    error-printer state is thread-local, so the disable must be applied
+    on every thread that drives netCDF4 writes (main + each pool worker).
+    Best-effort: silently no-ops if libhdf5 cannot be opened.
+    """
+    try:
+        import ctypes
+        import ctypes.util
+        soname = ctypes.util.find_library('hdf5') or 'libhdf5.so'
+        ctypes.CDLL(soname).H5Eset_auto2(ctypes.c_int64(0), None, None)
+    except (OSError, AttributeError):
+        pass
+
+
+_silence_hdf5_errors()
+
+
 def hours_range(start_date, end_date):
     """
     This function takes the start and end date and returns
@@ -900,7 +926,9 @@ def get_sat(list_of_urls, obs2d_dir, logger, sat_type):
     list_of_files = []
     completed = 0
 
-    with ThreadPoolExecutor(max_workers=max_workers) as executor:
+    with ThreadPoolExecutor(
+        max_workers=max_workers, initializer=_silence_hdf5_errors,
+    ) as executor:
         futures = {
             executor.submit(
                 _download_single_file, url, obs2d_dir, logger, sat_type,

--- a/tests/satellite_observations_test.py
+++ b/tests/satellite_observations_test.py
@@ -10,6 +10,7 @@ rebuild logic, and unify path prefixes across stages.
 import importlib.util
 import logging
 import os
+import socket
 import sys
 from pathlib import Path
 from types import SimpleNamespace
@@ -158,30 +159,8 @@ class TestDownloadSizeValidation:
         obs2d_dir = str(tmp_path)
         os.makedirs(os.path.join(obs2d_dir, 'G19'), exist_ok=True)
 
-        # Build a fake response that yields chunks summing to > cap.
         oversize_total = sat._RAW_SAT_MAX_BYTES + 4 * sat._DOWNLOAD_CHUNK_BYTES
-
-        class FakeResponse:
-            def __init__(self, total):
-                self.remaining = total
-
-            def read(self, n):
-                if self.remaining <= 0:
-                    return b''
-                give = min(n, self.remaining)
-                self.remaining -= give
-                return b'\x00' * give
-
-            def __enter__(self):
-                return self
-
-            def __exit__(self, *args):
-                return False
-
-        with patch.object(
-            sat.urllib.request, 'urlopen',
-            return_value=FakeResponse(oversize_total),
-        ):
+        with _patch_urlopen_yielding(oversize_total):
             result = sat._download_single_file(
                 self.URL, obs2d_dir, logger, 'GOES',
             )
@@ -193,14 +172,43 @@ class TestDownloadSizeValidation:
     def test_download_returns_none_on_timeout(self, tmp_path, logger):
         """A connect/read timeout raises socket.timeout (an OSError);
         the helper catches it, cleans up, and returns None."""
-        import socket as _socket
         obs2d_dir = str(tmp_path)
         os.makedirs(os.path.join(obs2d_dir, 'G19'), exist_ok=True)
 
         with patch.object(
             sat.urllib.request, 'urlopen',
-            side_effect=_socket.timeout('read timed out'),
+            side_effect=socket.timeout('read timed out'),
         ):
+            result = sat._download_single_file(
+                self.URL, obs2d_dir, logger, 'GOES',
+            )
+
+        assert result is None
+        raw_path = os.path.join(obs2d_dir, self.URL.rsplit('/', 1)[-1])
+        assert not os.path.exists(raw_path)
+
+    def test_download_aborts_on_wall_clock_timeout(
+        self, tmp_path, logger, monkeypatch,
+    ):
+        """A slow-loris upstream sending bytes within the per-read timeout
+        but never finishing must be aborted by the wall-clock guard."""
+        obs2d_dir = str(tmp_path)
+        os.makedirs(os.path.join(obs2d_dir, 'G19'), exist_ok=True)
+
+        # Force the wall-clock budget to expire immediately on the
+        # second monotonic() call (inside the loop). The first call
+        # captures the deadline; subsequent calls jump past it.
+        clock = [0.0]
+
+        def fake_monotonic():
+            clock[0] += sat._DOWNLOAD_TOTAL_TIMEOUT_SECONDS + 1
+            return clock[0]
+
+        monkeypatch.setattr(sat.time, 'monotonic', fake_monotonic)
+
+        # urlopen returns a stream that would otherwise yield healthy
+        # bytes — but the wall-clock check trips before any read.
+        with _patch_urlopen_yielding(8 * 1024 * 1024):
             result = sat._download_single_file(
                 self.URL, obs2d_dir, logger, 'GOES',
             )

--- a/tests/satellite_observations_test.py
+++ b/tests/satellite_observations_test.py
@@ -1,0 +1,380 @@
+"""Tests for bin/obs_retrieval/get_satellite_observations.py.
+
+Covers issue #120: partial GOES SST downloads are silently cached and
+later surface as cryptic HDF5 traces from masksat_by_ofs opening a
+missing concat file. The fixes validate per-hour download size, make
+concat_sat honest about write success, fix the stale masked-file
+rebuild logic, and unify path prefixes across stages.
+"""
+
+import importlib.util
+import logging
+import os
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Import the module from bin/ (not on the normal package path)
+# ---------------------------------------------------------------------------
+_MODULE_PATH = (
+    Path(__file__).resolve().parent.parent
+    / 'bin' / 'obs_retrieval' / 'get_satellite_observations.py'
+)
+_spec = importlib.util.spec_from_file_location(
+    'get_satellite_observations', _MODULE_PATH,
+)
+assert _spec is not None and _spec.loader is not None
+sat = importlib.util.module_from_spec(_spec)
+
+logging.basicConfig(level=logging.DEBUG)
+sys.modules['get_satellite_observations'] = sat
+_spec.loader.exec_module(sat)
+
+
+@pytest.fixture
+def logger():
+    return logging.getLogger('test_get_satellite_observations')
+
+
+def _make_byte_file(path, n_bytes):
+    """Create a file at ``path`` of exactly ``n_bytes`` bytes."""
+    Path(path).parent.mkdir(parents=True, exist_ok=True)
+    with open(path, 'wb') as f:
+        f.write(b'\x00' * n_bytes)
+
+
+# ===========================================================================
+# _download_single_file — size validation + cleanup behavior
+# ===========================================================================
+class TestDownloadSizeValidation:
+    """A truncated download or undersized cache must be rejected and cleaned
+    up; the per-hour failure returns None and the caller skips that hour."""
+
+    URL = (
+        'https://example.test/'
+        '20260425170000-NOAA-L3C_GHRSST-SSTsubskin-'
+        'ABI_G19-ACSPO_V3.00-v02.1-fv01.0.nc'
+    )
+
+    def test_rejects_undersized_raw_download(self, tmp_path, logger):
+        """48 KB truncated raw download is removed; returns None."""
+        obs2d_dir = str(tmp_path)
+
+        def fake_urlretrieve(url, dest):
+            _make_byte_file(dest, 48 * 1024)
+            return dest, None
+
+        with patch.object(
+            sat.urllib.request, 'urlretrieve', side_effect=fake_urlretrieve,
+        ):
+            result = sat._download_single_file(
+                self.URL, obs2d_dir, logger, 'GOES',
+            )
+
+        assert result is None
+        # Raw download cleaned up.
+        raw_path = os.path.join(obs2d_dir, self.URL.rsplit('/', 1)[-1])
+        assert not os.path.exists(raw_path)
+        # Trimmed sat_fname was never written.
+        sat_fname = os.path.join(
+            obs2d_dir, 'G19',
+            self.URL.rsplit('/', 1)[-1].rsplit('.', 1)[0].split('.')[0]
+            + '_sst.nc',
+        )
+        assert not os.path.exists(sat_fname)
+
+    def test_rejects_undersized_cached_file(self, tmp_path, logger):
+        """A pre-existing 10 KB cached file is discarded and a re-download
+        is attempted; if the retry also fails, returns None."""
+        obs2d_dir = str(tmp_path)
+        # Pre-create the corrupt cached file.
+        sat_fname = os.path.join(
+            obs2d_dir, 'G19',
+            self.URL.rsplit('/', 1)[-1].rsplit('.', 1)[0].split('.')[0]
+            + '_sst.nc',
+        )
+        _make_byte_file(sat_fname, 10 * 1024)
+        assert os.path.exists(sat_fname)
+
+        # Make the retry fail too — undersized again.
+        def fake_urlretrieve(url, dest):
+            _make_byte_file(dest, 48 * 1024)
+            return dest, None
+
+        with patch.object(
+            sat.urllib.request, 'urlretrieve', side_effect=fake_urlretrieve,
+        ):
+            result = sat._download_single_file(
+                self.URL, obs2d_dir, logger, 'GOES',
+            )
+
+        assert result is None
+        # Cached corrupt file was removed (the new download was also
+        # rejected, so sat_fname stays absent at the end).
+        assert not os.path.exists(sat_fname)
+
+    def test_returns_none_on_urlretrieve_oserror(self, tmp_path, logger):
+        """Mid-stream socket reset returns None; partial file is cleaned up."""
+        obs2d_dir = str(tmp_path)
+        os.makedirs(os.path.join(obs2d_dir, 'G19'), exist_ok=True)
+
+        def fake_urlretrieve(url, dest):
+            # Simulate partial write before the connection drops.
+            _make_byte_file(dest, 30 * 1024)
+            raise ConnectionResetError('connection reset by peer')
+
+        with patch.object(
+            sat.urllib.request, 'urlretrieve', side_effect=fake_urlretrieve,
+        ):
+            result = sat._download_single_file(
+                self.URL, obs2d_dir, logger, 'GOES',
+            )
+
+        assert result is None
+        raw_path = os.path.join(obs2d_dir, self.URL.rsplit('/', 1)[-1])
+        assert not os.path.exists(raw_path)
+
+    def test_accepts_healthy_cached_file(self, tmp_path, logger):
+        """A healthy cached file is returned as-is, no re-download."""
+        obs2d_dir = str(tmp_path)
+        sat_fname = os.path.join(
+            obs2d_dir, 'G19',
+            self.URL.rsplit('/', 1)[-1].rsplit('.', 1)[0].split('.')[0]
+            + '_sst.nc',
+        )
+        _make_byte_file(sat_fname, 100 * 1024)  # > _TRIMMED_SAT_MIN_BYTES
+
+        # urlretrieve must NOT be called.
+        with patch.object(
+            sat.urllib.request, 'urlretrieve',
+            side_effect=AssertionError('should not download'),
+        ):
+            result = sat._download_single_file(
+                self.URL, obs2d_dir, logger, 'GOES',
+            )
+
+        assert result == sat_fname
+
+
+# ===========================================================================
+# get_sat — partial-failure resilience
+# ===========================================================================
+class TestGetSatPartialFailure:
+    def test_continues_when_some_downloads_fail(self, tmp_path, logger):
+        """If some _download_single_file calls return None, get_sat returns
+        the successful subset and does not raise."""
+        urls = [f'https://example.test/file_{i}_G19.nc' for i in range(3)]
+
+        # First two succeed (return path strings), third returns None.
+        def fake_dl(url, obs2d_dir, log, sat_type):
+            if 'file_2' in url:
+                return None
+            return f'/fake/{url.rsplit("/", 1)[-1]}'
+
+        with patch.object(sat, '_download_single_file', side_effect=fake_dl):
+            result = sat.get_sat(urls, str(tmp_path), logger, 'GOES')
+
+        assert len(result) == 2
+        assert all(r is not None for r in result)
+
+
+# ===========================================================================
+# concat_sat — write honesty
+# ===========================================================================
+class TestConcatSatHonesty:
+    """concat_sat must never return a path string for a file it didn't
+    successfully write."""
+
+    def _make_inputs(self, tmp_path):
+        """Make a directory with one valid .nc input, return (obs2d_dir,
+        list_of_files, prop1)."""
+        obs2d_dir = tmp_path / 'obs2d'
+        sat_subdir = obs2d_dir / 'G19'
+        sat_subdir.mkdir(parents=True)
+        # Create a real netCDF input so xr.open_dataset/concat have
+        # something to work with.
+        import numpy as np
+        import xarray as xr
+        ds = xr.Dataset(
+            {'sst': (('time', 'lat', 'lon'), np.zeros((1, 4, 4)))},
+            coords={'time': [0], 'lat': range(4), 'lon': range(4)},
+        )
+        # File basename must contain '00-' so concat_sat's name-munging
+        # produces a meaningful save_path (.split('00-')[-1]).
+        input_path = sat_subdir / (
+            '20260425170000-NOAA-L3C_GHRSST-SSTsubskin-'
+            'ABI_G19-ACSPO_V3.00_sst.nc'
+        )
+        ds.to_netcdf(str(input_path))
+        list_of_files = [str(input_path)]
+        prop1 = SimpleNamespace(
+            start_date_full='2026-04-25T17:00:00Z',
+            end_date_full='2026-04-26T17:00:00Z',
+        )
+        return str(obs2d_dir), list_of_files, prop1
+
+    def test_exits_when_to_netcdf_silently_no_ops(self, tmp_path, logger):
+        """If to_netcdf returns without writing the file, concat_sat must
+        sys.exit rather than return a phantom path."""
+        obs2d_dir, list_of_files, prop1 = self._make_inputs(tmp_path)
+
+        # Patch to_netcdf to silently do nothing. Disable the purge sweep
+        # so it doesn't consume the small synthetic test inputs.
+        with patch.object(sat, '_purge_undersized_sat_files'):
+            with patch('xarray.Dataset.to_netcdf', return_value=None):
+                with pytest.raises(SystemExit):
+                    sat.concat_sat(list_of_files, obs2d_dir, logger, prop1)
+
+    def test_reraises_keyboard_interrupt(self, tmp_path, logger):
+        """KeyboardInterrupt during write must propagate, not be swallowed."""
+        obs2d_dir, list_of_files, prop1 = self._make_inputs(tmp_path)
+
+        with patch.object(sat, '_purge_undersized_sat_files'):
+            with patch(
+                'xarray.Dataset.to_netcdf', side_effect=KeyboardInterrupt,
+            ):
+                with pytest.raises(KeyboardInterrupt):
+                    sat.concat_sat(list_of_files, obs2d_dir, logger, prop1)
+
+    def test_exits_on_oserror_during_write(self, tmp_path, logger):
+        """OSError (disk full, permission denied) during write must abort."""
+        obs2d_dir, list_of_files, prop1 = self._make_inputs(tmp_path)
+
+        with patch.object(sat, '_purge_undersized_sat_files'):
+            with patch(
+                'xarray.Dataset.to_netcdf', side_effect=OSError('disk full'),
+            ):
+                with pytest.raises(SystemExit):
+                    sat.concat_sat(list_of_files, obs2d_dir, logger, prop1)
+
+
+# ===========================================================================
+# _purge_undersized_sat_files
+# ===========================================================================
+class TestPurgeUndersized:
+    def test_removes_undersized_and_keeps_healthy(self, tmp_path, logger):
+        """Sweeps a directory, removing only files below threshold."""
+        d = tmp_path / 'G19'
+        d.mkdir()
+        bad = d / 'bad_sst.nc'
+        good = d / 'good_sst.nc'
+        not_sst = d / 'unrelated.nc'
+        _make_byte_file(str(bad), 10 * 1024)
+        _make_byte_file(str(good), 100 * 1024)
+        _make_byte_file(str(not_sst), 10 * 1024)
+
+        sat._purge_undersized_sat_files(str(d), 50 * 1024, logger)
+
+        assert not bad.exists()
+        assert good.exists()
+        assert not_sst.exists()  # only *_sst.nc are swept
+
+    def test_handles_missing_directory(self, tmp_path, logger):
+        """Nonexistent directory is a no-op, not a crash."""
+        sat._purge_undersized_sat_files(
+            str(tmp_path / 'does-not-exist'), 50 * 1024, logger,
+        )
+
+
+# ===========================================================================
+# _masked_file_is_fresh
+# ===========================================================================
+class TestMaskedFileFreshness:
+    """Stale or undersized masked outputs must trigger rebuild, not be
+    silently reused — that was the latent bug in the original
+    if/else structure at the masked-file check."""
+
+    def test_missing_file_not_fresh(self, tmp_path):
+        """A nonexistent path is unambiguously not fresh."""
+        assert not sat._masked_file_is_fresh(str(tmp_path / 'missing.nc'))
+
+    def test_fresh_large_file_is_fresh(self, tmp_path):
+        """Recently written, sufficiently large file: skip rebuild."""
+        path = tmp_path / 'cbofs.nc'
+        _make_byte_file(str(path), 200 * 1024)
+        assert sat._masked_file_is_fresh(str(path))
+
+    def test_old_file_not_fresh(self, tmp_path):
+        """File older than 1h: must trigger rebuild even if size is fine."""
+        path = tmp_path / 'cbofs.nc'
+        _make_byte_file(str(path), 200 * 1024)
+        # 2 hours old.
+        old = path.stat().st_mtime - 7200
+        os.utime(str(path), (old, old))
+        assert not sat._masked_file_is_fresh(str(path))
+
+    def test_undersized_file_not_fresh(self, tmp_path):
+        """File below 50 KB: must trigger rebuild even if mtime is fresh."""
+        path = tmp_path / 'cbofs.nc'
+        _make_byte_file(str(path), 10 * 1024)  # < 50 KB threshold
+        assert not sat._masked_file_is_fresh(str(path))
+
+
+# ===========================================================================
+# _verify_masked_output
+# ===========================================================================
+class TestVerifyMaskedOutput:
+    """Post-clip verification ensures masked outputs land on disk —
+    catches the failure mode where to_netcdf reports success but
+    leaves nothing for downstream stages to read."""
+
+    def test_passes_for_healthy_file(self, tmp_path, logger):
+        """Healthy file (>= 50 KB): no exception."""
+        path = tmp_path / 'cbofs.nc'
+        _make_byte_file(str(path), 200 * 1024)
+        # Should not raise.
+        sat._verify_masked_output(str(path), logger)
+
+    def test_exits_for_missing_file(self, tmp_path, logger):
+        """Nonexistent path aborts the run."""
+        with pytest.raises(SystemExit):
+            sat._verify_masked_output(str(tmp_path / 'missing.nc'), logger)
+
+    def test_exits_for_undersized_file(self, tmp_path, logger):
+        """File below 50 KB threshold aborts the run."""
+        path = tmp_path / 'cbofs.nc'
+        _make_byte_file(str(path), 10 * 1024)
+        with pytest.raises(SystemExit):
+            sat._verify_masked_output(str(path), logger)
+
+
+# ===========================================================================
+# parameter_dir_validation — path resolution
+# ===========================================================================
+class TestPathResolution:
+    def test_relative_prop_path_resolved_to_absolute(
+        self, tmp_path, logger, monkeypatch,
+    ):
+        """When prop.path is relative, parameter_dir_validation resolves it
+        against cwd so all stages agree on the absolute prefix."""
+        # Set up a fake repo root with the required folders.
+        ofs_extents = tmp_path / 'ofs_extents'
+        ofs_extents.mkdir()
+        (ofs_extents / 'cbofs.shp').write_text('fake')
+
+        monkeypatch.chdir(tmp_path)
+
+        prop = SimpleNamespace(
+            ofs='cbofs',
+            path='./',
+            start_date_full='2026-04-25T17:00:00Z',
+            end_date_full='2026-04-26T17:00:00Z',
+        )
+        dir_params = {
+            'home': str(tmp_path),
+            'ofs_extents_dir': 'ofs_extents',
+            'data_dir': 'data',
+            'observations_dir': 'observations',
+            '2d_satellite_dir': '2d_satellite',
+        }
+
+        sat.parameter_dir_validation(prop, dir_params, logger)
+
+        resolved = prop.data_observations_2d_satellite_path
+        assert os.path.isabs(resolved)
+        assert resolved.startswith(str(tmp_path.resolve()))
+        assert os.path.isdir(resolved)

--- a/tests/satellite_observations_test.py
+++ b/tests/satellite_observations_test.py
@@ -47,6 +47,35 @@ def _make_byte_file(path, n_bytes):
         f.write(b'\x00' * n_bytes)
 
 
+class _FakeStreamingResponse:
+    """Minimal urlopen response stand-in that yields ``total`` bytes
+    of zero-padding in chunked reads."""
+
+    def __init__(self, total):
+        self.remaining = total
+
+    def read(self, n):
+        if self.remaining <= 0:
+            return b''
+        give = min(n, self.remaining)
+        self.remaining -= give
+        return b'\x00' * give
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return False
+
+
+def _patch_urlopen_yielding(n_bytes):
+    """Returns a patch context that makes urlopen yield exactly ``n_bytes``."""
+    return patch.object(
+        sat.urllib.request, 'urlopen',
+        return_value=_FakeStreamingResponse(n_bytes),
+    )
+
+
 # ===========================================================================
 # _download_single_file — size validation + cleanup behavior
 # ===========================================================================
@@ -64,13 +93,7 @@ class TestDownloadSizeValidation:
         """48 KB truncated raw download is removed; returns None."""
         obs2d_dir = str(tmp_path)
 
-        def fake_urlretrieve(url, dest):
-            _make_byte_file(dest, 48 * 1024)
-            return dest, None
-
-        with patch.object(
-            sat.urllib.request, 'urlretrieve', side_effect=fake_urlretrieve,
-        ):
+        with _patch_urlopen_yielding(48 * 1024):
             result = sat._download_single_file(
                 self.URL, obs2d_dir, logger, 'GOES',
             )
@@ -100,14 +123,8 @@ class TestDownloadSizeValidation:
         _make_byte_file(sat_fname, 10 * 1024)
         assert os.path.exists(sat_fname)
 
-        # Make the retry fail too — undersized again.
-        def fake_urlretrieve(url, dest):
-            _make_byte_file(dest, 48 * 1024)
-            return dest, None
-
-        with patch.object(
-            sat.urllib.request, 'urlretrieve', side_effect=fake_urlretrieve,
-        ):
+        # Make the retry fail too — undersized again (48 KB < 1 MB raw min).
+        with _patch_urlopen_yielding(48 * 1024):
             result = sat._download_single_file(
                 self.URL, obs2d_dir, logger, 'GOES',
             )
@@ -117,18 +134,72 @@ class TestDownloadSizeValidation:
         # rejected, so sat_fname stays absent at the end).
         assert not os.path.exists(sat_fname)
 
-    def test_returns_none_on_urlretrieve_oserror(self, tmp_path, logger):
-        """Mid-stream socket reset returns None; partial file is cleaned up."""
+    def test_returns_none_on_connection_error(self, tmp_path, logger):
+        """A mid-stream connection reset (OSError subclass) returns None;
+        any partial file is cleaned up."""
         obs2d_dir = str(tmp_path)
         os.makedirs(os.path.join(obs2d_dir, 'G19'), exist_ok=True)
 
-        def fake_urlretrieve(url, dest):
-            # Simulate partial write before the connection drops.
-            _make_byte_file(dest, 30 * 1024)
-            raise ConnectionResetError('connection reset by peer')
+        with patch.object(
+            sat.urllib.request, 'urlopen',
+            side_effect=ConnectionResetError('connection reset by peer'),
+        ):
+            result = sat._download_single_file(
+                self.URL, obs2d_dir, logger, 'GOES',
+            )
+
+        assert result is None
+        raw_path = os.path.join(obs2d_dir, self.URL.rsplit('/', 1)[-1])
+        assert not os.path.exists(raw_path)
+
+    def test_download_aborts_on_size_cap_exceeded(self, tmp_path, logger):
+        """A misbehaving upstream that streams more than _RAW_SAT_MAX_BYTES
+        is aborted mid-stream; partial file is removed; returns None."""
+        obs2d_dir = str(tmp_path)
+        os.makedirs(os.path.join(obs2d_dir, 'G19'), exist_ok=True)
+
+        # Build a fake response that yields chunks summing to > cap.
+        oversize_total = sat._RAW_SAT_MAX_BYTES + 4 * sat._DOWNLOAD_CHUNK_BYTES
+
+        class FakeResponse:
+            def __init__(self, total):
+                self.remaining = total
+
+            def read(self, n):
+                if self.remaining <= 0:
+                    return b''
+                give = min(n, self.remaining)
+                self.remaining -= give
+                return b'\x00' * give
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                return False
 
         with patch.object(
-            sat.urllib.request, 'urlretrieve', side_effect=fake_urlretrieve,
+            sat.urllib.request, 'urlopen',
+            return_value=FakeResponse(oversize_total),
+        ):
+            result = sat._download_single_file(
+                self.URL, obs2d_dir, logger, 'GOES',
+            )
+
+        assert result is None
+        raw_path = os.path.join(obs2d_dir, self.URL.rsplit('/', 1)[-1])
+        assert not os.path.exists(raw_path)
+
+    def test_download_returns_none_on_timeout(self, tmp_path, logger):
+        """A connect/read timeout raises socket.timeout (an OSError);
+        the helper catches it, cleans up, and returns None."""
+        import socket as _socket
+        obs2d_dir = str(tmp_path)
+        os.makedirs(os.path.join(obs2d_dir, 'G19'), exist_ok=True)
+
+        with patch.object(
+            sat.urllib.request, 'urlopen',
+            side_effect=_socket.timeout('read timed out'),
         ):
             result = sat._download_single_file(
                 self.URL, obs2d_dir, logger, 'GOES',
@@ -148,9 +219,9 @@ class TestDownloadSizeValidation:
         )
         _make_byte_file(sat_fname, 100 * 1024)  # > _TRIMMED_SAT_MIN_BYTES
 
-        # urlretrieve must NOT be called.
+        # urlopen must NOT be called.
         with patch.object(
-            sat.urllib.request, 'urlretrieve',
+            sat.urllib.request, 'urlopen',
             side_effect=AssertionError('should not download'),
         ):
             result = sat._download_single_file(


### PR DESCRIPTION
### Description of Changes

Closes #120.

Partial GOES SST downloads from the NESDIS THREDDS server were leaving ~48 KB truncated `.nc` files in `data/observations/2d_satellite/G19/` (vs healthy ~8 MB). The pipeline silently re-used the corrupt cache on every subsequent run, then `masksat_by_ofs` surfaced a cryptic HDF5 `H5FD__sec2_open(): No such file or directory` traceback when it tried to open a concat output that had never actually been written. Three independent bugs combined to produce the observed symptom; this PR fixes all three.

**Changes in `bin/obs_retrieval/get_satellite_observations.py`:**

- `_download_single_file`: validate raw download size (≥ 1 MB), trimmed output size (≥ 50 KB), and cached file size on the reuse path. Wrap `urllib.request.urlretrieve` in a narrow except for `URLError`/`OSError` so partial files are deterministically cleaned up. Per-hour failures `return None` so the caller drops that hour and continues — the missing hour shows up as a gap in the concat rather than aborting the run.
- `concat_sat`: post-write existence + size verification (catches phantom paths). Broadened write-time except to also cover `OSError`/`RuntimeError`. `KeyboardInterrupt` is re-raised instead of swallowed. Cache short-circuit and post-write verify use separate thresholds (1 MB cache, 50 KB verify) so a 1-hour smoke run still passes verification. New `_purge_undersized_sat_files` sweep before re-concat cleans up legacy corrupt caches from pre-fix runs.
- Stale masked-file rebuild: refactored the `if/else` so a stale or undersized `<ofs>.nc` triggers rebuild instead of being silently re-used. New `_verify_masked_output` aborts on missing/undersized clip.
- Path-prefix unification: `parameter_dir_validation` resolves `prop.path` to absolute once. Drops the inconsistent `Path.cwd()` / `Path(__file__).parent.parent.parent` patterns that broke when cwd ≠ install prefix.
- `get_satellite`: end-of-run hour-coverage summary log (INFO when full, WARNING when partial) so silent partial concats can't masquerade as full coverage downstream.
- All size thresholds extracted as module-level constants for clarity.

**New tests in `tests/satellite_observations_test.py`:** 18 unit tests covering download size validation, `urlretrieve` `OSError` cleanup, `get_sat` partial-failure resilience, `concat_sat` write honesty (phantom path, `KeyboardInterrupt`, `OSError`), purge sweep, masked-file freshness, post-clip verify, and cwd-independent path resolution.

Suggested label: `bug` (could not add directly — fork contributor lacks label permission on upstream repo; please add on merge).

### Expected Outcome of Changes

- The HDF5 `No such file or directory` traceback that motivated #120 no longer occurs. Identical user-facing invocation; no CLI changes.
- Operational runs continue with a temporal gap when individual NESDIS hourly files are unavailable, rather than aborting the entire job. Coverage is logged at WARNING level so downstream consumers can see at a glance whether the concat is complete.
- Output files (`<ofs>.nc`, `<ofs>_sport.nc`, the GOES/SPoRT concats) land in the same directory regardless of which `cwd` the script was launched from, eliminating the silent-mismatch failure mode on systems installed under e.g. `/opt/ofs_dps/`.
- No changes to web-app inputs, JSON schemas, or station/skill output formats.

### Developer Questions and Checklist
**Is this a high priority PR? If yes, why and is there a date by which it needs to be merged?**
Medium priority — fixes issue (#120) that produces confusing HDF5 stderr traces and silent corruption on systems with intermittent connectivity to NESDIS THREDDS. 

**Are there any changes needed to how the code should be run for operational runs? (Commands, flags, job timings, etc.)**
No. Same CLI, same flags, same expected runtime.

**Does this update need to be deployed for operational runs?**
Yes — operational systems running the 2D pipeline against NESDIS see the same intermittent 503/timeout pattern that motivated this fix. After deployment, ops should see WARNING-level coverage summaries on partial-NESDIS days instead of silent corruption.

**Does this update require front end/web app changes? (If yes, provide documentation to Min)**
No.

**Does this impact code development work on adding SCHISM?**
No.

**Does this impact code development work on adding ADCIRC?**
No.

- [x] Developer's name is removed throughout the code?
- [x] Did you add relevant labels to the PR? 
- [x] Have you run pylint and is the code at an acceptable pylint score (>8)? — 9.32 → 9.46 on the modified file (+0.14).
- [x] Jobs contain the appropriate file checking and handle errors for any missing data? — this PR is specifically about hardening that exact behavior.
- [x] Is log free of critical ERRORs or WARNINGs? For errors that are not critical and can remain in code, is there sufficient handling and logging? — under healthy NESDIS, run is silent at INFO. Under partial NESDIS, single WARNING summary line. ERRORs only on actual abort conditions (concat write failure, masked-output verification failure).

### Testing Instructions

**1. Unit tests **
```
pytest tests/satellite_observations_test.py -v --no-cov
```
Expected: 18 passing.

**2. Full test suite **
```
pytest tests/ --no-cov -q
```
Expected: 473 passing, 0 failing. Baseline pre-PR was 455; this PR adds 18.

**3. Live e2e against NESDIS (cbofs, 24-hour window)**
```
rm -rf data/observations/2d_satellite/   # clean cache
python ./bin/obs_retrieval/get_satellite_observations.py \
    -o cbofs -p ./ -s 2026-04-25T17:00:00Z -e 2026-04-26T17:00:00Z
```
Expected:
- Healthy NESDIS day: GOES concat, SPoRT concat, `cbofs.nc`, `cbofs_sport.nc` all on disk; INFO-level coverage summary.
- Degraded NESDIS day (some 503/timeouts): WARNING-level coverage summary like `Satellite hour-coverage summary: requested 25 hours; GOES X/25 files retrieved; SPoRT Y/3 files retrieved`. Run still exits 0. No HDF5 phantom-path stderr traceback.

**4. Forced corrupt-cache scenario**
```
mkdir -p data/observations/2d_satellite/G19
dd if=/dev/zero of=data/observations/2d_satellite/G19/20260425170000-NOAA-L3C_GHRSST-SSTsubskin-ABI_G19-ACSPO_V3_sst.nc bs=1024 count=48
python ./bin/obs_retrieval/get_satellite_observations.py \
    -o cbofs -p ./ -s 2026-04-25T17:00:00Z -e 2026-04-26T17:00:00Z
```
Expected: WARNING `Cached file ... is undersized (49152 bytes < 51200); removing and re-downloading`. The corrupt 48 KB file is removed, replaced by a re-download (or skipped if re-download also fails). No HDF5 trace.

**5. cwd-independent path test**
From any non-repo directory:
```
cd /tmp && python /path/to/repo/bin/obs_retrieval/get_satellite_observations.py \
    -o cbofs -p /path/to/repo/ -s 2026-04-25T17:00:00Z -e 2026-04-26T17:00:00Z
```
Expected: all download / concat / masked outputs under `/path/to/repo/data/observations/2d_satellite/`, NOT under `/tmp/data/...`.

**Cast coverage**
This PR only modifies the satellite observation retrieval, which is whichcast-agnostic. No cast-specific testing required for this script. Reviewers running the broader 2D pipeline should still test `nowcast`, `forecast_a`, and `forecast_b` to confirm the path-resolution change doesn't impact downstream `create_2dplot.py` orchestration (it should not — `prop.data_observations_2d_satellite_path` is now consistent.

### Reminder checklist for PR reviewer
- [ ] Run PEP8 compliance tests to ensure the code follows best practices
- [ ] Check that documentation in the script is sufficient
- [ ] Validate the output values (if applicable) to make sure the calculations are correct and make scientific/physical sense; include a comment on the pull request including what validation you performed, for replicability.
- [ ] Test code both on Windows and Linux (and MacOS, if available), using several OFS as test cases
- [ ] **Test for all 'cast' options: forecast_a, forecast_b, and nowcast**
- [ ] When approving or commenting on a pull request, add information on the calls you use in case they need to be replicated or referenced.

