### PR TITLE
Add OFS Shapefile Overlap Utility

### DIFF
--- a/bin/utils/get_shapefile_intersection.py
+++ b/bin/utils/get_shapefile_intersection.py
@@ -4,6 +4,7 @@ import argparse
 import logging
 import logging.config
 from pathlib import Path
+from datetime import datetime
 
 import geopandas as gpd
 
@@ -11,7 +12,7 @@ from ofs_skill.obs_retrieval.filter_inventory import filter_inventory
 from ofs_skill.obs_retrieval.ofs_inventory_stations import retrieving_inventories
 from ofs_skill.obs_retrieval.ofs_geometry import ofs_geometry
 
-def get_shapefile_intersection(shp1, shp2, home_path, stationowner, start_date, end_date, logger=None):
+def get_shapefile_intersection(shp1, shp2, home_path, stationowner, logger=None):
     """
     Takes two shapefiles, finds their overlapping areas,
     and writes the result to a new shapefile. Then a new inventory is
@@ -77,6 +78,8 @@ def get_shapefile_intersection(shp1, shp2, home_path, stationowner, start_date, 
         sys.exit(-1)
 
     # --- Inventory Retrieval ---
+    start_date = datetime.now().strftime("%Y-%m-%d")
+    end_date = start_date
     try:
         logger.info('Initializing geometry and retrieving inventories...')
         geo = ofs_geometry(new_ofs, home_path, logger, None)
@@ -119,12 +122,6 @@ if __name__ == "__main__":
                         required=False,
                         default='co-ops,ndbc,usgs,chs',
                         help="Input station provider to use: 'CO-OPS', 'NDBC', 'USGS', 'CHS'")
-    parser.add_argument('-s', '--start_date',
-                        required=False,
-                        help="Assessment start date: YYYY-MM-DDThh:mm:ssZ e.g. '2023-01-01T12:34:00Z'")
-    parser.add_argument('-e', '--end_date',
-                        required=False,
-                        help="Assessment end date: YYYY-MM-DDThh:mm:ssZ e.g. '2023-01-01T12:34:00Z'")
 
     args = parser.parse_args()
 
@@ -134,7 +131,5 @@ if __name__ == "__main__":
         shp2=args.ofs2.lower(),
         home_path=args.home_path,
         stationowner=args.station_owner,
-        start_date=args.start_date,
-        end_date=args.end_date,
         logger=None
     )

--- a/bin/utils/get_shapefile_intersection.py
+++ b/bin/utils/get_shapefile_intersection.py
@@ -1,135 +1,229 @@
-import os
-import sys
+"""
+Compute the spatial intersection of two OFS shapefiles and build an
+observation-station inventory restricted to the overlap region.
+
+Outputs:
+    ofs_extents/{ofs1}_{ofs2}_overlap.shp
+    control_files/inventory_all_{ofs1}_{ofs2}_overlap.csv
+
+@author: PL
+"""
+from __future__ import annotations
+
 import argparse
 import logging
 import logging.config
-from pathlib import Path
+import os
+import sys
 from datetime import datetime
+from pathlib import Path
 
 import geopandas as gpd
 
 from ofs_skill.obs_retrieval.filter_inventory import filter_inventory
-from ofs_skill.obs_retrieval.ofs_inventory_stations import retrieving_inventories
 from ofs_skill.obs_retrieval.ofs_geometry import ofs_geometry
+from ofs_skill.obs_retrieval.ofs_inventory_stations import retrieving_inventories
+
+
+def _resolve_ofs_shapefile(ofs_name, shape_path):
+    """Resolve {ofs_name}.shp inside shape_path and reject any value that
+    escapes that directory via ``..`` or an absolute prefix."""
+    base = Path(shape_path).resolve()
+    candidate = (base / f'{ofs_name}.shp').resolve()
+    try:
+        candidate.relative_to(base)
+    except ValueError as exc:
+        raise ValueError(
+            f'OFS name {ofs_name!r} resolves outside {base}'
+        ) from exc
+    return candidate
+
 
 def get_shapefile_intersection(shp1, shp2, home_path, stationowner, logger=None):
-    """
-    Takes two shapefiles, finds their overlapping areas,
-    and writes the result to a new shapefile. Then a new inventory is
-    collected
-    """
+    """Find overlap between two OFS shapefiles, write it as a new shapefile,
+    then retrieve an observation-station inventory inside the overlap."""
 
     # --- Logger Setup ---
     if logger is None:
         log_config_file = os.path.join(home_path, 'conf', 'logging.conf')
 
         if not os.path.isfile(log_config_file):
-            print(f"CRITICAL ERROR: Log config file not found at {log_config_file}")
-            sys.exit(-1)
+            print(f'CRITICAL ERROR: Log config file not found at {log_config_file}')
+            sys.exit(1)
 
         logging.config.fileConfig(log_config_file)
         logger = logging.getLogger('root')
-        logger.info(f"Using log config {log_config_file}")
+        logger.info('Using log config %s', log_config_file)
 
     logger.info('--- Starting Overlap Process ---')
 
     # --- Shapefile Setup & Loading ---
     shape_path = os.path.join(home_path, 'ofs_extents')
 
-    logger.info(f"Loading first shapefile: {shp1}...")
     try:
-        shp1_path = os.path.join(shape_path, f"{shp1}.shp")
-        gdf1 = gpd.read_file(shp1_path)
-    except Exception as e:
-        logger.error(f"Error loading {shp1_path}: {e}")
-        sys.exit(-1)
+        shp1_path = _resolve_ofs_shapefile(shp1, shape_path)
+        shp2_path = _resolve_ofs_shapefile(shp2, shape_path)
+    except ValueError as exc:
+        logger.error('Invalid OFS argument: %s', exc)
+        sys.exit(1)
 
-    logger.info(f"Loading second shapefile: {shp2}...")
+    logger.info('Loading first shapefile: %s...', shp1)
     try:
-        shp2_path = os.path.join(shape_path, f"{shp2}.shp")
+        gdf1 = gpd.read_file(shp1_path)
+    except (OSError, ValueError) as exc:
+        logger.error('Error loading %s: %s', shp1_path, exc)
+        sys.exit(1)
+
+    logger.info('Loading second shapefile: %s...', shp2)
+    try:
         gdf2 = gpd.read_file(shp2_path)
-    except Exception as e:
-        logger.error(f"Error loading {shp2_path}: {e}")
-        sys.exit(-1)
+    except (OSError, ValueError) as exc:
+        logger.error('Error loading %s: %s', shp2_path, exc)
+        sys.exit(1)
 
     # --- Spatial Intersection ---
     if gdf1.crs != gdf2.crs:
-        logger.warning("CRS mismatch detected. Reprojecting the second shapefile to match the first...")
+        logger.warning(
+            'CRS mismatch detected. Reprojecting the second shapefile to '
+            'match the first...'
+        )
         gdf2 = gdf2.to_crs(gdf1.crs)
 
-    logger.info("Calculating intersection...")
+    logger.info('Calculating intersection...')
     intersection_gdf = gpd.overlay(gdf1, gdf2, how='intersection')
 
     if intersection_gdf.empty:
-        logger.info("No overlapping areas were found between the two shapefiles. No output created.")
+        logger.info(
+            'No overlapping areas were found between the two shapefiles. '
+            'No output created.'
+        )
         return
 
+    # Downstream ofs_geometry keeps only the largest polygon — warn when the
+    # intersection produces multiple features or a mixed geometry type so
+    # disconnected legitimate pieces aren't silently dropped without notice.
+    if len(intersection_gdf) > 1:
+        logger.warning(
+            'Intersection produced %d separate features; downstream '
+            'ofs_geometry will use the largest polygon only.',
+            len(intersection_gdf),
+        )
+    if 'GeometryCollection' in set(intersection_gdf.geom_type.unique()):
+        logger.warning(
+            'Intersection contains a GeometryCollection (mixed geometry '
+            'types). Inspect the output before relying on the inventory.'
+        )
+
+    # Pin the output to EPSG:4326. ofs_geometry reads point coordinates
+    # without consulting the .prj file, so we cannot rely on it to handle
+    # non-WGS84 inputs correctly.
+    if intersection_gdf.crs is None or intersection_gdf.crs.to_epsg() != 4326:
+        intersection_gdf = intersection_gdf.to_crs(4326)
+
     # --- Save New Shapefile ---
-    logger.info(f"Saving overlapping areas to {shape_path}...")
-    new_ofs = f"{shp1}_{shp2}_overlap"
+    logger.info('Saving overlapping areas to %s...', shape_path)
+    new_ofs = f'{shp1}_{shp2}_overlap'
 
     try:
-        intersection_gdf = intersection_gdf.rename(columns={'Shape_Leng_2': 'Shp_Lng_2'})
-        shp3_path = os.path.join(shape_path, f"{new_ofs}.shp")
+        # Drop the overlay-suffixed metadata columns (OBJECTID_1/_2,
+        # Shape_Leng_1/_2, Shape_Area_1/_2, BUFF_DIST_1/_2, ...) before
+        # write. The DBF format silently truncates field names to 10 chars,
+        # which can collide _1/_2 pairs into a single column. The overlap
+        # polygon is the only attribute any downstream consumer needs.
+        intersection_gdf = intersection_gdf[['geometry']]
+        shp3_path = os.path.join(shape_path, f'{new_ofs}.shp')
         intersection_gdf.to_file(shp3_path)
-        logger.info(f"Successfully saved {new_ofs}.shp!")
-    except Exception as e:
-        logger.error(f"Error saving to {shape_path}: {e}")
-        sys.exit(-1)
+        logger.info('Successfully saved %s.shp!', new_ofs)
+    except (OSError, ValueError) as exc:
+        logger.error('Error saving to %s: %s', shape_path, exc)
+        sys.exit(1)
 
     # --- Inventory Retrieval ---
-    start_date = datetime.now().strftime("%Y-%m-%d")
+    # retrieving_inventories accepts %Y-%m-%d directly. The format differs
+    # from the rest of the codebase because we bypass
+    # ofs_inventory_stations.parameter_validation, which expects %Y%m%d.
+    start_date = datetime.now().strftime('%Y-%m-%d')
     end_date = start_date
     try:
         logger.info('Initializing geometry and retrieving inventories...')
         geo = ofs_geometry(new_ofs, home_path, logger, None)
 
         dataset_final = retrieving_inventories(
-            geo, start_date, end_date, new_ofs, stationowner, logger, config_file=None
+            geo, start_date, end_date, new_ofs, stationowner, logger,
+            config_file=None,
         )
 
-        logger.info('Searching for and filtering duplicate stations in inventory file...')
+        logger.info(
+            'Searching for and filtering duplicate stations in inventory '
+            'file...'
+        )
         dataset_final = filter_inventory(dataset_final, [], logger)
         logger.info('Duplicate station filter complete!')
 
         control_files_path = os.path.join(home_path, 'control_files')
-        inventory_file_path = os.path.join(control_files_path, f"inventory_all_{new_ofs}.csv")
+        inventory_file_path = os.path.join(
+            control_files_path, f'inventory_all_{new_ofs}.csv'
+        )
+
+        if os.path.exists(inventory_file_path):
+            logger.warning(
+                'Overwriting existing inventory file: %s',
+                inventory_file_path,
+            )
 
         dataset_final.to_csv(inventory_file_path)
-        logger.info(f"Final Inventory saved as: {inventory_file_path}")
+        logger.info('Final Inventory saved as: %s', inventory_file_path)
 
     except Exception as ex:
-        logger.error(f"Error creating inventory file inventory_all_{new_ofs}.csv -- {ex}")
-        raise Exception('Error happened at ofs_inventory_stations') from ex
+        logger.exception(
+            'Error creating inventory file inventory_all_%s.csv', new_ofs
+        )
+        raise RuntimeError(
+            f'Inventory retrieval failed for {new_ofs}'
+        ) from ex
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     parser = argparse.ArgumentParser(
-        description="Find the overlapping area between two OFS shapefiles and save to a new shapefile."
+        description=(
+            'Find the overlapping area between two OFS shapefiles, save '
+            'the intersection as a new shapefile, and build an '
+            'observation-station inventory inside the overlap.'
+        ),
     )
 
-    # Define standard POSIX command-line arguments
-    parser.add_argument('-o1', '--ofs1',
-                        required=True,
-                        help="First OFS to overlap")
-    parser.add_argument('-o2', '--ofs2',
-                        required=True,
-                        help="Second OFS to overlap")
-    parser.add_argument('-p', '--home_path',
-                        required=True,
-                        help="Path to directory where package is installed")
-    parser.add_argument('-so', '--station_owner',
-                        required=False,
-                        default='co-ops,ndbc,usgs,chs',
-                        help="Input station provider to use: 'CO-OPS', 'NDBC', 'USGS', 'CHS'")
+    parser.add_argument(
+        '-o1', '--ofs1',
+        required=True,
+        help='First OFS to overlap',
+    )
+    parser.add_argument(
+        '-o2', '--ofs2',
+        required=True,
+        help='Second OFS to overlap',
+    )
+    parser.add_argument(
+        '-p', '--home_path',
+        required=True,
+        help='Path to directory where package is installed',
+    )
+    parser.add_argument(
+        '-so', '--station_owner',
+        required=False,
+        default='co-ops,ndbc,usgs,chs',
+        help=(
+            'Comma-separated station providers to include. Valid choices: '
+            "'co-ops', 'ndbc', 'usgs', 'chs' "
+            "(default: 'co-ops,ndbc,usgs,chs')."
+        ),
+    )
 
     args = parser.parse_args()
 
-    # Run the function
     get_shapefile_intersection(
         shp1=args.ofs1.lower(),
         shp2=args.ofs2.lower(),
         home_path=args.home_path,
         stationowner=args.station_owner,
-        logger=None
+        logger=None,
     )

--- a/bin/utils/get_shapefile_intersection.py
+++ b/bin/utils/get_shapefile_intersection.py
@@ -1,0 +1,140 @@
+import os
+import sys
+import argparse
+import logging
+import logging.config
+from pathlib import Path
+
+import geopandas as gpd
+
+from ofs_skill.obs_retrieval.filter_inventory import filter_inventory
+from ofs_skill.obs_retrieval.ofs_inventory_stations import retrieving_inventories
+from ofs_skill.obs_retrieval.ofs_geometry import ofs_geometry
+
+def get_shapefile_intersection(shp1, shp2, home_path, stationowner, start_date, end_date, logger=None):
+    """
+    Takes two shapefiles, finds their overlapping areas,
+    and writes the result to a new shapefile. Then a new inventory is
+    collected
+    """
+
+    # --- Logger Setup ---
+    if logger is None:
+        log_config_file = os.path.join(home_path, 'conf', 'logging.conf')
+
+        if not os.path.isfile(log_config_file):
+            print(f"CRITICAL ERROR: Log config file not found at {log_config_file}")
+            sys.exit(-1)
+
+        logging.config.fileConfig(log_config_file)
+        logger = logging.getLogger('root')
+        logger.info(f"Using log config {log_config_file}")
+
+    logger.info('--- Starting Overlap Process ---')
+
+    # --- Shapefile Setup & Loading ---
+    shape_path = os.path.join(home_path, 'ofs_extents')
+
+    logger.info(f"Loading first shapefile: {shp1}...")
+    try:
+        shp1_path = os.path.join(shape_path, f"{shp1}.shp")
+        gdf1 = gpd.read_file(shp1_path)
+    except Exception as e:
+        logger.error(f"Error loading {shp1_path}: {e}")
+        sys.exit(-1)
+
+    logger.info(f"Loading second shapefile: {shp2}...")
+    try:
+        shp2_path = os.path.join(shape_path, f"{shp2}.shp")
+        gdf2 = gpd.read_file(shp2_path)
+    except Exception as e:
+        logger.error(f"Error loading {shp2_path}: {e}")
+        sys.exit(-1)
+
+    # --- Spatial Intersection ---
+    if gdf1.crs != gdf2.crs:
+        logger.warning("CRS mismatch detected. Reprojecting the second shapefile to match the first...")
+        gdf2 = gdf2.to_crs(gdf1.crs)
+
+    logger.info("Calculating intersection...")
+    intersection_gdf = gpd.overlay(gdf1, gdf2, how='intersection')
+
+    if intersection_gdf.empty:
+        logger.info("No overlapping areas were found between the two shapefiles. No output created.")
+        return
+
+    # --- Save New Shapefile ---
+    logger.info(f"Saving overlapping areas to {shape_path}...")
+    new_ofs = f"{shp1}_{shp2}_overlap"
+
+    try:
+        intersection_gdf = intersection_gdf.rename(columns={'Shape_Leng_2': 'Shp_Lng_2'})
+        shp3_path = os.path.join(shape_path, f"{new_ofs}.shp")
+        intersection_gdf.to_file(shp3_path)
+        logger.info(f"Successfully saved {new_ofs}.shp!")
+    except Exception as e:
+        logger.error(f"Error saving to {shape_path}: {e}")
+        sys.exit(-1)
+
+    # --- Inventory Retrieval ---
+    try:
+        logger.info('Initializing geometry and retrieving inventories...')
+        geo = ofs_geometry(new_ofs, home_path, logger, None)
+
+        dataset_final = retrieving_inventories(
+            geo, start_date, end_date, new_ofs, stationowner, logger, config_file=None
+        )
+
+        logger.info('Searching for and filtering duplicate stations in inventory file...')
+        dataset_final = filter_inventory(dataset_final, [], logger)
+        logger.info('Duplicate station filter complete!')
+
+        control_files_path = os.path.join(home_path, 'control_files')
+        inventory_file_path = os.path.join(control_files_path, f"inventory_all_{new_ofs}.csv")
+
+        dataset_final.to_csv(inventory_file_path)
+        logger.info(f"Final Inventory saved as: {inventory_file_path}")
+
+    except Exception as ex:
+        logger.error(f"Error creating inventory file inventory_all_{new_ofs}.csv -- {ex}")
+        raise Exception('Error happened at ofs_inventory_stations') from ex
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Find the overlapping area between two OFS shapefiles and save to a new shapefile."
+    )
+
+    # Define standard POSIX command-line arguments
+    parser.add_argument('-o1', '--ofs1',
+                        required=True,
+                        help="First OFS to overlap")
+    parser.add_argument('-o2', '--ofs2',
+                        required=True,
+                        help="Second OFS to overlap")
+    parser.add_argument('-p', '--home_path',
+                        required=True,
+                        help="Path to directory where package is installed")
+    parser.add_argument('-so', '--station_owner',
+                        required=False,
+                        default='co-ops,ndbc,usgs,chs',
+                        help="Input station provider to use: 'CO-OPS', 'NDBC', 'USGS', 'CHS'")
+    parser.add_argument('-s', '--start_date',
+                        required=False,
+                        help="Assessment start date: YYYY-MM-DDThh:mm:ssZ e.g. '2023-01-01T12:34:00Z'")
+    parser.add_argument('-e', '--end_date',
+                        required=False,
+                        help="Assessment end date: YYYY-MM-DDThh:mm:ssZ e.g. '2023-01-01T12:34:00Z'")
+
+    args = parser.parse_args()
+
+    # Run the function
+    get_shapefile_intersection(
+        shp1=args.ofs1.lower(),
+        shp2=args.ofs2.lower(),
+        home_path=args.home_path,
+        stationowner=args.station_owner,
+        start_date=args.start_date,
+        end_date=args.end_date,
+        logger=None
+    )


### PR DESCRIPTION
### Description of Changes

This PR introduces a new command-line utility for identifying overlapping areas between two OFS shapefiles and automatically generating inventory files for observation stations within the overlapping region. Each overlapping OFS can then be run with the same set of observation stations, which will facilitate inter-model comparisons.

#### Changes
- **New file**: `bin/utils/get_shapefile_intersection.py` - A utility script that:
  - Loads two OFS shapefiles and calculates their spatial intersection using GeoPandas
  - Automatically handles coordinate reference system (CRS) mismatches by reprojecting to match
  - Saves the resulting overlapping geometry as a new shapefile
  - Auto-generates an inventory of observation stations within the overlapping area

### Expected Outcome of Changes

Improved functionality for comparing different models that have overlapping domains.

### Developer Questions and Checklist
**Is this a high priority PR? If yes, why and is there a date by which it needs to be merged?**
No.

**Are there any changes needed to how the code should be run on the server? (Commands, flags, job timings, etc.)**
No.

**Does this update need to be installed on the server?**
Yes.

**Does this update require front end/web app changes? (If yes, provide documentation to Min)**
No.

**Does this impact code development work on adding SCHISM? (If yes, tag Atieh)**
No.

**Does this impact code development work on adding ADCIRC?**
_No/Yes + tag Jack if yes_
No.

**Does this impact the expected number of output files for integration tests (i.e., will the integration test fail even though code changes result in desired change in the number of outputs?)**
No.

- [x] Developer's name is removed throughout the code?
- [x] Did you add relevant labels to the PR?
- [x] Have you run pylint and is the code at an acceptable pylint score? (>8.0)
- [x] Jobs contain the appropriate file checking and handle errors for any missing data?
- [x] Is log free of critical ERRORs or WARNINGs? For errors that are not critical and can remain in code, is there sufficient handling and logging?

### Testing Instructions

**Basic usage**:

`python ./bin/utils/get_shapefile_intersection.py -o1 necofs -o2 stofs_3d_atl -p ./`

**Custom station providers**:

`python ./bin/utils/get_shapefile_intersection.py -o1 necofs -o2 stofs_3d_atl -p ./ -so co-ops,ndbc`

**Arguments**:

`-o1`, `--ofs1`: First OFS shapefile to overlap (required)
`-o2`, `--ofs2`: Second OFS shapefile to overlap (required)
`-p`, `--home_path`: Path to package installation directory (required)
`-so`, `--station_owner`: Station provider selection (optional, default: 'co-ops,ndbc,usgs,chs')

**Output**:

Shapefile: `ofs_extents/{ofs1}_{ofs2}_overlap.shp`
Inventory CSV: `control_files/inventory_all_{ofs1}_{ofs2}_overlap.csv`

**Testing**

Run the script for two OFS that overlap, and two that do not. The non-overlapping OFS should cause the program to exit. Check that the overlapping OFS generate a new shapefile, and a new inventory file.

Next, check if the inventory file accurately contains only stations in the intersecting shapefile, and did not miss any stations that should be in the intersecting shapefile. 
1) Run `ofs_inventory_stations_cli.py` for both OFS from your overlap test above.
2) In the [attached test file](https://github.com/user-attachments/files/27226432/get_shapefile_intersection_test.py), replace the paths to the intersecting shapefile, the intersecting inventory file, the complete inventory file for OFS1 and the complete inventory file for OFS2.
3) Run the test file.
4) Excluded stations and stations that are included but outside the intersecting shapefile will be logged and saved to a CSV.

Note that the test uses a slightly different routine than `ofs_inventory_stations` to find stations within a shapefile. So for any excluded or erroneously included stations that the test identifies, please verify that they are actually incorrect by checking their location either using google or on the web application.

### Reminder checklist for PR reviewer:
- [x] Run PEP8 compliance tests to ensure the code follows best practices
- [x] Check that documentation in the script is sufficient
- [x] Validate the output values (if applicable) to make sure the calculations are correct and make scientific/physical sense; include a comment on the pull request including what validation you performed, for replicability.
- [x] Test code both locally and on the linux server, using several OFS as test cases
- [x] **Test for all ‘cast’ options: forecast_a, forecast_b, and nowcast**
- [x] When approving or commenting on a pull request, add information on the calls you use in case they need to be replicated.
