### PR TITLE
Add station summary barplots & NECOFS  / STOFS fixes

### DIFF
--- a/bin/visualization/create_1dplot.py
+++ b/bin/visualization/create_1dplot.py
@@ -334,10 +334,10 @@ def _emit_summary_barplots(prop, var_info, logger):
             prop.whichcast = whichcast
             try:
                 summary_barplots.make_summary_bars(prop, var_info, logger)
-            except Exception as ex:
-                logger.warning(
-                    'Summary bar plot failed for %s/%s/%s: %s',
-                    prop.ofs, var_info[0], whichcast, ex)
+            except Exception:
+                logger.exception(
+                    'Summary bar plot failed for %s/%s/%s',
+                    prop.ofs, var_info[0], whichcast)
     finally:
         if saved_whichcast is not None:
             prop.whichcast = saved_whichcast

--- a/bin/visualization/create_1dplot.py
+++ b/bin/visualization/create_1dplot.py
@@ -80,7 +80,6 @@ import pandas as pd
 from ofs_skill.model_processing import (
     check_model_files,
     get_fcst_dates,
-    get_fcst_hours,
     model_properties,
     parse_ofs_ctlfile,
     read_vdatum_from_bucket,
@@ -89,7 +88,7 @@ from ofs_skill.obs_retrieval import parse_arguments_to_list, utils
 from ofs_skill.obs_retrieval.station_ctl_file_extract import station_ctl_file_extract
 from ofs_skill.obs_retrieval.utils import get_parallel_config
 from ofs_skill.skill_assessment.get_skill import get_skill
-from ofs_skill.visualization import create_gui, plotting_scalar, plotting_vector
+from ofs_skill.visualization import create_gui, plotting_scalar, plotting_vector, summary_barplots
 
 warnings.filterwarnings('ignore')
 
@@ -321,6 +320,29 @@ def _process_station_plot(
     return station_id_val
 
 
+def _emit_summary_barplots(prop, var_info, logger):
+    """Generate per-whichcast station summary bar plots after the
+    per-station plots for this variable have been written.  Failures
+    are logged but never propagated -- a buggy summary plot must not
+    abort the rest of the run.
+    """
+    saved_whichcast = getattr(prop, 'whichcast', None)
+    try:
+        for whichcast in getattr(prop, 'whichcasts', [saved_whichcast]):
+            if whichcast is None:
+                continue
+            prop.whichcast = whichcast
+            try:
+                summary_barplots.make_summary_bars(prop, var_info, logger)
+            except Exception as ex:
+                logger.warning(
+                    'Summary bar plot failed for %s/%s/%s: %s',
+                    prop.ofs, var_info[0], whichcast, ex)
+    finally:
+        if saved_whichcast is not None:
+            prop.whichcast = saved_whichcast
+
+
 def _ensure_paired_data_exists(read_ofs_ctl_file, prop, var_info, logger):
     """
     Pre-check for missing paired data files and call get_skill()
@@ -513,6 +535,7 @@ def _plot_variable_for_cycle(variable, prop, logger):
     if read_ofs_ctl_file is not None:
         create_1dplot_2nd_part(
             read_ofs_ctl_file, prop, var_info, logger)
+        _emit_summary_barplots(prop, var_info, logger)
 
 
 def create_1dplot(prop, logger):
@@ -831,6 +854,7 @@ def create_1dplot(prop, logger):
             create_1dplot_2nd_part(
                 read_ofs_ctl_file, p, var_info,
                 logger)
+            _emit_summary_barplots(p, var_info, logger)
 
     # --- Forecast cycle parallelism for forecast_a mode ---
     parallel_config = get_parallel_config(logger)

--- a/bin/visualization/create_summary_barplots.py
+++ b/bin/visualization/create_summary_barplots.py
@@ -90,10 +90,10 @@ def main(prop):
             prop.whichcast = whichcast
             try:
                 summary_barplots.make_summary_bars(prop, var_info, logger)
-            except Exception as ex:
-                logger.error(
-                    'Summary bar plot failed for %s/%s/%s: %s',
-                    prop.ofs, variable, whichcast, ex)
+            except Exception:
+                logger.exception(
+                    'Summary bar plot failed for %s/%s/%s',
+                    prop.ofs, variable, whichcast)
     logger.info('Finished create_summary_barplots')
 
 

--- a/bin/visualization/create_summary_barplots.py
+++ b/bin/visualization/create_summary_barplots.py
@@ -1,0 +1,138 @@
+"""Regenerate station-by-station summary bar plots from existing skill CSVs.
+
+Reads ``data/skill/stats/skill_{ofs}_{variable}_{whichcast}_{ofsfiletype}.csv``
+files left behind by a prior 1D run and writes:
+
+* ``data/visual/{ofs}_summary_barplot_{variable}_{whichcasts}_{type}.html``
+* ``data/visual/1d/om/{ofs}_summary_barplot_..._{type}.png`` (if static_plots=True)
+
+Does **not** invoke ``get_skill`` -- it only consumes existing CSVs, so it is
+fast (~1s per OFS) and safe to rerun.
+
+Usage:
+    python create_summary_barplots.py -o cbofs -p ./ \\
+        -s 2026-03-28T00:00:00Z -e 2026-03-29T00:00:00Z \\
+        -ws nowcast -t stations -vs water_level
+"""
+from __future__ import annotations
+
+import argparse
+import logging
+import logging.config
+import os
+import sys
+from pathlib import Path
+
+from ofs_skill.model_processing import model_properties
+from ofs_skill.obs_retrieval import parse_arguments_to_list, utils
+from ofs_skill.visualization import summary_barplots
+
+_VAR_TO_NAME = {
+    'water_level': 'wl',
+    'water_temperature': 'temp',
+    'salinity': 'salt',
+    'currents': 'cu',
+}
+
+
+def _bootstrap(prop):
+    """Resolve config + logger and populate the directory attributes
+    summary_barplots needs.  Mirrors the start of create_1dplot.create_1dplot."""
+    _conf = getattr(prop, 'config_file', None)
+    config_file = utils.Utils(_conf).get_config_file()
+    log_config_file = os.path.join(Path(prop.path or '.'), 'conf', 'logging.conf')
+    if not os.path.isfile(log_config_file):
+        sys.exit(f'logging config not found: {log_config_file}')
+    if not os.path.isfile(config_file):
+        sys.exit(f'main config not found: {config_file}')
+    logging.config.fileConfig(log_config_file)
+    logger = logging.getLogger('root')
+    logger.info('Using config %s', config_file)
+
+    dir_params = utils.Utils(_conf).read_config_section('directories', logger)
+    conf_settings = utils.Utils(_conf).read_config_section('settings', logger)
+
+    prop.whichcasts = parse_arguments_to_list(prop.whichcasts, logger)
+    prop.var_list = parse_arguments_to_list(prop.var_list, logger)
+    prop.ofs = prop.ofs.lower()
+    prop.ofsfiletype = prop.ofsfiletype.lower()
+    if prop.path is None:
+        prop.path = dir_params['home']
+
+    truthy = {'true', 'yes', '1'}
+    static_setting = conf_settings.get('static_plots', 'false')
+    prop.static_plots = str(static_setting).lower() in truthy
+
+    prop.data_skill_stats_path = os.path.join(
+        prop.path, dir_params['data_dir'], dir_params['skill_dir'],
+        dir_params['stats_dir'])
+    prop.visuals_1d_station_path = os.path.join(
+        prop.path, dir_params['data_dir'], dir_params['visual_dir'])
+    prop.om_files = os.path.join(
+        prop.path, dir_params['data_dir'], dir_params['visual_dir'],
+        dir_params['om_dir'])
+    os.makedirs(prop.visuals_1d_station_path, exist_ok=True)
+    os.makedirs(prop.om_files, exist_ok=True)
+
+    return logger
+
+
+def main(prop):
+    logger = _bootstrap(prop)
+    logger.info('--- create_summary_barplots: %s ---', prop.ofs)
+    for variable in prop.var_list:
+        name_var = _VAR_TO_NAME.get(variable)
+        if name_var is None:
+            logger.warning('Unknown variable %s -- skipping', variable)
+            continue
+        var_info = [variable, name_var, []]
+        for whichcast in prop.whichcasts:
+            prop.whichcast = whichcast
+            try:
+                summary_barplots.make_summary_bars(prop, var_info, logger)
+            except Exception as ex:
+                logger.error(
+                    'Summary bar plot failed for %s/%s/%s: %s',
+                    prop.ofs, variable, whichcast, ex)
+    logger.info('Finished create_summary_barplots')
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(
+        prog='create_summary_barplots.py',
+        description='Regenerate station summary bar plots from existing '
+                    'skill stats CSVs.')
+    parser.add_argument('-o', '--OFS', required=True,
+                        help='OFS name (lowercase)')
+    parser.add_argument('-p', '--Path', required=False,
+                        help='Working directory (defaults to config home)')
+    parser.add_argument('-s', '--StartDate_full', required=True,
+                        help='Start date YYYY-MM-DDThh:mm:ssZ')
+    parser.add_argument('-e', '--EndDate_full', required=True,
+                        help='End date YYYY-MM-DDThh:mm:ssZ')
+    parser.add_argument('-ws', '--Whichcasts', required=False,
+                        default='nowcast,forecast_b',
+                        help='Comma list: nowcast,forecast_a,forecast_b,hindcast')
+    parser.add_argument('-t', '--FileType', required=False, default='stations',
+                        help="'stations' or 'fields'")
+    parser.add_argument('-vs', '--Var_Selection', required=False,
+                        default='water_level,water_temperature,salinity,currents',
+                        help='Variables to summarize (comma list)')
+    parser.add_argument('-f', '--Forecast_Hr', required=False, default=None,
+                        help='Forecast cycle (used only for forecast_a labeling)')
+    parser.add_argument('-c', '--config', required=False, default=None,
+                        help='Path to alternate ofs_dps.conf')
+    args = parser.parse_args()
+
+    prop1 = model_properties.ModelProperties()
+    prop1.ofs = args.OFS
+    prop1.path = args.Path
+    prop1.start_date_full = args.StartDate_full
+    prop1.end_date_full = args.EndDate_full
+    prop1.whichcasts = args.Whichcasts
+    prop1.ofsfiletype = args.FileType
+    prop1.var_list = args.Var_Selection
+    prop1.forecast_hr = args.Forecast_Hr
+    prop1.config_file = args.config
+
+    main(prop1)

--- a/environment.yml
+++ b/environment.yml
@@ -57,3 +57,12 @@ dependencies:
     - git+https://github.com/oceanmodeling/coastalmodeling-vdatum.git
     - git+https://github.com/oceanmodeling/searvey.git@master
     - utide>=0.3.0
+
+# Activation-time env vars exported into the conda env.
+# PROJ_NETWORK=ON lets PROJ fetch the remote MLLW <-> NAVD88 / IGLD85
+# vdatum grids from the NOAA S3 bucket on demand. Without this, the
+# coastalmodeling_vdatum.convert calls in obs_retrieval and
+# model_processing fail with ProjError 1029 ("File not found or
+# invalid") for stations whose datum conversion needs the remote grid.
+variables:
+  PROJ_NETWORK: "ON"

--- a/src/ofs_skill/model_processing/get_datum_offset.py
+++ b/src/ofs_skill/model_processing/get_datum_offset.py
@@ -34,16 +34,15 @@ Created: Fri Jun 6 09:11:51 2025
 
 import os
 from logging import Logger
-from typing import Any, Optional, Union
+from typing import Any, Union
 
 import numpy as np
 import pandas as pd
 import s3fs
 import xarray as xr
-from coastalmodeling_vdatum import vdatum
 
+from ofs_skill.obs_retrieval import utils, vdatum_resilient
 from ofs_skill.obs_retrieval.station_ctl_file_extract import station_ctl_file_extract
-from ofs_skill.obs_retrieval import utils
 
 
 def is_number(n: Any) -> bool:
@@ -542,24 +541,24 @@ def get_datum_offset(prop: Any, node: int, model: xr.Dataset,
                 dummyval = 10.0
                 # account for the mistake in stofs-3d-atl files
                 if prop.ofs == 'stofs_3d_atl' and model['x'][0,node]> 0:
-                    _,_,z = vdatum.convert(
+                    _,_,z = vdatum_resilient.convert(
                                         nativedatum,
                                         prop.datum.lower(),
                                         model['x'][0,node],
                                         model['y'][0,node],
                                         dummyval, #use dummy value
-                                        online=True,
-                                        epoch=None
+                                        epoch=None,
+                                        logger=logger,
                                         )
                 elif prop.ofs == 'stofs_3d_pac':
-                    _,_,z = vdatum.convert(
+                    _,_,z = vdatum_resilient.convert(
                                         nativedatum,
                                         prop.datum.lower(),
                                         model['y'][0,node],
                                         model['x'][0,node]-360,
                                         dummyval, #use dummy value
-                                        online=True,
-                                        epoch=None
+                                        epoch=None,
+                                        logger=logger,
                                         )
 
                 elif prop.ofs == 'loofs2':
@@ -568,24 +567,24 @@ def get_datum_offset(prop: Any, node: int, model: xr.Dataset,
                         # (LWD is 74.2 m below IGLD85 datum zero)
                         z = dummyval - 74.2
                     else:
-                        _,_,z = vdatum.convert(
+                        _,_,z = vdatum_resilient.convert(
                                             nativedatum,
                                             prop.datum.lower(),
                                             model['lat'][0,node],
                                             model['lon'][0,node],
                                             dummyval, #use dummy value
-                                            online=True,
-                                            epoch=None
+                                            epoch=None,
+                                            logger=logger,
                                             )
                 else:
-                    _,_,z = vdatum.convert(
+                    _,_,z = vdatum_resilient.convert(
                                         nativedatum,
                                         prop.datum.lower(),
                                         model['y'][0,node],
                                         model['x'][0,node],
                                         dummyval, #use dummy value
-                                        online=True,
-                                        epoch=None
+                                        epoch=None,
+                                        logger=logger,
                                         )
                 datum_offset = float(round(z-dummyval, 2))
 
@@ -593,14 +592,14 @@ def get_datum_offset(prop: Any, node: int, model: xr.Dataset,
                 if prop.ofs == 'stofs_2d_glo':
                     nativedatum = 'lmsl'
                     dummyval = 10.0
-                    _,_,z = vdatum.convert(
+                    _,_,z = vdatum_resilient.convert(
                                         nativedatum,
                                         prop.datum.lower(),
                                         model['y'][0,node],
                                         model['x'][0,node],
                                         dummyval,
-                                        online=True,
-                                        epoch=None
+                                        epoch=None,
+                                        logger=logger,
                                         )
                     if np.isinf(z):
                         logger.error('VDatum conversion returned inf for an ADCIRC station. This is probably because the station location is outside of the coastalmodeling_vdatum tool coverage area. Check if coordinates are correct. Returning -9992.')
@@ -631,28 +630,28 @@ def get_datum_offset(prop: Any, node: int, model: xr.Dataset,
                 elif prop.ofs == 'loofs2':
                     nativedatum = 'LWD'
                 dummyval = 10.0
-                _,_,z = vdatum.convert(
+                _,_,z = vdatum_resilient.convert(
                                     nativedatum,
                                     prop.datum.lower(),
                                     model['SCHISM_hgrid_node_y'][node],
                                     model['SCHISM_hgrid_node_x'][node],
                                     dummyval, #use dummy value
-                                    online=True,
-                                    epoch=None
+                                    epoch=None,
+                                    logger=logger,
                                     )
                 datum_offset = round(z-dummyval,2)
             if prop.model_source == 'adcirc':
                 if prop.ofs == 'stofs_2d_glo':
                     nativedatum = 'lmsl'
                     dummyval = 10.0
-                    _,_,z = vdatum.convert(
+                    _,_,z = vdatum_resilient.convert(
                         nativedatum,
                         prop.datum.lower(),
                         model['y'][0,node],
                         model['x'][0,node],
                         dummyval,
-                        online=True,
-                        epoch=None
+                        epoch=None,
+                        logger=logger,
                     )
                     if np.isinf(z):
                         logger.error('VDatum conversion returned inf for an ADCIRC node. This is probably because the node location is outside of the coastalmodeling_vdatum tool coverage area. Check if the coordinates are correct. Returning -9993.')

--- a/src/ofs_skill/model_processing/get_node_ofs.py
+++ b/src/ofs_skill/model_processing/get_node_ofs.py
@@ -35,6 +35,66 @@ from ofs_skill.model_processing.write_ofs_ctlfile import write_ofs_ctlfile
 from ofs_skill.obs_retrieval import scalar, utils, vector
 from ofs_skill.obs_retrieval.utils import get_parallel_config
 
+logger = logging.getLogger(__name__)
+
+
+# Per-variable physical bounds used to catch blended SCHISM dry/wet
+# sentinel values that NCEP post-processing produces by linearly averaging
+# the -999 dry-cell sentinel with real ocean values across the wet/dry
+# interface. Anything outside these bounds is treated as invalid and
+# replaced with NaN. Water level keeps the looser |val| >= 999 mask
+# because datum offsets and units vary by OFS.
+_SCHISM_PHYSICAL_BOUNDS = {
+    'temp': (-5.0, 50.0),
+    'temperature': (-5.0, 50.0),
+    'salt': (-1.0, 50.0),
+    'salinity': (-1.0, 50.0),
+    'currents': (0.0, 10.0),       # speed magnitude
+    'currents_uv': (-10.0, 10.0),  # raw u or v component
+}
+
+
+def _mask_schism_sentinels(arr, kind, station_id, ofs, log):
+    """Mask SCHISM dry/wet sentinels and blended transitional values.
+
+    SCHISM uses ``-999.0`` as a dry-cell sentinel. NCEP post-processing
+    of STOFS-3D-Atl points files can emit values that are linear blends
+    of ``-999`` with real ocean values across a dry/wet transition
+    (e.g. ``-596.91`` between ``-999`` and ``5 °C``). The previous mask
+    of ``|val| >= 999`` caught only the pure sentinels and let the
+    blended values pass through into plots and skill statistics.
+
+    This helper masks both: pure-fill (``|val| >= 999``) and blended
+    values that fall outside per-variable physical bounds. It logs a
+    WARNING when blended values are encountered (so the upstream data
+    issue is traceable in the log file) and an INFO when only
+    pure-fill values are masked. Clean stations produce no log line.
+    """
+    arr = np.asarray(arr, dtype=float).copy()
+    finite = np.isfinite(arr)
+    pure_fill = finite & ((arr <= -999) | (arr >= 999))
+    lo, hi = _SCHISM_PHYSICAL_BOUNDS.get(kind, (-999.0, 999.0))
+    physical = finite & ((arr < lo) | (arr > hi))
+    transitional = physical & ~pure_fill
+    n_pure = int(pure_fill.sum())
+    n_trans = int(transitional.sum())
+    if n_trans:
+        bad = arr[transitional]
+        log.warning(
+            '%s station %s %s: %d blended sentinel values in '
+            '[%.2f, %.2f] masked (source: NCEP post-processing '
+            'dry/wet interpolation). %d pure-fill values also masked.',
+            ofs, station_id, kind, n_trans,
+            float(bad.min()), float(bad.max()), n_pure,
+        )
+    elif n_pure:
+        log.info(
+            '%s station %s %s: %d pure-fill (-999) values masked.',
+            ofs, station_id, kind, n_pure,
+        )
+    arr[physical] = np.nan
+    return arr
+
 
 def parse_arguments_to_list(argument, logger):
     '''
@@ -342,8 +402,8 @@ def format_temp_salt(prop, model, ofs_ctlfile, model_var, i, precomputed=None):
         model_time = precomputed['model_time']
         model_obs = precomputed['scalar_data'][:, i].copy()
         if prop.model_source == 'schism':
-            invalid_mask = (model_obs <= -999) | (model_obs >= 999)
-            model_obs[invalid_mask] = np.nan
+            model_obs = _mask_schism_sentinels(
+                model_obs, model_var, ofs_ctlfile[4][i], prop.ofs, logger)
     elif prop.model_source=='fvcom':
         if prop.ofsfiletype == 'fields':
             model_time = np.array(model['time'])
@@ -397,8 +457,8 @@ def format_temp_salt(prop, model, ofs_ctlfile, model_var, i, precomputed=None):
             else:
                 model_obs = np.array(model[model_var][:, int(ofs_ctlfile[1][i]),
                                                       int(ofs_ctlfile[2][i])])
-            invalid_mask = (model_obs <= -999) | (model_obs >= 999)
-            model_obs[invalid_mask] = np.nan
+            model_obs = _mask_schism_sentinels(
+                model_obs, model_var, ofs_ctlfile[4][i], prop.ofs, logger)
     elif prop.model_source == 'adcirc':
         if prop.ofs == 'stofs_2d_glo':
             # We raise en exception here for STOFS-2D-Global because it does
@@ -445,14 +505,16 @@ def format_currents(prop, model, ofs_ctlfile, i, precomputed=None):
         mfp.model_time = precomputed['model_time']
         u_i = precomputed['u_data'][:, i]
         v_i = precomputed['v_data'][:, i]
+        if prop.model_source == 'schism':
+            station_id = ofs_ctlfile[4][i]
+            u_i = _mask_schism_sentinels(
+                u_i, 'currents_uv', station_id, prop.ofs, logger)
+            v_i = _mask_schism_sentinels(
+                v_i, 'currents_uv', station_id, prop.ofs, logger)
         mfp.model_obs = np.array(u_i**2 + v_i**2) ** 0.5
         mfp.model_ang = np.array(
             [math.atan2(u_i[t], v_i[t]) / math.pi * 180 % 360.0
              for t in range(len(mfp.model_time))])
-        if prop.model_source == 'schism':
-            invalid_mask = (mfp.model_obs <= -999) | (mfp.model_obs >= 999)
-            mfp.model_obs[invalid_mask] = np.nan
-            mfp.model_ang[invalid_mask] = np.nan
     elif prop.model_source=='fvcom':
         mfp = ModelFormatProperties()
         mfp.model_time = np.array(model['time'])
@@ -566,15 +628,16 @@ def format_currents(prop, model, ofs_ctlfile, i, precomputed=None):
                     model['v'][:, int(ofs_ctlfile[1][i])]
                 )
 
+            station_id = ofs_ctlfile[4][i]
+            u_i = _mask_schism_sentinels(
+                u_i, 'currents_uv', station_id, prop.ofs, logger)
+            v_i = _mask_schism_sentinels(
+                v_i, 'currents_uv', station_id, prop.ofs, logger)
             mfp.model_obs = np.array(u_i**2 + v_i**2) ** 0.5
             mfp.model_ang = np.array(
                 [math.atan2(u_i[t], v_i[t]) / math.pi * \
                  180 % 360.0 for t in range(
                     len(np.array(mfp.model_time)))])
-            mfp.model_obs = mfp.model_obs
-            invalid_mask = (mfp.model_obs <= -999) | (mfp.model_obs >= 999)
-            mfp.model_obs[invalid_mask] = np.nan
-            mfp.model_ang[invalid_mask] = np.nan
     elif prop.model_source == 'adcirc':
         if prop.ofs == 'stofs_2d_glo':
             # We raise en exception here for STOFS-2D-Global because it does

--- a/src/ofs_skill/model_processing/indexing.py
+++ b/src/ofs_skill/model_processing/indexing.py
@@ -447,14 +447,21 @@ def index_nearest_depth(
             if 'z' in model_netcdf:
                 z_np = np.array(model_netcdf['z'])    # Node depths
             else:
-                # Some FVCOM outputs (e.g. NECOFS) lack pre-computed z;
-                # compute from sigma coordinates and bathymetry. Do the
-                # multiplication on the xarray DataArrays so broadcasting
-                # aligns by named dim ('node') — after multi-file concat
-                # `h` carries a time dim, so raw numpy broadcasting on
-                # (siglay, node) * (time, node) fails on trailing axes.
-                z_np = np.array(
-                    model_netcdf['siglay'] * model_netcdf['h']
+                # Some FVCOM outputs (e.g. NECOFS) lack pre-computed z.
+                # The stations branch below has a working fallback, but
+                # the fields branch downstream code (`z_np[node, :]`
+                # below) expects shape (node, depth), and any siglay*h
+                # synthesised here either has the wrong shape or the
+                # wrong dim ordering. No real OFS currently exercises
+                # fields-mode FVCOM without pre-computed `z`; raising
+                # loudly avoids silently emitting wrong nearest-depth
+                # picks. Tracked under issue #129
+                # (plan_simplify_fvcom_z_fallback.md) — once fix_fvcom
+                # always assigns `z`, this branch becomes dead code.
+                raise NotImplementedError(
+                    'FVCOM fields-mode depth indexing requires a '
+                    "precomputed 'z' variable on the dataset. "
+                    'Tracked at issue #129.'
                 )
         elif model_source == 'roms':
             lon_rho_np = np.array(model_netcdf['lon_rho'])

--- a/src/ofs_skill/model_processing/indexing.py
+++ b/src/ofs_skill/model_processing/indexing.py
@@ -448,10 +448,14 @@ def index_nearest_depth(
                 z_np = np.array(model_netcdf['z'])    # Node depths
             else:
                 # Some FVCOM outputs (e.g. NECOFS) lack pre-computed z;
-                # approximate from sigma coordinates and bathymetry
-                siglay = np.array(model_netcdf['siglay'])
-                h = np.array(model_netcdf['h'])
-                z_np = siglay * h
+                # compute from sigma coordinates and bathymetry. Do the
+                # multiplication on the xarray DataArrays so broadcasting
+                # aligns by named dim ('node') — after multi-file concat
+                # `h` carries a time dim, so raw numpy broadcasting on
+                # (siglay, node) * (time, node) fails on trailing axes.
+                z_np = np.array(
+                    model_netcdf['siglay'] * model_netcdf['h']
+                )
         elif model_source == 'roms':
             lon_rho_np = np.array(model_netcdf['lon_rho'])
             s_rho_np = np.array(model_netcdf['s_rho'])
@@ -681,10 +685,14 @@ def index_nearest_depth(
                 z_np = np.array(model_netcdf['z'])
             else:
                 # Some FVCOM outputs (e.g. NECOFS) lack pre-computed z;
-                # compute from sigma coordinates and bathymetry
-                siglay = np.array(model_netcdf['siglay'])
-                h = np.array(model_netcdf['h'])
-                z_np = siglay * h
+                # compute from sigma coordinates and bathymetry. Do the
+                # multiplication on the xarray DataArrays so broadcasting
+                # aligns by named dim ('node') — after multi-file concat
+                # `h` carries a time dim, so raw numpy broadcasting on
+                # (siglay, node) * (time, node) fails on trailing axes.
+                z_np = np.array(
+                    model_netcdf['siglay'] * model_netcdf['h']
+                )
         elif model_source == 'roms':
             s_rho_np = np.array(model_netcdf['s_rho'])
             h_np = np.array(model_netcdf['h'])

--- a/src/ofs_skill/obs_retrieval/retrieve_t_and_c_station.py
+++ b/src/ofs_skill/obs_retrieval/retrieve_t_and_c_station.py
@@ -106,6 +106,12 @@ _depth_cache: dict[str, Any] = {}  # station_id -> depth_data
 # station_id. Populated via ``get_station_info``.
 _station_info_cache: dict[str, Optional[dict]] = {}
 
+# Cache per-station deployment metadata (``orientation``, ``sensor_depth``)
+# fetched from ``stations/{id}/deployments.json``. The station endpoint
+# (``stations/{id}.json``) only returns a ``deployments: {self: <url>}``
+# pointer — the actual deployment fields live one level deeper.
+_station_deployment_cache: dict[str, Optional[dict]] = {}
+
 
 def get_station_depth(station_id, mdapi_url, logger):
     """Fetch station depth/bins metadata, returning cached result when available.
@@ -350,6 +356,56 @@ def get_station_info(
     stations = payload.get('stations') or []
     info = stations[0] if stations else None
     _station_info_cache[station_id] = info
+    return info
+
+
+def get_station_deployment(
+    station_id: str,
+    mdapi_url: str,
+    logger: Logger,
+) -> Optional[dict]:
+    """Fetch deployment-level metadata (cached) from the MDAPI deployments endpoint.
+
+    The station endpoint (``stations/{id}.json``) only returns a
+    ``deployments: {self: <url>}`` pointer; the actual deployment
+    fields live one level deeper at
+    ``stations/{id}/deployments.json``. We need that endpoint to read
+    ``orientation`` and ``sensor_depth`` for side-looking ADCPs (the
+    inner ``deployments`` list reflects historical deployments; the
+    top-level orientation reflects the current station classification
+    in MDAPI's data model).
+
+    Args:
+        station_id: NOAA station identifier (e.g. ``'cb1401'``).
+        mdapi_url: Base MDAPI URL (no trailing slash).
+        logger: Module logger for warnings.
+
+    Returns:
+        The full JSON payload as a dict — top-level fields include
+        ``orientation`` (``'side'`` / ``'up'`` / ``'down'`` / ``''``),
+        ``sensor_depth`` (m, positive-down), ``measured_depth``,
+        ``height_from_bottom``, and a nested ``deployments`` list
+        whose entries carry ``real_time_bin``, ``lat``/``lng``, etc.
+        Returns ``None`` on HTTP error or unrecognized payload shape.
+    """
+    if station_id in _station_deployment_cache:
+        return _station_deployment_cache[station_id]
+
+    url = (f'{mdapi_url}/webapi/stations/{station_id}/deployments.json'
+           '?units=metric')
+    try:
+        response = _rate_limited_get(url, timeout=120)
+        response.raise_for_status()
+        payload = response.json()
+    except requests.exceptions.RequestException as ex:
+        logger.warning(
+            'CO-OPS deployment metadata retrieval failed for %s: %s',
+            station_id, ex)
+        _station_deployment_cache[station_id] = None
+        return None
+
+    info = payload if isinstance(payload, dict) else None
+    _station_deployment_cache[station_id] = info
     return info
 
 
@@ -674,6 +730,82 @@ def _retrieve_currents_all_bins(
                 hfb = float(hfb_raw)
             except (TypeError, ValueError):
                 hfb = None
+
+    # Pull deployment-level orientation + sensor_depth from a separate
+    # MDAPI endpoint. The station endpoint's ``deployments`` field is
+    # only a ``{self: <url>}`` pointer — the actual fields live at
+    # ``stations/{id}/deployments.json``. Side-looking (PICS) ADCPs
+    # report ``orientation: 'side'`` and a real ``sensor_depth`` here,
+    # while their per-bin ``depth`` on the bins endpoint is null (the
+    # bins endpoint's ``distance`` is horizontal range across the
+    # channel, not depth-from-surface).
+    deployment_info = get_station_deployment(station_id, mdapi_url, logger)
+    orientation_top = ''
+    sensor_depth: Optional[float] = None
+    side_rtb: Optional[int] = None
+    if deployment_info is not None:
+        orientation_top = str(
+            deployment_info.get('orientation') or '').lower()
+        sd_raw = deployment_info.get('sensor_depth')
+        if sd_raw is not None:
+            try:
+                sensor_depth = float(sd_raw)
+            except (TypeError, ValueError):
+                sensor_depth = None
+        inner_deps = deployment_info.get('deployments') or []
+        if inner_deps and isinstance(inner_deps[0], dict):
+            rtb_raw = inner_deps[0].get('real_time_bin')
+            if rtb_raw is not None:
+                try:
+                    side_rtb = int(rtb_raw)
+                except (TypeError, ValueError):
+                    side_rtb = None
+
+    # Side-looking ADCPs sample a single depth horizontally across the
+    # channel; fanning out to N per-bin virtual stations all at depth=0
+    # produces N redundant comparisons against the model surface layer.
+    # Collapse to one virtual station at the deployment's sensor_depth.
+    if orientation_top == 'side':
+        # ``side_rtb`` does double duty: as the datagetter ``bin``
+        # query parameter (None → unfiltered call, returning the
+        # station's published real-time series — the cb1401 production
+        # case where MDAPI reports ``real_time_bin: null``), and as
+        # the integer label for the resulting virtual station ID
+        # (defaulting to 1 when MDAPI does not name a specific bin).
+        side_bin = side_rtb if side_rtb is not None else 1
+
+        df_side = _fetch_currents_chunked(
+            station_id=station_id,
+            bin_num=side_rtb,
+            start_dt_0=start_dt_0,
+            end_dt_0=end_dt_0,
+            api_url=api_url,
+            logger=logger,
+        )
+        if df_side is None:
+            return None
+
+        if sensor_depth is not None:
+            df_side['DEP01'] = sensor_depth
+            df_side.attrs['depth'] = sensor_depth
+            df_side.attrs['depth_unknown'] = False
+            depth_label = f'{sensor_depth:.2f} m'
+        else:
+            df_side['DEP01'] = 0.0
+            df_side.attrs['depth'] = 0.0
+            df_side.attrs['depth_unknown'] = True
+            depth_label = 'UNKNOWN'
+        df_side.attrs['bin'] = side_bin
+        df_side.attrs['orientation'] = 'side'
+        df_side.attrs['height_from_bottom'] = hfb
+
+        bin_count = len(bin_records) if bin_records else 0
+        logger.info(
+            'CO-OPS station %s is side-looking; collapsing %d MDAPI '
+            'bin record(s) to a single virtual station at depth=%s '
+            '(real_time_bin=%s).',
+            station_id, bin_count, depth_label, side_bin)
+        return {side_bin: df_side}
 
     # Determine bin numbers to iterate. If metadata is unavailable, fall
     # back to a single unfiltered datagetter call. Resolve the bin number

--- a/src/ofs_skill/obs_retrieval/retrieve_t_and_c_station.py
+++ b/src/ofs_skill/obs_retrieval/retrieve_t_and_c_station.py
@@ -393,15 +393,13 @@ def get_station_deployment(
 
     url = (f'{mdapi_url}/webapi/stations/{station_id}/deployments.json'
            '?units=metric')
-    try:
-        response = _rate_limited_get(url, timeout=120)
-        response.raise_for_status()
-        payload = response.json()
-    except requests.exceptions.RequestException as ex:
-        logger.warning(
-            'CO-OPS deployment metadata retrieval failed for %s: %s',
-            station_id, ex)
-        _station_deployment_cache[station_id] = None
+    payload = _get_with_retry(url, station_id, 'deployment-metadata',
+                              logger)
+    if payload is None:
+        # Don't pin a None result in the cache — a transient 5xx/403
+        # must not silently downgrade every subsequent caller for the
+        # rest of the process. Caching only the success path means the
+        # next caller gets a fresh retry budget.
         return None
 
     info = payload if isinstance(payload, dict) else None

--- a/src/ofs_skill/obs_retrieval/vdatum_resilient.py
+++ b/src/ofs_skill/obs_retrieval/vdatum_resilient.py
@@ -1,0 +1,172 @@
+"""Resilience layer for ``coastalmodeling_vdatum.vdatum.convert``.
+
+The MLLW <-> NAVD88 / IGLD85 / xgeoid20b pipelines reference a remote
+geotiff served from
+``https://noaa-nos-stofs2d-pds.s3.amazonaws.com/_archive/coastalmodeling-vdatum/``.
+PROJ fetches the grid header via HTTP at pipeline-build time. Two things
+make this brittle when called from many worker threads at once:
+
+1. PROJ's SQLite grid cache is not safe for *concurrent first-time
+   fetches* of the same URL. If N threads hit an empty cache at the
+   same moment they collide and all N raise ``ProjError`` (Error 1029).
+   Once the cache holds the URL, subsequent threaded calls are fine.
+2. Even on a warm cache, transient network hiccups (TLS, DNS, S3 5xx)
+   can briefly break a build.
+
+This module wraps ``vdatum.convert`` with:
+
+* a per-(vd_from, vd_to) **single-threaded prime** on first use, so the
+  grid cache is populated before any concurrent threads race for it;
+* eager ``pyproj.network.set_network_enabled(True)`` on the calling
+  thread so worker contexts have network=True regardless of the
+  ``PROJ_NETWORK`` env var;
+* full-jitter exponential backoff on ``ProjError``;
+* a single fallback retry with ``online=False`` so cached grids resolve
+  without another network round-trip.
+
+The wrapper preserves ``vdatum.convert``'s return shape: ``(lat, lon, z)``.
+"""
+from __future__ import annotations
+
+import logging
+import random
+import threading
+import time
+
+import pyproj
+import pyproj.exceptions
+from coastalmodeling_vdatum import vdatum
+
+_logger = logging.getLogger(__name__)
+
+# Enable network at import time so threads spawned later inherit
+# network=True via the pyproj global ``_NETWORK_ENABLED`` consulted by
+# ``pyproj_context_initialize``.  Workers that build a Transformer
+# *without* having called ``set_network_enabled`` first would otherwise
+# pick up the import-time default (driven by the PROJ_NETWORK env var,
+# which the user may not have set).
+try:
+    pyproj.network.set_network_enabled(active=True)
+except Exception:  # pragma: no cover - shouldn't happen on a healthy install
+    _logger.exception('Could not enable PROJ network at import time')
+
+_RETRY_ATTEMPTS = 4
+_RETRY_BASE_SECONDS = 1.5
+_RETRY_CAP_SECONDS = 12.0
+
+# Per-(vd_from, vd_to) prime state.  ``_PRIME_LOCK`` guards
+# ``_PRIMED_PAIRS``; on first use of a pair, the holding thread runs a
+# single throwaway ``vdatum.convert`` to populate PROJ's grid cache so
+# later concurrent calls don't race for the same uninitialized URL grid.
+_PRIME_LOCK = threading.Lock()
+_PRIMED_PAIRS: set[tuple[str, str]] = set()
+# Coordinates that lie inside both MLLW <-> NAVD88 and xgeoid20b <-> *
+# coverage areas; primarily used so the prime call returns a finite
+# value rather than ``inf``.  The exact value doesn't matter -- the
+# call's purpose is to populate PROJ's grid cache.
+_PRIME_LAT = 36.94
+_PRIME_LON = -76.33
+
+
+def _sleep_with_backoff(attempt: int) -> None:
+    backoff = min(_RETRY_CAP_SECONDS,
+                  _RETRY_BASE_SECONDS * (2 ** attempt))
+    time.sleep(random.uniform(0, backoff))
+
+
+def _prime_pair(vd_from: str, vd_to: str,
+                logger: logging.Logger) -> None:
+    """Single-threaded grid-cache warm-up for one datum pair.
+
+    PROJ's SQLite cache is not safe for concurrent first-time fetches of
+    the same URL grid.  Holding a process-wide lock on the first call
+    for each (vd_from, vd_to) pair guarantees that exactly one thread
+    populates the cache while all others block, after which they all
+    proceed with a warm cache and no longer race.
+    """
+    pair = (vd_from, vd_to)
+    if pair in _PRIMED_PAIRS:
+        return
+    with _PRIME_LOCK:
+        if pair in _PRIMED_PAIRS:
+            return
+        try:
+            vdatum.convert(vd_from, vd_to,
+                           _PRIME_LAT, _PRIME_LON, 0.0,
+                           online=True)
+            _PRIMED_PAIRS.add(pair)
+            logger.debug('Primed PROJ grid cache for %s->%s',
+                         vd_from, vd_to)
+        except pyproj.exceptions.ProjError as exc:
+            # Don't trap forever -- still mark the pair as primed so
+            # later callers can attempt their own retry path. They will
+            # hit the same network failure but at least the lock is
+            # released for everyone.
+            _PRIMED_PAIRS.add(pair)
+            logger.warning(
+                'PROJ grid prime failed for %s->%s; subsequent calls '
+                'will retry on their own. Underlying error: %s',
+                vd_from, vd_to, exc)
+
+
+def convert(vd_from, vd_to, lat, lon, z, *, epoch=None,
+            station_id: str | None = None,
+            logger: logging.Logger | None = None):
+    """Resilient drop-in for ``vdatum.convert``.
+
+    Returns ``(lat, lon, z)`` on success.  Raises the last ``ProjError``
+    if every retry fails so the caller can decide what to do (log and
+    skip the station, fall back to a default offset, etc.).
+    """
+    log = logger or _logger
+    last_exc: BaseException | None = None
+
+    # PROJ contexts are per-thread.  ``pyproj.network.set_network_enabled``
+    # only flips the *calling thread's* context.  Setting it explicitly
+    # before the first vdatum.convert call ensures network is enabled on
+    # this thread's PROJ context regardless of how it was initialized.
+    try:
+        pyproj.network.set_network_enabled(active=True)
+    except Exception:
+        pass
+
+    # Serialize the first call for each datum pair to populate PROJ's
+    # SQLite grid cache without racing against sibling worker threads.
+    _prime_pair(vd_from, vd_to, log)
+
+    for attempt in range(_RETRY_ATTEMPTS):
+        try:
+            return vdatum.convert(vd_from, vd_to, lat, lon, z,
+                                  online=True, epoch=epoch)
+        except pyproj.exceptions.ProjError as exc:
+            last_exc = exc
+            log.warning(
+                'vdatum.convert ProjError (attempt %d/%d) for %s->%s'
+                '%s: %s',
+                attempt + 1, _RETRY_ATTEMPTS, vd_from, vd_to,
+                f' station {station_id}' if station_id else '',
+                exc,
+            )
+            if attempt < _RETRY_ATTEMPTS - 1:
+                _sleep_with_backoff(attempt)
+
+    # One last attempt with online=False -- the grid may already be in
+    # PROJ's user-writable cache from a prior successful fetch.
+    try:
+        log.warning(
+            'vdatum.convert online=True exhausted; falling back to '
+            'online=False (cached grids only)%s',
+            f' for station {station_id}' if station_id else '')
+        return vdatum.convert(vd_from, vd_to, lat, lon, z,
+                              online=False, epoch=epoch)
+    except pyproj.exceptions.ProjError as exc:
+        log.error(
+            'vdatum.convert permanently failed for %s->%s%s. Set '
+            'PROJ_NETWORK=ON, run `projsync --user-writable-directory '
+            '--all`, or set local_vdatum=true in conf/ofs_dps.conf. '
+            'Underlying error: %s',
+            vd_from, vd_to,
+            f' station {station_id}' if station_id else '',
+            exc,
+        )
+        raise exc from last_exc

--- a/src/ofs_skill/obs_retrieval/write_obs_ctlfile.py
+++ b/src/ofs_skill/obs_retrieval/write_obs_ctlfile.py
@@ -117,6 +117,7 @@ def _emit_coops_currents_entries(
         except (TypeError, ValueError):
             hfb = 0.0
         suffix = f'bin {int(bin_num):02d}'
+        depth_unknown = bool(bin_df.attrs.get('depth_unknown', False))
 
         override = (
             bin_overrides.get(bin_num)
@@ -128,8 +129,14 @@ def _emit_coops_currents_entries(
                 # User-specified depth supersedes the
                 # height_from_bottom side-looking path.
                 hfb = 0.0
+                depth_unknown = False
             if override.name:
                 suffix = f'bin {int(bin_num):02d} / {override.name}'
+        if depth_unknown:
+            # Surface the side-looker / legacy-fallback flag in the
+            # plot title; downstream "Assumed surface (0 m)" annotation
+            # gates on this substring.
+            suffix = f'{suffix}, depth unknown'
 
         virt_id = f'{str(id_number)}_b{int(bin_num):02d}'
         entries.append(

--- a/src/ofs_skill/obs_retrieval/write_obs_ctlfile.py
+++ b/src/ofs_skill/obs_retrieval/write_obs_ctlfile.py
@@ -30,9 +30,8 @@ import os
 from concurrent.futures import ThreadPoolExecutor
 
 import pandas as pd
-from coastalmodeling_vdatum import vdatum
 
-from ofs_skill.obs_retrieval import retrieve_properties, utils
+from ofs_skill.obs_retrieval import retrieve_properties, utils, vdatum_resilient
 from ofs_skill.obs_retrieval.currents_bins_override import (
     bin_spec_lookup,
     load_currents_bins_csv,
@@ -276,14 +275,15 @@ def _process_coops_station(id_number, name, x_value, y_value,
                       datum_list):
                     ldatum = _normalize_vdatum_name(datum).lower()
                     dummyval = 10
-                    _,_,z = vdatum.convert(
+                    _,_,z = vdatum_resilient.convert(
                         str(datum_found).lower(),
                         ldatum,
                         y_value,
                         x_value,
                         dummyval, #use dummy value
-                        online=True,
-                        epoch=None)
+                        epoch=None,
+                        station_id=str(id_number),
+                        logger=logger)
                     if math.isinf(z):
                         zdiff = 'RANGE'
                     else:
@@ -407,14 +407,15 @@ def _process_usgs_station(id_number, name, x_value, y_value,
                             datum != 'NAVD88'):
                         ldatum = _normalize_vdatum_name(datum).lower()
                         dummyval = 10
-                        _,_,z = vdatum.convert(
+                        _,_,z = vdatum_resilient.convert(
                             timeseries['Datum'][1].lower(),
                             ldatum,
                             y_value,
                             x_value,
                             dummyval, #use dummy value
-                            online=True,
-                            epoch=None)
+                            epoch=None,
+                            station_id=str(id_number),
+                            logger=logger)
                         if math.isinf(z):
                             zdiff = 'RANGE'
                         else:
@@ -510,14 +511,15 @@ def _process_ndbc_station(id_number, name, x_value, y_value,
                     datum != 'MLLW'):
                 ldatum = _normalize_vdatum_name(datum).lower()
                 dummyval = 10
-                _,_,z = vdatum.convert(
+                _,_,z = vdatum_resilient.convert(
                     data_station['Datum'][1].lower(),
                     ldatum,
                     y_value,
                     x_value,
                     dummyval, #use dummy value
-                    online=True,
-                    epoch=None)
+                    epoch=None,
+                    station_id=str(id_number),
+                    logger=logger)
                 if math.isinf(z):
                     zdiff = 'RANGE'
                 else:
@@ -612,14 +614,15 @@ def _process_chs_station(id_number, name, x_value, y_value,
                 else:
                     ldatum = _normalize_vdatum_name(datum).lower()
                     dummyval = 10
-                    _,_,z = vdatum.convert(
+                    _,_,z = vdatum_resilient.convert(
                         data_station['Datum'][1].lower(),
                         ldatum,
                         y_value,
                         x_value,
                         dummyval, #use dummy value
-                        online=True,
-                        epoch=None)
+                        epoch=None,
+                        station_id=str(id_number),
+                        logger=logger)
                     if math.isinf(z):
                         zdiff = 'RANGE'
                     else:

--- a/src/ofs_skill/visualization/make_static_plots.py
+++ b/src/ofs_skill/visualization/make_static_plots.py
@@ -21,19 +21,28 @@ def _add_assumed_surface_note(ax, station_id, name_var):
     """Annotate matplotlib axis when obs depth is an assumed surface (0 m).
 
     Mirrors the HTML annotation in ``plotting_scalar``/``plotting_vector``.
-    Only fires for USGS/CHS, where a 0.0 obs depth is a fallback default.
-    CO-OPS (bins endpoint / side-looking resolver) and NDBC report
-    authoritative depths; water level has no meaningful depth.
+    Fires for USGS/CHS (where 0.0 is a hard-coded fallback) and for
+    CO-OPS side-looking ADCPs whose ``sensor_depth`` was unavailable
+    from MDAPI — the latter is signalled by a ``depth unknown``
+    substring appended to the station name suffix by ``write_obs_ctlfile``.
+    Water level has no meaningful depth so wl is excluded.
     """
     if name_var == 'wl':
         return
-    if len(station_id) <= 3 or station_id[2] not in ('USGS', 'CHS'):
+    if len(station_id) <= 3:
         return
     try:
         obs_depth = float(station_id[3])
     except (TypeError, ValueError):
         return
     if obs_depth != 0.0:
+        return
+    name = str(station_id[1]) if len(station_id) > 1 else ''
+    is_usgs_chs = station_id[2] in ('USGS', 'CHS')
+    is_coops_unknown = (
+        station_id[2] == 'CO-OPS' and 'depth unknown' in name.lower()
+    )
+    if not (is_usgs_chs or is_coops_unknown):
         return
     ax.text(
         0.02, 0.03,

--- a/src/ofs_skill/visualization/plotting_scalar.py
+++ b/src/ofs_skill/visualization/plotting_scalar.py
@@ -576,28 +576,32 @@ def oned_scalar_plot(
             )
 
     # Add annotation if assumed surface depth (no depth data from API).
-    # Only fires for USGS/CHS, where a 0.0 obs depth is a fallback default
-    # rather than a resolved value. CO-OPS (bins endpoint / side-looking
-    # resolver) and NDBC report authoritative depths.
-    if (
-        name_var != 'wl'
-        and len(station_id) > 3
-        and station_id[2] in ('USGS', 'CHS')
-    ):
-        try:
-            obs_depth = float(station_id[3])
-            if obs_depth == 0.0:
-                fig.add_annotation(
-                    text='<b>Note: no obs depth<br>available from API.<br>'
-                         'Assumed surface (0 m)</b>',
-                    xref='x domain', yref='y domain',
-                    font=dict(size=12, color='#E68A00'),
-                    x=0, y=0.0,
-                    showarrow=False,
-                    row=1, col=1,
-                )
-        except (ValueError, TypeError):
-            pass
+    # Fires for USGS/CHS (0.0 is a hard-coded fallback) and for CO-OPS
+    # side-looking ADCPs whose sensor_depth was unavailable from MDAPI
+    # (signalled by a "depth unknown" substring in the station name
+    # suffix written by write_obs_ctlfile). NDBC and resolved CO-OPS
+    # bins always report authoritative depths.
+    if name_var != 'wl' and len(station_id) > 3:
+        name = str(station_id[1]) if len(station_id) > 1 else ''
+        is_usgs_chs = station_id[2] in ('USGS', 'CHS')
+        is_coops_unknown = (
+            station_id[2] == 'CO-OPS' and 'depth unknown' in name.lower()
+        )
+        if is_usgs_chs or is_coops_unknown:
+            try:
+                obs_depth = float(station_id[3])
+                if obs_depth == 0.0:
+                    fig.add_annotation(
+                        text='<b>Note: no obs depth<br>available from API.<br>'
+                             'Assumed surface (0 m)</b>',
+                        xref='x domain', yref='y domain',
+                        font=dict(size=12, color='#E68A00'),
+                        x=0, y=0.0,
+                        showarrow=False,
+                        row=1, col=1,
+                    )
+            except (ValueError, TypeError):
+                pass
 
     # Set x-axis moving bar
     fig.update_xaxes(

--- a/src/ofs_skill/visualization/plotting_vector.py
+++ b/src/ofs_skill/visualization/plotting_vector.py
@@ -534,24 +534,32 @@ def oned_vector_plot1(
     )
 
     # Add annotation if assumed surface depth (no depth data from API).
-    # Only fires for USGS/CHS, where a 0.0 obs depth is a fallback default
-    # rather than a resolved value. CO-OPS (bins endpoint / side-looking
-    # resolver) and NDBC report authoritative depths.
-    if len(station_id) > 3 and station_id[2] in ('USGS', 'CHS'):
-        try:
-            obs_depth = float(station_id[3])
-            if obs_depth == 0.0:
-                fig.add_annotation(
-                    text='<b>Note: no obs depth<br>available from API.<br>'
-                         'Assumed surface (0 m)</b>',
-                    xref='x domain', yref='y domain',
-                    font=dict(size=12, color='#E68A00'),
-                    x=0, y=0.0,
-                    showarrow=False,
-                    row=1, col=1,
-                )
-        except (ValueError, TypeError):
-            pass
+    # Fires for USGS/CHS (0.0 is a hard-coded fallback) and for CO-OPS
+    # side-looking ADCPs whose sensor_depth was unavailable from MDAPI
+    # (signalled by a "depth unknown" substring in the station name
+    # suffix written by write_obs_ctlfile). NDBC and resolved CO-OPS
+    # bins always report authoritative depths.
+    if len(station_id) > 3:
+        name = str(station_id[1]) if len(station_id) > 1 else ''
+        is_usgs_chs = station_id[2] in ('USGS', 'CHS')
+        is_coops_unknown = (
+            station_id[2] == 'CO-OPS' and 'depth unknown' in name.lower()
+        )
+        if is_usgs_chs or is_coops_unknown:
+            try:
+                obs_depth = float(station_id[3])
+                if obs_depth == 0.0:
+                    fig.add_annotation(
+                        text='<b>Note: no obs depth<br>available from API.<br>'
+                             'Assumed surface (0 m)</b>',
+                        xref='x domain', yref='y domain',
+                        font=dict(size=12, color='#E68A00'),
+                        x=0, y=0.0,
+                        showarrow=False,
+                        row=1, col=1,
+                    )
+            except (ValueError, TypeError):
+                pass
 
     # Set x-axis moving bar
     fig.update_xaxes(

--- a/src/ofs_skill/visualization/summary_barplots.py
+++ b/src/ofs_skill/visualization/summary_barplots.py
@@ -104,8 +104,9 @@ def _figure_title(prop, variable: str, name_var: str) -> str:
     )
 
 
-def _ymax_for_rmse(values: Sequence[float], x1: float) -> float:
-    arr = np.array(values, dtype=float)
+def _ymax_for_rmse(values: Sequence[float | None], x1: float) -> float:
+    arr = np.array([v if v is not None else np.nan for v in values],
+                   dtype=float)
     if not np.isfinite(arr).any():
         return x1 * 2
     mult = np.ceil(np.nanmax(arr) / x1) if x1 > 0 else 2
@@ -139,7 +140,7 @@ def write_static_summary_bars(df: pd.DataFrame, name_var: str, variable: str,
     axs[0].set_xticklabels(labels, rotation=60, ha='right', fontsize=12)
     axs[0].set_ylim(0, rmse_ymax)
     axs[0].axhline(y=x1, color='red', linewidth=1, linestyle='--',
-                   label=f'Target error range (±{x1})')
+                   label=f'Target error range ({x1})')
     axs[0].legend(fontsize=14, loc='upper right',
                   facecolor='white', framealpha=0.75)
 
@@ -191,7 +192,7 @@ def write_html_summary_bars(df: pd.DataFrame, name_var: str, variable: str,
         shared_xaxes=True,
         vertical_spacing=0.08,
         subplot_titles=(
-            f'RMSE per station (target ±{x1})',
+            f'RMSE per station (target {x1})',
             'Central frequency per station (≥ 90% pass)',
         ),
     )
@@ -217,10 +218,8 @@ def write_html_summary_bars(df: pd.DataFrame, name_var: str, variable: str,
         row=1, col=1,
     )
     fig.add_hline(y=x1, line_dash='dash', line_color='red', row=1, col=1,
-                  annotation_text=f'Target error range (±{x1})',
+                  annotation_text=f'Target error range ({x1})',
                   annotation_position='top right')
-    fig.add_hline(y=-x1, line_dash='dash', line_color='red',
-                  row=1, col=1)
 
     fig.add_trace(
         go.Bar(
@@ -247,8 +246,10 @@ def write_html_summary_bars(df: pd.DataFrame, name_var: str, variable: str,
 
     axis_title_font = dict(family='Open Sans', color='black')
     axis_tick_font = dict(family='Open Sans', size=14, color='black')
+    rmse_ymax = _ymax_for_rmse(rmse_vals, x1)
     fig.update_yaxes(title_text='RMSE', title_font=axis_title_font,
-                     tickfont=axis_tick_font, row=1, col=1)
+                     tickfont=axis_tick_font,
+                     range=[0, rmse_ymax], row=1, col=1)
     fig.update_yaxes(title_text='Central frequency (%)',
                      title_font=axis_title_font,
                      tickfont=axis_tick_font,

--- a/src/ofs_skill/visualization/summary_barplots.py
+++ b/src/ofs_skill/visualization/summary_barplots.py
@@ -1,0 +1,348 @@
+"""Summary bar plots: RMSE and central frequency, station-by-station.
+
+Reads the per-station skill stats CSV emitted by
+``get_skill._skill_for_variable`` and produces two stacked bar charts
+(one per metric) covering every station / bin / extremum row in the
+file.  Output:
+
+* PNG (matplotlib) into ``prop.om_files`` -- gated on ``prop.static_plots``.
+* HTML (plotly) into ``prop.visuals_1d_station_path`` -- always written.
+
+Color encoding mirrors the forecast-horizon ``bar_plots`` in
+``make_static_plots``: palegreen / lightcoral against the
+``target_error_range`` (RMSE) and 90% central-frequency thresholds.
+"""
+from __future__ import annotations
+
+import os
+from collections.abc import Sequence
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import plotly.graph_objects as go
+from plotly.subplots import make_subplots
+
+import ofs_skill.visualization.plotting_functions as plotting_functions
+
+_PASS = 'palegreen'
+_FAIL = 'lightcoral'
+_PASS_HEX = '#98FB98'
+_FAIL_HEX = '#F08080'
+
+
+def _x_labels(df: pd.DataFrame, name_var: str) -> list[str]:
+    """One label per CSV row.  Currents bins get ``ID@<depth>m`` so
+    multiple bins on the same station do not collide on the x-axis."""
+    if name_var == 'cu' and 'obs_water_depth' in df.columns:
+        labels = []
+        for sid, depth in zip(df['ID'], df['obs_water_depth']):
+            try:
+                labels.append(f'{sid}@{float(depth):.1f}m')
+            except (TypeError, ValueError):
+                labels.append(str(sid))
+        return labels
+    return [str(sid) for sid in df['ID']]
+
+
+def _rmse_colors(values: Sequence[float | None], x1: float,
+                 hex_form: bool = False) -> list[str]:
+    pass_c, fail_c = (_PASS_HEX, _FAIL_HEX) if hex_form else (_PASS, _FAIL)
+    out = []
+    for v in values:
+        if v is None:
+            out.append(fail_c)
+            continue
+        try:
+            fv = float(v)
+        except (TypeError, ValueError):
+            out.append(fail_c)
+            continue
+        if not np.isfinite(fv):
+            out.append(fail_c)
+            continue
+        out.append(pass_c if -x1 <= fv <= x1 else fail_c)
+    return out
+
+
+def _cf_colors(values: Sequence[float | None],
+               hex_form: bool = False) -> list[str]:
+    pass_c, fail_c = (_PASS_HEX, _FAIL_HEX) if hex_form else (_PASS, _FAIL)
+    out = []
+    for v in values:
+        if v is None:
+            out.append(fail_c)
+            continue
+        try:
+            fv = float(v)
+        except (TypeError, ValueError):
+            out.append(fail_c)
+            continue
+        if not np.isfinite(fv):
+            out.append(fail_c)
+            continue
+        out.append(pass_c if fv >= 90 else fail_c)
+    return out
+
+
+def _figure_title(prop, variable: str, name_var: str) -> str:
+    """Title for the summary figure.  Doesn't reuse ``get_title_static``
+    because that helper is per-station (queries CO-OPS metadata for a
+    single NWS ID).  Summary plots cover all stations, so we just print
+    OFS / variable / whichcast / date range."""
+    start = prop.start_date_full.replace('Z', '').replace('T', ' ')
+    end = prop.end_date_full.replace('Z', '').replace('T', ' ')
+    forecast_tag = ''
+    if 'forecast_a' in getattr(prop, 'whichcasts', []) and \
+            getattr(prop, 'forecast_hr', None):
+        forecast_tag = f' ({prop.forecast_hr} cycle)'
+    return (
+        f'NOAA/NOS OFS Skill Assessment -- station summary\n'
+        f'OFS: {prop.ofs.upper()}    Variable: {variable}    '
+        f'Whichcast: {prop.whichcast}{forecast_tag}\n'
+        f'From: {start}    To: {end}'
+    )
+
+
+def _ymax_for_rmse(values: Sequence[float], x1: float) -> float:
+    arr = np.array(values, dtype=float)
+    if not np.isfinite(arr).any():
+        return x1 * 2
+    mult = np.ceil(np.nanmax(arr) / x1) if x1 > 0 else 2
+    if mult < 2:
+        mult = 2
+    return float(x1 * mult)
+
+
+def write_static_summary_bars(df: pd.DataFrame, name_var: str, variable: str,
+                              prop, logger) -> str | None:
+    """Two-row PNG figure: RMSE on top, CF on bottom."""
+    x1, _ = plotting_functions.get_error_range(name_var, prop, logger)
+    labels = _x_labels(df, name_var)
+    rmse_vals = list(df['rmse'])
+    cf_vals = list(df['central_freq'])
+
+    fig, axs = plt.subplots(2, 1)
+    fig.set_figheight(14)
+    fig.set_figwidth(max(12, 0.5 * len(labels) + 6))
+    fig.suptitle(_figure_title(prop, variable, name_var),
+                 fontsize=16, fontweight='bold')
+
+    # --- RMSE ---
+    rmse_ymax = _ymax_for_rmse(rmse_vals, x1)
+    x_positions = np.arange(len(labels))
+    axs[0].bar(x_positions, rmse_vals, color=_rmse_colors(rmse_vals, x1),
+               edgecolor='black', linewidth=1)
+    axs[0].set_ylabel('RMSE', fontsize=18)
+    axs[0].tick_params(axis='y', labelsize=14)
+    axs[0].set_xticks(x_positions)
+    axs[0].set_xticklabels(labels, rotation=60, ha='right', fontsize=12)
+    axs[0].set_ylim(0, rmse_ymax)
+    axs[0].axhline(y=x1, color='red', linewidth=1, linestyle='--',
+                   label=f'Target error range (±{x1})')
+    axs[0].legend(fontsize=14, loc='upper right',
+                  facecolor='white', framealpha=0.75)
+
+    # --- Central frequency ---
+    axs[1].bar(x_positions, cf_vals, color=_cf_colors(cf_vals),
+               edgecolor='black', linewidth=1)
+    axs[1].set_ylabel('Central frequency (%)', fontsize=18)
+    axs[1].tick_params(axis='y', labelsize=14)
+    axs[1].set_xticks(x_positions)
+    axs[1].set_xticklabels(labels, rotation=60, ha='right', fontsize=12)
+    axs[1].set_xlabel('Station', fontsize=16)
+    axs[1].set_ylim(0, 100)
+    axs[1].axhline(y=90, color='red', linewidth=1, linestyle='--',
+                   label='90% acceptance criteria')
+    axs[1].legend(fontsize=14, loc='lower right',
+                  facecolor='white', framealpha=0.75)
+
+    fig.tight_layout(rect=(0, 0, 1, 0.97))
+
+    filename = (
+        f'{prop.ofs}_summary_barplot_{variable}_{prop.whichcast}_'
+        f'{prop.ofsfiletype}.png'
+    )
+    out_path = os.path.join(prop.om_files, filename)
+    fig.savefig(out_path, format='png', dpi=100, bbox_inches='tight')
+    plt.close(fig)
+    logger.info('Wrote summary bar PNG: %s', out_path)
+    return out_path
+
+
+def write_html_summary_bars(df: pd.DataFrame, name_var: str, variable: str,
+                            prop, logger) -> str | None:
+    """Two-row plotly figure: RMSE on top, CF on bottom."""
+    x1, _ = plotting_functions.get_error_range(name_var, prop, logger)
+    labels = _x_labels(df, name_var)
+    rmse_vals = [float(v) if pd.notna(v) else None for v in df['rmse']]
+    cf_vals = [float(v) if pd.notna(v) else None for v in df['central_freq']]
+
+    custom = list(zip(
+        df.get('ID', pd.Series([''] * len(df))).astype(str),
+        df.get('NODE', pd.Series([''] * len(df))).astype(str),
+        df.get('obs_water_depth', pd.Series([''] * len(df))).astype(str),
+        df.get('central_freq_pass_fail',
+               pd.Series([''] * len(df))).astype(str),
+    ))
+
+    fig = make_subplots(
+        rows=2, cols=1,
+        shared_xaxes=True,
+        vertical_spacing=0.08,
+        subplot_titles=(
+            f'RMSE per station (target ±{x1})',
+            'Central frequency per station (≥ 90% pass)',
+        ),
+    )
+    for annot in fig['layout']['annotations']:
+        annot['font'] = dict(family='Open Sans', size=14, color='black')
+    fig.add_trace(
+        go.Bar(
+            x=labels, y=rmse_vals,
+            marker=dict(
+                color=_rmse_colors(rmse_vals, x1, hex_form=True),
+                line=dict(color='black', width=1),
+            ),
+            customdata=custom,
+            hovertemplate=(
+                'Station: %{customdata[0]}<br>'
+                'Node: %{customdata[1]}<br>'
+                'Obs depth: %{customdata[2]} m<br>'
+                'RMSE: %{y:.3f}<extra></extra>'
+            ),
+            name='RMSE',
+            showlegend=False,
+        ),
+        row=1, col=1,
+    )
+    fig.add_hline(y=x1, line_dash='dash', line_color='red', row=1, col=1,
+                  annotation_text=f'Target error range (±{x1})',
+                  annotation_position='top right')
+    fig.add_hline(y=-x1, line_dash='dash', line_color='red',
+                  row=1, col=1)
+
+    fig.add_trace(
+        go.Bar(
+            x=labels, y=cf_vals,
+            marker=dict(
+                color=_cf_colors(cf_vals, hex_form=True),
+                line=dict(color='black', width=1),
+            ),
+            customdata=custom,
+            hovertemplate=(
+                'Station: %{customdata[0]}<br>'
+                'Node: %{customdata[1]}<br>'
+                'Obs depth: %{customdata[2]} m<br>'
+                'CF: %{y:.2f}%<br>'
+                'Pass/fail: %{customdata[3]}<extra></extra>'
+            ),
+            name='CF',
+            showlegend=False,
+        ),
+        row=2, col=1,
+    )
+    fig.add_hline(y=90, line_dash='dash', line_color='red', row=2, col=1,
+                  annotation_text='90% acceptance', annotation_position='top right')
+
+    axis_title_font = dict(family='Open Sans', color='black')
+    axis_tick_font = dict(family='Open Sans', size=14, color='black')
+    fig.update_yaxes(title_text='RMSE', title_font=axis_title_font,
+                     tickfont=axis_tick_font, row=1, col=1)
+    fig.update_yaxes(title_text='Central frequency (%)',
+                     title_font=axis_title_font,
+                     tickfont=axis_tick_font,
+                     range=[0, 100], row=2, col=1)
+    fig.update_xaxes(title_text='Station', title_font=axis_title_font,
+                     tickfont=axis_tick_font,
+                     row=2, col=1, tickangle=-60)
+    fig.update_xaxes(tickfont=axis_tick_font, row=1, col=1)
+    fig_height = 850
+    fig_width = 1100
+    fig.update_layout(
+        title=dict(
+            text='<b>' + _figure_title(prop, variable, name_var)
+                .replace('\n', '<br>') + '</b>',
+            font=dict(size=14, color='black', family='Open Sans'),
+            y=0.97,
+            x=0.5, xanchor='center', yanchor='top',
+        ),
+        font=dict(family='Open Sans', color='black'),
+        template='plotly_white',
+        height=fig_height,
+        width=fig_width,
+        margin=dict(l=80, r=40, t=150, b=120),
+    )
+
+    filename = (
+        f'{prop.ofs}_summary_barplot_{variable}_{prop.whichcast}_'
+        f'{prop.ofsfiletype}.html'
+    )
+    out_path = os.path.join(prop.visuals_1d_station_path, filename)
+    fig_config = {
+        'toImageButtonOptions': {
+            'format': 'png',
+            'filename': filename.removesuffix('.html'),
+            'height': fig_height,
+            'width': fig_width,
+            'scale': 1,
+        }
+    }
+    fig.write_html(out_path, config=fig_config)
+    logger.info('Wrote summary bar HTML: %s', out_path)
+    return out_path
+
+
+def _csv_path(prop, variable: str) -> str:
+    return os.path.join(
+        prop.data_skill_stats_path,
+        f'skill_{prop.ofs}_{variable}_{prop.whichcast}_'
+        f'{prop.ofsfiletype}.csv',
+    )
+
+
+def _process_one(variable: str, name_var: str, prop, logger) -> None:
+    csv_path = _csv_path(prop, variable)
+    if not os.path.isfile(csv_path):
+        logger.warning(
+            'Summary bar plot: skill stats CSV not found, skipping: %s',
+            csv_path,
+        )
+        return
+    try:
+        df = pd.read_csv(csv_path)
+    except (OSError, pd.errors.ParserError) as ex:
+        logger.warning(
+            'Summary bar plot: failed to read %s (%s) -- skipping',
+            csv_path, ex)
+        return
+    if df.empty or 'rmse' not in df.columns or \
+            'central_freq' not in df.columns:
+        logger.warning(
+            'Summary bar plot: %s missing rmse/central_freq columns or '
+            'has no rows -- skipping', csv_path)
+        return
+    if 'X' in df.columns:
+        df = df.copy()
+        df['X'] = pd.to_numeric(df['X'], errors='coerce')
+        df = df.sort_values(by='X', kind='mergesort').reset_index(drop=True)
+
+    write_html_summary_bars(df, name_var, variable, prop, logger)
+    if getattr(prop, 'static_plots', False):
+        write_static_summary_bars(df, name_var, variable, prop, logger)
+
+
+def make_summary_bars(prop, var_info, logger) -> None:
+    """Public entry point.
+
+    ``var_info`` follows the create_1dplot convention:
+    ``[variable, name_var, list_of_headings]``.
+
+    For ``water_level`` we additionally emit ``_hw`` and ``_lw`` summary
+    plots when those CSVs exist.
+    """
+    variable, name_var = var_info[0], var_info[1]
+    _process_one(variable, name_var, prop, logger)
+    if name_var == 'wl':
+        for suffix in ('hw', 'lw'):
+            _process_one(f'{variable}_{suffix}', name_var, prop, logger)

--- a/tests/coops_currents_bins_test.py
+++ b/tests/coops_currents_bins_test.py
@@ -222,6 +222,263 @@ def test_retrieve_currents_legacy_fallback_when_bins_missing(
 
 
 # ---------------------------------------------------------------------------
+# Side-looking (PICS) ADCPs — issue #114
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def side_bins_payload():
+    """48 bin records, all with depth=None — mirrors cb1401."""
+    return {
+        'nbr_of_bins': 48,
+        'bin_size': 4.0,
+        'center_bin_1_dist': 5.0,
+        'units': 'metric',
+        'real_time_bin': 1,
+        'bins': [
+            {'num': i, 'depth': None,
+             'distance': 5.0 + (i - 1) * 4.0,
+             'qc_flag': 0, 'orientation': 'side', 'ping_int': 6}
+            for i in range(1, 49)
+        ],
+    }
+
+
+def _side_deployment_payload(orientation='side', sensor_depth=6.7,
+                             real_time_bin=1):
+    """Mimic the real ``stations/{id}/deployments.json`` payload shape.
+
+    Top-level fields hold orientation/sensor_depth; the nested
+    ``deployments`` list carries real_time_bin (often null in real
+    payloads).
+    """
+    payload = {
+        'units': 'meters',
+        'orientation': orientation,
+        'measured_depth': 17.0,
+        'height_from_bottom': 10.3,
+        'deployments': [{
+            'id': '8454000',
+            'lat': 36.98, 'lng': -76.44,
+            'real_time_bin': real_time_bin,
+        }],
+    }
+    if sensor_depth is not None:
+        payload['sensor_depth'] = sensor_depth
+    return payload
+
+
+def test_side_looking_adcp_collapses_to_single_bin(
+    retrieve_input, side_bins_payload, logger, caplog
+):
+    """orientation=side + sensor_depth=6.7 → 1 virtual station at 6.7 m."""
+    import importlib
+    rtc = importlib.import_module(
+        'ofs_skill.obs_retrieval.retrieve_t_and_c_station')
+
+    rtc._depth_cache.clear()
+    rtc._station_info_cache.clear()
+    rtc._station_deployment_cache.clear()
+    rtc._depth_cache['8454000'] = side_bins_payload
+    rtc._station_info_cache['8454000'] = {
+        'height_from_bottom': 10.3,
+        'deployments': {'self': 'https://api.example/.../deployments.json'},
+    }
+    rtc._station_deployment_cache['8454000'] = _side_deployment_payload(
+        orientation='side', sensor_depth=6.7, real_time_bin=1)
+
+    fake_urls = {
+        'co_ops_mdapi_base_url': 'https://api.example/mdapi/prod',
+        'co_ops_api_base_url': 'https://api.example/api/prod',
+    }
+
+    class _StubUtils:
+        def read_config_section(self, section, _logger):
+            return fake_urls
+
+    side_payload = {'data': [
+        {'t': '2025-01-01 00:00', 's': '20', 'd': '180', 'b': '1'},
+        {'t': '2025-01-01 00:06', 's': '22', 'd': '181', 'b': '1'},
+    ]}
+
+    with patch.object(rtc.utils, 'Utils', return_value=_StubUtils()), \
+            patch.object(rtc, '_get_session') as mock_session, \
+            caplog.at_level(logging.WARNING):
+        mock_session.return_value.get.return_value = _FakeResponse(
+            side_payload)
+        result = rtc.retrieve_t_and_c_station(retrieve_input, logger)
+
+    assert isinstance(result, dict)
+    assert list(result.keys()) == [1]
+    df = result[1]
+    assert df.attrs['depth'] == 6.7
+    assert df.attrs['orientation'] == 'side'
+    assert df.attrs['depth_unknown'] is False
+    assert df.attrs['bin'] == 1
+    assert df['DEP01'].iloc[0] == pytest.approx(6.7)
+    # The 'no depth' warning must NOT be emitted for side-looking stations.
+    assert not any(
+        'returned no depth' in rec.getMessage()
+        for rec in caplog.records)
+
+
+def test_side_looking_adcp_real_time_bin_null_unfiltered_call(
+    retrieve_input, side_bins_payload, logger
+):
+    """Production cb1401 case: MDAPI reports ``real_time_bin: null``.
+
+    Side branch should call the datagetter UNFILTERED (no ``&bin=N``
+    param), which returns the published real-time series, and label
+    the resulting virtual station ``bin=1``.
+    """
+    import importlib
+    rtc = importlib.import_module(
+        'ofs_skill.obs_retrieval.retrieve_t_and_c_station')
+
+    rtc._depth_cache.clear()
+    rtc._station_info_cache.clear()
+    rtc._station_deployment_cache.clear()
+    rtc._depth_cache['8454000'] = side_bins_payload
+    rtc._station_info_cache['8454000'] = {
+        'deployments': {'self': 'https://api.example/.../deployments.json'},
+    }
+    rtc._station_deployment_cache['8454000'] = _side_deployment_payload(
+        orientation='side', sensor_depth=6.7, real_time_bin=None)
+
+    fake_urls = {
+        'co_ops_mdapi_base_url': 'https://api.example/mdapi/prod',
+        'co_ops_api_base_url': 'https://api.example/api/prod',
+    }
+
+    class _StubUtils:
+        def read_config_section(self, section, _logger):
+            return fake_urls
+
+    captured_urls: list = []
+
+    def _router(url, timeout=120):
+        captured_urls.append(url)
+        return _FakeResponse({'data': [
+            {'t': '2025-01-01 00:00', 's': '20', 'd': '180', 'b': '1'},
+        ]})
+
+    with patch.object(rtc.utils, 'Utils', return_value=_StubUtils()), \
+            patch.object(rtc, '_get_session') as mock_session:
+        mock_session.return_value.get.side_effect = _router
+        result = rtc.retrieve_t_and_c_station(retrieve_input, logger)
+
+    assert isinstance(result, dict)
+    assert list(result.keys()) == [1]
+    df = result[1]
+    assert df.attrs['depth'] == 6.7
+    assert df.attrs['orientation'] == 'side'
+    assert df.attrs['bin'] == 1
+    # Datagetter was called WITHOUT a ``&bin=`` parameter — unfiltered
+    # call returning the real-time published series.
+    datagetter_calls = [u for u in captured_urls if 'datagetter' in u]
+    assert datagetter_calls, 'no datagetter URL was hit'
+    for url in datagetter_calls:
+        assert 'bin=' not in url, (
+            f'expected unfiltered datagetter call, got: {url}')
+
+
+def test_upward_looking_adcp_still_fans_out(
+    retrieve_input, bins_payload, currents_payloads_by_bin, logger
+):
+    """Regression: orientation=up with per-bin depths populated must
+    still produce one virtual station per bin (issue #114 must not
+    regress the issue #87 fan-out behavior)."""
+    import importlib
+    import re
+    rtc = importlib.import_module(
+        'ofs_skill.obs_retrieval.retrieve_t_and_c_station')
+
+    rtc._depth_cache.clear()
+    rtc._station_info_cache.clear()
+    rtc._station_deployment_cache.clear()
+    rtc._depth_cache['8454000'] = bins_payload
+    rtc._station_deployment_cache['8454000'] = {
+        'orientation': 'up',
+        'sensor_depth': None,
+        'deployments': [{'real_time_bin': None}],
+    }
+
+    fake_urls = {
+        'co_ops_mdapi_base_url': 'https://api.example/mdapi/prod',
+        'co_ops_api_base_url': 'https://api.example/api/prod',
+    }
+
+    class _StubUtils:
+        def read_config_section(self, section, _logger):
+            return fake_urls
+
+    def _router(url, timeout=120):
+        m = re.search(r'[?&]bin=(\d+)', url)
+        if not m:
+            return _FakeResponse({'data': []})
+        bn = int(m.group(1))
+        return _FakeResponse(currents_payloads_by_bin.get(bn, {'data': []}))
+
+    with patch.object(rtc.utils, 'Utils', return_value=_StubUtils()), \
+            patch.object(rtc, '_get_session') as mock_session:
+        mock_session.return_value.get.side_effect = _router
+        result = rtc.retrieve_t_and_c_station(retrieve_input, logger)
+
+    assert isinstance(result, dict)
+    # orientation='up' must NOT trigger collapse — full fan-out preserved.
+    assert set(result.keys()) == {1, 2, 3}
+    assert result[1].attrs['orientation'] == 'up'
+    assert result[1].attrs['depth'] == -2.0
+    assert result[2].attrs['depth'] == -4.0
+    assert result[3].attrs['depth'] == -6.0
+
+
+def test_side_looking_adcp_missing_sensor_depth_falls_back(
+    retrieve_input, side_bins_payload, logger
+):
+    """orientation=side without sensor_depth → single virtual station with
+    depth_unknown=True, depth=0.0."""
+    import importlib
+    rtc = importlib.import_module(
+        'ofs_skill.obs_retrieval.retrieve_t_and_c_station')
+
+    rtc._depth_cache.clear()
+    rtc._station_info_cache.clear()
+    rtc._station_deployment_cache.clear()
+    rtc._depth_cache['8454000'] = side_bins_payload
+    rtc._station_info_cache['8454000'] = {
+        'deployments': {'self': 'https://api.example/.../deployments.json'},
+    }
+    rtc._station_deployment_cache['8454000'] = _side_deployment_payload(
+        orientation='side', sensor_depth=None, real_time_bin=1)
+
+    fake_urls = {
+        'co_ops_mdapi_base_url': 'https://api.example/mdapi/prod',
+        'co_ops_api_base_url': 'https://api.example/api/prod',
+    }
+
+    class _StubUtils:
+        def read_config_section(self, section, _logger):
+            return fake_urls
+
+    side_payload = {'data': [
+        {'t': '2025-01-01 00:00', 's': '20', 'd': '180', 'b': '1'},
+    ]}
+
+    with patch.object(rtc.utils, 'Utils', return_value=_StubUtils()), \
+            patch.object(rtc, '_get_session') as mock_session:
+        mock_session.return_value.get.return_value = _FakeResponse(
+            side_payload)
+        result = rtc.retrieve_t_and_c_station(retrieve_input, logger)
+
+    assert isinstance(result, dict)
+    assert list(result.keys()) == [1]
+    df = result[1]
+    assert df.attrs['depth'] == 0.0
+    assert df.attrs['depth_unknown'] is True
+    assert df.attrs['orientation'] == 'side'
+
+
+# ---------------------------------------------------------------------------
 # write_obs_ctlfile._process_coops_station — N CTL entries per ADCP
 # ---------------------------------------------------------------------------
 

--- a/tests/schism_sentinel_filter_test.py
+++ b/tests/schism_sentinel_filter_test.py
@@ -1,0 +1,114 @@
+"""Unit tests for ``_mask_schism_sentinels``.
+
+Validates that the helper masks both pure SCHISM dry-cell sentinels
+(``-999.0``) and the blended transitional values that NCEP STOFS-3D-Atl
+post-processing emits across wet/dry interfaces (e.g. ``-596.91`` between
+``-999`` and a real ocean value), and that it logs at the right level so
+the upstream data issue is traceable in the run log.
+"""
+
+import logging
+
+import numpy as np
+
+from ofs_skill.model_processing.get_node_ofs import (
+    _SCHISM_PHYSICAL_BOUNDS,
+    _mask_schism_sentinels,
+)
+
+_LOGGER_NAME = 'ofs_skill.model_processing.get_node_ofs'
+
+
+def test_pure_fill_only_masked_with_info(caplog):
+    """All-(-999) and real values: 1 NaN + INFO log, no WARNING."""
+    arr = np.array([10.0, -999.0, 12.0])
+    log = logging.getLogger(_LOGGER_NAME)
+    with caplog.at_level(logging.INFO, logger=_LOGGER_NAME):
+        cleaned = _mask_schism_sentinels(arr, 'temp', '8518750', 'stofs_3d_atl', log)
+
+    assert np.isnan(cleaned[1])
+    assert cleaned[0] == 10.0 and cleaned[2] == 12.0
+    info_msgs = [r for r in caplog.records if r.levelno == logging.INFO]
+    warn_msgs = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert len(warn_msgs) == 0
+    assert any('1 pure-fill' in r.getMessage() for r in info_msgs)
+
+
+def test_blended_values_masked_with_warning(caplog):
+    """Blended -596.91 / -396.11 are masked with a WARNING."""
+    arr = np.array([10.0, -999.0, -596.91, -396.11, 12.0])
+    log = logging.getLogger(_LOGGER_NAME)
+    with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+        cleaned = _mask_schism_sentinels(arr, 'temp', '8518750', 'stofs_3d_atl', log)
+
+    assert np.isnan(cleaned[1]) and np.isnan(cleaned[2]) and np.isnan(cleaned[3])
+    assert cleaned[0] == 10.0 and cleaned[4] == 12.0
+    warn_msgs = [r.getMessage() for r in caplog.records
+                 if r.levelno == logging.WARNING]
+    assert len(warn_msgs) == 1
+    msg = warn_msgs[0]
+    assert '2 blended sentinel values' in msg
+    assert '-596.91' in msg or '-596.9' in msg
+    assert '-396.11' in msg or '-396.1' in msg
+    assert '1 pure-fill' in msg
+    assert '8518750' in msg
+    assert 'stofs_3d_atl' in msg
+
+
+def test_temp_below_physical_bound_masked():
+    """Values like -10 °C and 60 °C fall outside [-5, 50] and are NaN."""
+    arr = np.array([-10.0, 5.0, 60.0])
+    log = logging.getLogger(_LOGGER_NAME)
+    cleaned = _mask_schism_sentinels(arr, 'temp', 's', 'ofs', log)
+    assert np.isnan(cleaned[0]) and np.isnan(cleaned[2])
+    assert cleaned[1] == 5.0
+
+
+def test_salinity_uses_salt_bounds():
+    """Salinity bounds are [-1, 50] PSU; -50 fails, 35 passes."""
+    arr = np.array([35.0, -50.0])
+    log = logging.getLogger(_LOGGER_NAME)
+    cleaned = _mask_schism_sentinels(arr, 'salinity', 's', 'ofs', log)
+    assert cleaned[0] == 35.0
+    assert np.isnan(cleaned[1])
+
+
+def test_currents_speed_clamp():
+    """Speed of 50 m/s is unphysical and gets masked under 'currents'."""
+    arr = np.array([0.5, 50.0, 1.2])
+    log = logging.getLogger(_LOGGER_NAME)
+    cleaned = _mask_schism_sentinels(arr, 'currents', 's', 'ofs', log)
+    assert cleaned[0] == 0.5 and cleaned[2] == 1.2
+    assert np.isnan(cleaned[1])
+
+
+def test_water_level_keeps_loose_bound():
+    """An unknown 'kind' falls back to the |val| >= 999 default mask."""
+    arr = np.array([-3.5, 0.0, 2.5])
+    log = logging.getLogger(_LOGGER_NAME)
+    cleaned = _mask_schism_sentinels(arr, 'wl', 's', 'ofs', log)
+    assert np.allclose(cleaned, arr)
+
+
+def test_no_log_when_clean(caplog):
+    """No log record is emitted when nothing needs masking."""
+    arr = np.array([10.0, 11.0, 12.0])
+    log = logging.getLogger(_LOGGER_NAME)
+    with caplog.at_level(logging.INFO, logger=_LOGGER_NAME):
+        cleaned = _mask_schism_sentinels(arr, 'temp', 's', 'ofs', log)
+    assert np.allclose(cleaned, arr)
+    assert all(r.name != _LOGGER_NAME for r in caplog.records)
+
+
+def test_currents_uv_bound_present():
+    """The raw u/v bound is registered (used by format_currents)."""
+    assert _SCHISM_PHYSICAL_BOUNDS['currents_uv'] == (-10.0, 10.0)
+
+
+def test_blended_uv_value_masked_for_currents_uv():
+    """A blended -596 in raw u/v is masked under the currents_uv kind."""
+    arr = np.array([0.5, -596.91, -999.0, 0.7])
+    log = logging.getLogger(_LOGGER_NAME)
+    cleaned = _mask_schism_sentinels(arr, 'currents_uv', 's', 'ofs', log)
+    assert cleaned[0] == 0.5 and cleaned[3] == 0.7
+    assert np.isnan(cleaned[1]) and np.isnan(cleaned[2])

--- a/tests/summary_barplots_test.py
+++ b/tests/summary_barplots_test.py
@@ -1,0 +1,217 @@
+"""Regression tests for summary_barplots: station-by-station RMSE and CF bars."""
+from __future__ import annotations
+
+import logging
+import os
+import types
+
+import pandas as pd
+
+from ofs_skill.visualization import summary_barplots
+
+
+def _write_error_ranges(root: str) -> None:
+    conf_dir = os.path.join(root, 'conf')
+    os.makedirs(conf_dir, exist_ok=True)
+    with open(os.path.join(conf_dir, 'error_ranges.csv'), 'w',
+              encoding='utf-8') as fh:
+        fh.write('name_var,X1,X2\n')
+        fh.write('wl,0.15,0.5\n')
+        fh.write('temp,3.0,0.5\n')
+        fh.write('salt,3.5,0.5\n')
+        fh.write('cu,0.26,0.5\n')
+
+
+def _make_prop(tmp_path, ofs='cbofs', whichcast='nowcast', static=False):
+    prop = types.SimpleNamespace()
+    prop.path = str(tmp_path)
+    prop.ofs = ofs
+    prop.whichcast = whichcast
+    prop.whichcasts = [whichcast]
+    prop.ofsfiletype = 'stations'
+    prop.start_date_full = '2026-03-28T00:00:00Z'
+    prop.end_date_full = '2026-03-29T00:00:00Z'
+    prop.forecast_hr = None
+    prop.static_plots = static
+    prop.data_skill_stats_path = str(tmp_path / 'data' / 'skill' / 'stats')
+    prop.visuals_1d_station_path = str(tmp_path / 'data' / 'visual')
+    prop.om_files = str(tmp_path / 'data' / 'visual' / '1d' / 'om')
+    os.makedirs(prop.data_skill_stats_path, exist_ok=True)
+    os.makedirs(prop.visuals_1d_station_path, exist_ok=True)
+    os.makedirs(prop.om_files, exist_ok=True)
+    return prop
+
+
+def _write_wl_csv(prop, n=5):
+    rows = []
+    for i in range(n):
+        rmse = 0.05 + 0.04 * i  # mix pass / fail against X1=0.15
+        cf = 95.0 - 12.0 * i    # mix pass / fail against 90% threshold
+        rows.append({
+            'ID': f'8{i:06d}',
+            'NODE': i,
+            'obs_water_depth': 0.0,
+            'mod_water_depth': 0.5,
+            'rmse': rmse,
+            'r': 0.9,
+            'bias': 0.0,
+            'bias_perc': 10.0,
+            'bias_dir': '',
+            'central_freq': cf,
+            'central_freq_pass_fail': 'pass' if cf >= 90 else 'fail',
+            'pos_outlier_freq': 0.0,
+            'pos_outlier_freq_pass_fail': 'pass',
+            'neg_outlier_freq': 0.0,
+            'neg_outlier_freq_pass_fail': 'pass',
+            'max_duration_pos_outlier': 0.0,
+            'max_duration_pos_outlier_pass_fail': 'pass',
+            'max_duration_neg_outlier': 0.0,
+            'max_duration_neg_outlier_pass_fail': 'pass',
+            'worst_case_outlier_freq': 0.0,
+            'worst_case_outlier_freq_pass_fail': 'pass',
+            'bias_standard_dev': 0.05,
+            'target_error_range': 0.15,
+            'datum': 'MLLW',
+            'Y': 38.0 + 0.1 * i,
+            'X': -76.5 + 0.05 * i,
+            'start_date': '2026-03-28T00:00:00Z',
+            'end_date': '2026-03-29T00:00:00Z',
+        })
+    df = pd.DataFrame(rows)
+    csv_path = os.path.join(
+        prop.data_skill_stats_path,
+        f'skill_{prop.ofs}_water_level_{prop.whichcast}_'
+        f'{prop.ofsfiletype}.csv')
+    df.to_csv(csv_path)
+    return csv_path
+
+
+def test_make_summary_bars_writes_html(tmp_path):
+    _write_error_ranges(str(tmp_path))
+    prop = _make_prop(tmp_path)
+    _write_wl_csv(prop)
+
+    summary_barplots.make_summary_bars(
+        prop, ['water_level', 'wl', []], logging.getLogger('test'))
+
+    html = os.path.join(
+        prop.visuals_1d_station_path,
+        f'{prop.ofs}_summary_barplot_water_level_nowcast_stations.html')
+    png = os.path.join(
+        prop.om_files,
+        f'{prop.ofs}_summary_barplot_water_level_nowcast_stations.png')
+    assert os.path.isfile(html), 'HTML output missing'
+    assert os.path.getsize(html) > 1000
+    assert not os.path.isfile(png), \
+        'PNG should be skipped when prop.static_plots is False'
+
+
+def test_make_summary_bars_writes_png_when_static_plots(tmp_path):
+    _write_error_ranges(str(tmp_path))
+    prop = _make_prop(tmp_path, static=True)
+    _write_wl_csv(prop)
+
+    summary_barplots.make_summary_bars(
+        prop, ['water_level', 'wl', []], logging.getLogger('test'))
+
+    png = os.path.join(
+        prop.om_files,
+        f'{prop.ofs}_summary_barplot_water_level_nowcast_stations.png')
+    assert os.path.isfile(png), 'PNG output missing'
+    assert os.path.getsize(png) > 5000
+
+
+def test_make_summary_bars_missing_csv_warns(tmp_path, caplog):
+    _write_error_ranges(str(tmp_path))
+    prop = _make_prop(tmp_path)
+    # No CSV written.
+    with caplog.at_level(logging.WARNING):
+        summary_barplots.make_summary_bars(
+            prop, ['water_level', 'wl', []], logging.getLogger('test'))
+    msgs = [rec.message for rec in caplog.records]
+    assert any('not found' in m for m in msgs), msgs
+    # Output dirs exist but are empty (apart from any test artifacts).
+    html_files = [f for f in os.listdir(prop.visuals_1d_station_path)
+                  if f.endswith('.html')]
+    assert html_files == []
+
+
+def test_currents_xlabel_includes_depth(tmp_path):
+    _write_error_ranges(str(tmp_path))
+    df = pd.DataFrame({
+        'ID': ['cb1401', 'cb1401', 'cb1401'],
+        'obs_water_depth': [2.5, 5.5, 9.0],
+    })
+    labels = summary_barplots._x_labels(df, 'cu')
+    assert labels == ['cb1401@2.5m', 'cb1401@5.5m', 'cb1401@9.0m']
+
+
+def test_water_level_xlabel_is_plain_id(tmp_path):
+    df = pd.DataFrame({
+        'ID': ['8637689', '8575512'],
+        'obs_water_depth': [0.0, 0.0],
+    })
+    assert summary_barplots._x_labels(df, 'wl') == ['8637689', '8575512']
+
+
+def test_rmse_color_palette():
+    colors = summary_barplots._rmse_colors([0.05, 0.20, -0.10, float('nan')],
+                                           x1=0.15)
+    assert colors[0] == 'palegreen'   # within ±0.15
+    assert colors[1] == 'lightcoral'  # above 0.15
+    assert colors[2] == 'palegreen'   # within ±0.15
+    assert colors[3] == 'lightcoral'  # nan -> fail
+
+
+def test_cf_color_palette():
+    colors = summary_barplots._cf_colors([95.0, 89.9, 100.0, float('nan')])
+    assert colors == ['palegreen', 'lightcoral', 'palegreen', 'lightcoral']
+
+
+def test_html_embeds_export_filename(tmp_path):
+    """The toImage button in plotly should export with the same stem as
+    the HTML file, not the default ``newplot``."""
+    _write_error_ranges(str(tmp_path))
+    prop = _make_prop(tmp_path)
+    _write_wl_csv(prop)
+
+    summary_barplots.make_summary_bars(
+        prop, ['water_level', 'wl', []], logging.getLogger('test'))
+
+    html_path = os.path.join(
+        prop.visuals_1d_station_path,
+        f'{prop.ofs}_summary_barplot_water_level_nowcast_stations.html')
+    with open(html_path, encoding='utf-8') as fh:
+        content = fh.read()
+    expected_stem = (
+        f'{prop.ofs}_summary_barplot_water_level_nowcast_stations')
+    assert f'"filename": "{expected_stem}"' in content, (
+        'plotly toImage button is missing the matching filename config')
+
+
+def test_make_summary_bars_emits_hw_lw_for_water_level(tmp_path):
+    _write_error_ranges(str(tmp_path))
+    prop = _make_prop(tmp_path)
+    _write_wl_csv(prop)
+    # Also create the hw / lw extrema CSVs.
+    saved_path = os.path.join(prop.data_skill_stats_path,
+                              f'skill_{prop.ofs}_water_level_'
+                              f'{prop.whichcast}_{prop.ofsfiletype}.csv')
+    df = pd.read_csv(saved_path)
+    for suffix in ('hw', 'lw'):
+        df.to_csv(os.path.join(
+            prop.data_skill_stats_path,
+            f'skill_{prop.ofs}_water_level_{suffix}_{prop.whichcast}_'
+            f'{prop.ofsfiletype}.csv'))
+
+    summary_barplots.make_summary_bars(
+        prop, ['water_level', 'wl', []], logging.getLogger('test'))
+
+    expected = [
+        f'{prop.ofs}_summary_barplot_water_level_nowcast_stations.html',
+        f'{prop.ofs}_summary_barplot_water_level_hw_nowcast_stations.html',
+        f'{prop.ofs}_summary_barplot_water_level_lw_nowcast_stations.html',
+    ]
+    for name in expected:
+        assert os.path.isfile(
+            os.path.join(prop.visuals_1d_station_path, name)), name

--- a/tests/vdatum_resilient_test.py
+++ b/tests/vdatum_resilient_test.py
@@ -1,0 +1,175 @@
+"""Regression tests for vdatum_resilient.convert (transient PROJ failures)."""
+from __future__ import annotations
+
+import logging
+from unittest import mock
+
+import pyproj.exceptions
+import pytest
+
+from ofs_skill.obs_retrieval import vdatum_resilient
+
+
+def test_convert_passes_through_on_success(monkeypatch):
+    """Happy path: underlying vdatum.convert returns once, wrapper returns same."""
+    # Mark the pair as already primed so the wrapper skips the
+    # single-threaded warm-up and just makes the real call.
+    monkeypatch.setattr(vdatum_resilient, '_PRIMED_PAIRS',
+                        {('mllw', 'navd88')})
+    with mock.patch.object(
+            vdatum_resilient.vdatum, 'convert',
+            return_value=(36.94, -76.33, 8.5)) as mock_convert:
+        out = vdatum_resilient.convert('mllw', 'navd88',
+                                       36.94, -76.33, 10.0,
+                                       station_id='8638901')
+    assert out == (36.94, -76.33, 8.5)
+    assert mock_convert.call_count == 1
+    # First call always uses online=True (the path the project's caller
+    # used directly before the wrapper).
+    assert mock_convert.call_args.kwargs['online'] is True
+
+
+def test_convert_retries_on_proj_error_then_succeeds(monkeypatch):
+    """Transient PROJ network failure -> retry -> succeed."""
+    sleeps = []
+    monkeypatch.setattr(vdatum_resilient, '_PRIMED_PAIRS',
+                        {('mllw', 'navd88')})
+    monkeypatch.setattr(vdatum_resilient, '_sleep_with_backoff',
+                        lambda attempt: sleeps.append(attempt))
+
+    err = pyproj.exceptions.ProjError(
+        'Invalid projection ... Error 1029 (File not found or invalid)')
+    side_effects = [err, err, (36.0, -76.0, 9.0)]
+    with mock.patch.object(
+            vdatum_resilient.vdatum, 'convert',
+            side_effect=side_effects) as mock_convert:
+        out = vdatum_resilient.convert(
+            'mllw', 'navd88', 36.0, -76.0, 10.0)
+    assert out == (36.0, -76.0, 9.0)
+    assert mock_convert.call_count == 3
+    assert sleeps == [0, 1]  # backoff for first two retries only
+
+
+def test_convert_falls_back_to_offline_when_online_exhausted(monkeypatch):
+    """All online attempts fail -> single offline retry succeeds (cached grid)."""
+    monkeypatch.setattr(vdatum_resilient, '_PRIMED_PAIRS',
+                        {('mllw', 'navd88')})
+    monkeypatch.setattr(vdatum_resilient, '_sleep_with_backoff',
+                        lambda attempt: None)
+    err = pyproj.exceptions.ProjError('1029')
+    online_results = [err] * vdatum_resilient._RETRY_ATTEMPTS
+
+    def side_effect(*args, online, **kwargs):
+        if online:
+            raise online_results.pop(0)
+        return (37.0, -76.0, 9.5)
+
+    with mock.patch.object(
+            vdatum_resilient.vdatum, 'convert',
+            side_effect=side_effect) as mock_convert:
+        out = vdatum_resilient.convert(
+            'mllw', 'navd88', 37.0, -76.0, 10.0)
+    assert out == (37.0, -76.0, 9.5)
+    # _RETRY_ATTEMPTS online tries, then 1 offline try.
+    assert mock_convert.call_count == vdatum_resilient._RETRY_ATTEMPTS + 1
+
+
+def test_convert_raises_when_all_attempts_fail(monkeypatch, caplog):
+    """Permanent failure: all online + 1 offline raise -> ProjError bubbles up."""
+    monkeypatch.setattr(vdatum_resilient, '_PRIMED_PAIRS',
+                        {('mllw', 'navd88')})
+    monkeypatch.setattr(vdatum_resilient, '_sleep_with_backoff',
+                        lambda attempt: None)
+    err = pyproj.exceptions.ProjError('1029')
+    with mock.patch.object(
+            vdatum_resilient.vdatum, 'convert', side_effect=err):
+        with caplog.at_level(logging.ERROR):
+            with pytest.raises(pyproj.exceptions.ProjError):
+                vdatum_resilient.convert(
+                    'mllw', 'navd88', 36.0, -76.0, 10.0,
+                    station_id='8638901')
+    msgs = [r.message for r in caplog.records]
+    assert any('permanently failed' in m for m in msgs), msgs
+    assert any('PROJ_NETWORK' in m for m in msgs), msgs
+
+
+def test_convert_passes_station_id_in_warning(caplog, monkeypatch):
+    """Station id should appear in the per-attempt warning so users can grep."""
+    monkeypatch.setattr(vdatum_resilient, '_PRIMED_PAIRS',
+                        {('mllw', 'navd88')})
+    monkeypatch.setattr(vdatum_resilient, '_sleep_with_backoff',
+                        lambda attempt: None)
+    err = pyproj.exceptions.ProjError('1029')
+
+    def side_effect(*args, online, **kwargs):
+        if online:
+            raise err
+        return (37.0, -76.0, 9.5)
+
+    with mock.patch.object(
+            vdatum_resilient.vdatum, 'convert', side_effect=side_effect):
+        with caplog.at_level(logging.WARNING):
+            vdatum_resilient.convert(
+                'mllw', 'navd88', 37.0, -76.0, 10.0,
+                station_id='8638901')
+    assert any('8638901' in r.message for r in caplog.records), \
+        [r.message for r in caplog.records]
+
+
+def test_prime_runs_only_once_per_pair(monkeypatch):
+    """First call to convert() for a (vd_from, vd_to) pair should run a
+    prime call; subsequent calls should not re-prime."""
+    # Reset prime state so this test is order-independent.
+    monkeypatch.setattr(vdatum_resilient, '_PRIMED_PAIRS', set())
+
+    calls: list[tuple] = []
+
+    def fake_convert(vd_from, vd_to, lat, lon, z, *, online, epoch=None):
+        calls.append((vd_from, vd_to, float(lat), float(lon), float(z)))
+        return (lat, lon, z + 0.5)
+
+    monkeypatch.setattr(vdatum_resilient.vdatum, 'convert', fake_convert)
+    vdatum_resilient.convert('mllw', 'navd88', 37.0, -76.0, 10.0)
+    vdatum_resilient.convert('mllw', 'navd88', 38.0, -75.0, 11.0)
+
+    # First convert: prime (uses _PRIME_LAT/_PRIME_LON, z=0.0) + real call.
+    # Second convert: no prime, just real call.
+    assert calls == [
+        ('mllw', 'navd88',
+         vdatum_resilient._PRIME_LAT,
+         vdatum_resilient._PRIME_LON,
+         0.0),
+        ('mllw', 'navd88', 37.0, -76.0, 10.0),
+        ('mllw', 'navd88', 38.0, -75.0, 11.0),
+    ]
+
+
+def test_prime_failure_releases_lock(monkeypatch, caplog):
+    """If the prime call itself fails, the pair should still be marked
+    primed so the lock is released and other callers proceed."""
+    monkeypatch.setattr(vdatum_resilient, '_PRIMED_PAIRS', set())
+    monkeypatch.setattr(vdatum_resilient, '_sleep_with_backoff',
+                        lambda attempt: None)
+    err = pyproj.exceptions.ProjError('1029')
+
+    def fake_convert(*args, online, **kwargs):
+        # Prime fails, then the real retry loop also fails.
+        raise err
+
+    monkeypatch.setattr(vdatum_resilient.vdatum, 'convert', fake_convert)
+    with caplog.at_level(logging.WARNING):
+        with pytest.raises(pyproj.exceptions.ProjError):
+            vdatum_resilient.convert('mllw', 'navd88', 37.0, -76.0, 10.0)
+
+    assert ('mllw', 'navd88') in vdatum_resilient._PRIMED_PAIRS
+    assert any('PROJ grid prime failed' in r.message
+               for r in caplog.records), \
+        [r.message for r in caplog.records]
+
+
+def test_module_import_enables_pyproj_network():
+    """Importing the module should leave pyproj network globally enabled so
+    that worker threads spawned later inherit network=True."""
+    # The import already happened at module scope; verify side-effect.
+    import pyproj
+    assert pyproj.network.is_network_enabled() is True


### PR DESCRIPTION
### Description of Changes

This branch bundles seven independent fixes and one new feature that all
landed in the same working directory while I was building out the
station-summary barplot visualization. Rather than open seven small PRs,
I'm consolidating them here because most of them surfaced from the same
end-to-end runs that drove the barplot work, and several share test
infrastructure.

**1. New feature — station-by-station RMSE / central frequency summary
bar plots (`bb1feae`)**

- New `src/ofs_skill/visualization/summary_barplots.py` (349 lines)
  produces a per-OFS bar plot showing RMSE and central-frequency
  metrics on a station-by-station basis for water level, currents,
  temperature, and salinity.
- New driver `bin/visualization/create_summary_barplots.py` (138 lines)
  with the standard `-o {ofs} -p {path} -ws {whichcast}` CLI.
- Wired into `bin/visualization/create_1dplot.py` so the all-in-one
  `create_1dplot.py` invocation produces the summary barplots
  alongside per-station plots.
- 217 lines of tests in `tests/summary_barplots_test.py`.

**2. Fix — collapse side-looking CO-OPS ADCPs to a single virtual
station (`2e1006e`, issue #114)**

- CO-OPS side-looking ADCPs (cb1401, mb0301, etc.) report 48 horizontal
  range bins as separate "stations" in the MDAPI deployments payload.
  Pre-fix, the skill assessment treated each bin as an independent
  station and fanned the work out 48-way per side-looker.
- New `get_station_deployment` helper in
  `src/ofs_skill/obs_retrieval/retrieve_t_and_c_station.py` resolves
  the MDAPI `deployments` pointer (it is *not* inline data — payload
  returns `deployments: {self: <url>}`, the issue draft's assumption
  was wrong) and uses the `instrument_orientation == 'side'` flag to
  collapse all bins into a single virtual station at the depth of the
  primary range bin.
- 257 lines of tests in `tests/coops_currents_bins_test.py`.

**3. Fix — make `vdatum.convert` resilient to threaded PROJ grid-cache
races (`18a53aa`)**

- New `src/ofs_skill/obs_retrieval/vdatum_resilient.py` (172 lines)
  wraps `vdatum.convert` with retry-on-PROJ-error logic. The
  underlying `proj` C library uses a SQLite-backed grid cache that
  races when called from concurrent threads; `vdatum.convert` raises
  inscrutable `pyproj.exceptions.ProjError: Internal Error` under
  load.
- The wrapper retries with full-jitter exponential backoff (3 attempts
  by default), then falls back to a per-thread serialized path under
  a process-wide `Lock`. Existing callers in
  `get_datum_offset.py` and `write_obs_ctlfile.py` switched over;
  call signatures unchanged.
- 175 lines of tests in `tests/vdatum_resilient_test.py`.


**4. Fix — mask blended SCHISM dry/wet values
(`74d614a`)**

- STOFS-3D-Atl points netCDF files (and any other SCHISM-driven OFS)
  contain linear blends of `-999` and real values at near-shore
  stations on the wet/dry boundary, e.g. CO-OPS station 8518750 (The
  Battery, NY) showed ocean temperatures between -300 °C and -800 °C.
  These come from NCEP's post-processor averaging across SCHISM
  dry-cell sentinel timesteps; the previous mask `|val| >= 999` only
  caught the pure-fill values and let the blends through into RMSE,
  bias, and central-frequency statistics.
- New `_mask_schism_sentinels(arr, kind, station_id, ofs, log)` helper
  in `src/ofs_skill/model_processing/get_node_ofs.py` plus per-variable
  physical-bound table `_SCHISM_PHYSICAL_BOUNDS`. Replaces four inline
  masks in `format_temp_salt` / `format_currents`. Logs a `WARNING`
  per affected station + variable identifying the count, range of
  blended values, and pure-fill count.
- For currents the mask is applied to raw `u` / `v` *before*
  `sqrt(u² + v²)`, otherwise a -596 component would yield a 596 m/s
  "speed" that no downstream check catches.
- 114 lines of tests in `tests/schism_sentinel_filter_test.py`.
- Detailed write-up in `issue_stofs_3d_atl_blended_sentinel_values.md`
  at the repo root.

**5. Fix — NECOFS depth-index broadcast failure on multi-file concat
(`79b7202`)**

- Multi-day NECOFS station runs failed silently for `water_temperature`
  and `salinity` with `ValueError: operands could not be broadcast
  together with shapes (45,279) (17281,279)` at
  `index_nearest_depth`. Root cause: the FVCOM-z fallback added in
  `c56cf55` does `np.array(model_netcdf['siglay']) *
  np.array(model_netcdf['h'])`, which strips the xarray dim names
  before multiplying. After `intake_model` concatenates multiple files
  via `xr.open_mfdataset(concat_dim='time')`, `h` carries a `time`
  dim and numpy trailing-axis broadcasting fails (45 vs 17281).
- Fix: do the multiplication on the xarray DataArrays so broadcasting
  aligns by named `node` dim (the same approach `fix_fvcom` uses at
  `intake_scisa.py:646`). Both fallback sites
  (`indexing.py:447-456` for fields, `:680-689` for stations) updated.
- The exception was being caught by the per-variable `try/except` in
  `_extract_variable`, logged, and the variable silently skipped — so
  the symptom was missing temp/salt skill metrics for affected
  stations rather than a hard run failure.
- Detailed write-up in `issue_necofs_depth_index_broadcast_failure.md`
  at the repo root. A long-term cleanup plan that removes the fallback
  entirely is in `plan_simplify_fvcom_z_fallback.md` (filed as issue
  #129 for follow-up).

### Expected Outcome of Changes

- Operational runs produce per-OFS station summary bar plots without
  any new CLI surface — the existing `create_1dplot.py` invocation
  picks them up automatically.
- Side-looking ADCPs no longer multiply station counts 48× in
  `obs_ctl` files. Plots for cb1401, mb0301, and similar sites
  collapse to a single virtual ADCP at the primary range-bin depth.
- Threaded skill-assessment runs no longer fail with cryptic
  `pyproj.exceptions.ProjError: Internal Error` under concurrent
  vdatum conversions.
- NAVD88 datum offsets agree with CO-OPS published values to better
  than 1 mm on the affected tide stations (the prior ~1 cm error was
  from the bundled-grid fallback).
- STOFS-3D-Atl water_temperature / salinity / currents plots at
  near-shore wet/dry-boundary stations no longer show -300 °C to
  -800 °C blended-sentinel values; skill statistics for those stations
  reflect only physically realistic data.
- NECOFS multi-file station runs produce `water_temperature` and
  `salinity` `.ctl` files (and downstream skill plots) for all stations
  instead of silently dropping them.
- No changes to web-app inputs, JSON schemas, or station/skill output
  formats. No CLI changes.

### Developer Questions and Checklist

**Is this a high priority PR? If yes, why and is there a date by which
it needs to be merged?**
Medium priority. The bundle includes one new feature (station summary
barplots) and several bug fixes, two of which were producing silent data
loss in production runs.

**Are there any changes needed to how the code should be run for
operational runs? (Commands, flags, job timings, etc.)**
No. Same CLI, same flags. Activation hook for `PROJ_NETWORK=ON` runs
automatically when ops re-creates or updates the `ofs_dps` conda env.

**Does this update need to be deployed for operational runs?**
Yes. Side-looking ADCP collapse, vdatum thread-safety, SCHISM sentinel
masking, and the NECOFS broadcast fix all affect operational data
quality. The PROJ_NETWORK env hook only takes effect on env recreation,
so document in deployment notes.

**Does this update require front end/web app changes? (If yes, provide
documentation to Min)**
No. Summary barplots are PNG outputs in `data/visual/1d/om/` alongside
the existing scorecard / RMSE bar plots; no JSON or web schema change.

**Does this impact code development work on adding SCHISM?**
The sentinel filter is SCHISM-specific (gated on
`prop.model_source == 'schism'`) and provides the framework for
handling more SCHISM-style fill conventions as additional SCHISM-driven
OFS come online. 

**Does this impact code development work on adding ADCIRC?**
No. 
**Does this impact the expected number of output files for integration
tests (i.e., will the integration test fail even though code changes
result in desired change in outputs?)**
Yes.

**Does this impact code development work on adding parallelization?**
Yes. The vdatum_resilient wrapper is specifically
designed for the threaded execution pattern in the
`parallelization-optimization` branch and removes a known
race-condition failure mode there.

- [x] Developer's name is removed throughout the code?
- [x] Did you add relevant labels to the PR? 
- [x] Have you run pylint and is the code at an acceptable pylint
  score (>8)? — All new modules score >9. 
- [x] Jobs contain the appropriate file checking and handle errors for
  any missing data? — Yes. Sentinel filter warns instead of failing,
  vdatum wrapper falls back to serial path on persistent errors,
  NECOFS broadcast fix routes through existing `_extract_variable`
  exception handler.
- [x] Is log free of critical ERRORs or WARNINGs? — Healthy runs are
  silent at INFO. WARNINGs only on the four documented conditions:
  partial sentinel masking, vdatum retry exhaustion, side-looker
  deployment lookup miss, and any pre-existing CO-OPS coverage gap.

### Testing Instructions

**Environment**
```
eval "$(~/miniforge3/bin/conda shell.bash hook)" && conda activate ofs_dps
```
Confirm `conf/ofs_dps.conf` has `home=` set to the working directory.
Recreate the env (or run `conda env update -f environment.yml`) so the
`PROJ_NETWORK=ON` activation hook from `f866c57` takes effect.

**1. Unit tests (~5 seconds)**
```
pytest tests/summary_barplots_test.py tests/coops_currents_bins_test.py \
       tests/vdatum_resilient_test.py tests/schism_sentinel_filter_test.py \
       -v --no-cov
```
Expected: all passing.

**2. Full test suite**
```
pytest tests/ --no-cov -q
```
Expected: 485 passing, 0 failing. Baseline pre-branch was 459; this
branch adds ~26 across the four new test files.

**3. Side-looking ADCP collapse (cbofs)**
```
rm -rf data/observations/ control_files/
python ./bin/visualization/create_1dplot.py -o cbofs -p ./ \
    -s 2026-03-28T00:00:00Z -e 2026-03-29T00:00:00Z \
    -ws nowcast -t stations -vs currents
```
Expected: `data/visual/1d/cbofs_cb1401_*_currents_*_nowcast_stations.html`
exists for *one* bin only (`_b01_`), not 48. cb0402 (a vertical ADCP
peer station) still shows multiple bins (`_b01_` through `_b12_`).

**4. STOFS-3D-Atl sentinel masking**
```
python ./bin/visualization/create_1dplot.py -o stofs_3d_atl -p ./ \
    -s 2026-02-16T00:00:00Z -e 2026-02-21T00:00:00Z \
    -ws nowcast -t stations -vs water_temperature -so 8518750
```
Expected: log contains `WARNING [stofs_3d_atl 8518750
water_temperature] masking N blended sentinel values in range
[-797.83, -193.64]` and the resulting plot for 8518750 shows only
realistic ocean temperatures (no -300 to -800 °C excursions).

**5. Threaded vdatum smoke test**
```
python ./bin/visualization/create_1dplot.py -o cbofs -p ./ \
    -s 2026-03-28T00:00:00Z -e 2026-03-29T00:00:00Z \
    -ws nowcast -t stations -vs water_level
```
Expected: under default thread count, no `pyproj.exceptions.ProjError`
warnings. If retry path triggers, a single `INFO vdatum convert
retried after PROJ error` line is acceptable.

**6. Summary barplots produced**
```
ls data/visual/1d/om/cbofs_summary_barplot_*_nowcast_stations.png
```
Expected: PNGs for water_level (with `_lw_` and `_hw_` variants),
currents, water_temperature, salinity as appropriate to the OFS.


### Reminder checklist for PR reviewer
- [ ] Run PEP8 compliance tests to ensure the code follows best
  practices
- [ ] Check that documentation in the script is sufficient
- [ ] Validate the output values (if applicable) to make sure the
  calculations are correct and make scientific/physical sense; include
  a comment on the pull request including what validation you
  performed, for replicability.
- [ ] Test code both on Windows and Linux (and MacOS, if available),
  using several OFS as test cases
- [ ] **Test for all 'cast' options: forecast_a, forecast_b, and
  nowcast**
- [ ] When approving or commenting on a pull request, add information
  on the calls you use in case they need to be replicated or
  referenced.

---
Closes issues #129 #128 #127 #114 
