### PR TITLE
GUI tune-up

### DIFF
--- a/src/ofs_skill/visualization/create_gui.py
+++ b/src/ofs_skill/visualization/create_gui.py
@@ -14,17 +14,46 @@ from tkcalendar import DateEntry
 
 # Import from ofs_skill package
 from ofs_skill.obs_retrieval import utils
+from ofs_skill.model_processing.get_fcst_cycle import get_fcst_hours
 
 
 def create_gui(parser):
 
     def on_closing():
-        '''Function called when the user closes the window.'''
         if messagebox.askokcancel('Quit', 'Do you want to quit?'):
             # If the user confirms quitting, destroy the window
             root.destroy()
             print('Skill assessment run terminated by user.')
             sys.exit()
+
+    def quick_run_submit():
+        '''Bypasses standard validation and executes a pre-configured quick run.'''
+        if not directory_path_var.get():
+            messagebox.showerror('Error', 'Please select your home directory for Quick Run.')
+            return
+        if ofs_entry.get() == choices[0] or not ofs_entry.get():
+            messagebox.showerror('Error', 'Please select an OFS for Quick Run.')
+            return
+
+        # Assign user inputs
+        args_values.Path = directory_path_var.get()
+        args_values.OFS = ofs_entry.get()
+
+        # Auto-set the remaining arguments
+        args_values.Whichcasts = ['nowcast', 'forecast_a']
+        args_values.Forecast_Hr = 'now'
+        args_values.StartDate_full = None
+        args_values.EndDate_full = None
+        args_values.Datum = 'MLLW'
+        args_values.FileType = 'stations'
+        args_values.Station_Owner = ['co-ops', 'ndbc', 'usgs']
+        args_values.Var_Selection = ['water_level', 'water_temperature', 'salinity', 'currents']
+        args_values.Horizon_Skill = False
+        args_values.Currents_Bins_Csv = None
+        args_values.Disable_Model_File_Check = True # True means the check IS performed
+
+        # Close the GUI and pass values to the main script
+        root.destroy()
 
     def submit_and_close():
         # First check for required arguments and display error if not present
@@ -32,8 +61,11 @@ def create_gui(parser):
         if directory_path_var.get() is None:
             messagebox.showerror('Error', 'Please select your home directory.')
             error = 1
-        if ofs_entry.get() == choices[0]:
+        elif ofs_entry.get() == choices[0]:
             messagebox.showerror('Error', 'Please select the OFS.')
+            error = 1
+        elif cycle_var.get() in ['Select an OFS first...', '']:
+            messagebox.showerror('Error', 'Please select a model cycle.')
             error = 1
         elif datum_var.get() == dchoices[0]:
             messagebox.showerror('Error', 'Please choose a datum.')
@@ -59,6 +91,7 @@ def create_gui(parser):
              messagebox.showerror('Error', 'Please select at least one '
                                   'variable to assess.')
              error = 1
+
         args_values.Path = directory_path_var.get()
         args_values.OFS = ofs_entry.get()
         args_values.StartDate_full = format_date(start_entry.get_date(),
@@ -66,7 +99,7 @@ def create_gui(parser):
         args_values.EndDate_full = format_date(end_entry.get_date(),
                                                e_hour_scale.get())
         args_values.Whichcasts = [item for item in [var_now.get(), \
-                                var_fore.get()] if item != '0']
+                var_fore.get(), var_forea.get(), var_hind.get()] if item != '0']
         args_values.Datum = datum_var.get()
         args_values.FileType = filetype_var.get()
         args_values.Station_Owner = [item for item in [var_coops.get(), \
@@ -76,6 +109,19 @@ def create_gui(parser):
         args_values.Var_Selection = [item for item in [var_wl.get(), \
                                 var_temp.get(), var_salt.get(), var_cu.get()] if \
                                      item != '0']
+
+        # Add the cycle selection to args_values
+        selected_cycle = cycle_var.get()
+        if selected_cycle == 'Most recent available':
+            args_values.Forecast_Hr = 'now'
+        else:
+            args_values.Forecast_Hr = selected_cycle
+
+        # Add the CSV path. None if blank
+        args_values.Currents_Bins_Csv = cb_var.get() if cb_var.get() != "" else None
+
+        args_values.Disable_Model_File_Check = df_var.get()
+
         if error is None:
             root.destroy() # Close the GUI window
 
@@ -99,16 +145,59 @@ def create_gui(parser):
         if chosen_directory:  # Only update if a directory was selected
             directory_path_var.set(chosen_directory)
 
+    def browse_csv_file():
+        '''
+        Opens a file selection dialog for the currents bins CSV.
+        '''
+        chosen_file = filedialog.askopenfilename(
+            title="Select Currents Bins CSV",
+            filetypes=(("CSV files", "*.csv"), ("All files", "*.*"))
+        )
+        if chosen_file:
+            cb_var.set(chosen_file)
+
     def get_selected_date():
         selected_date = start_entry.get_date()
         print(f'Selected date: {selected_date}')
+
+    def update_cycles(event=None):
+        '''Updates the cycle combobox based on the selected OFS.'''
+        selected_ofs = ofs_entry.get()
+        if selected_ofs and selected_ofs != 'Select an OFS...':
+            # get_fcst_hours returns max forecast length and cycle hours
+            _, cycles = get_fcst_hours(selected_ofs)
+
+            # Format the integer array into strings like '00z', '06z'
+            cycle_choices = [f"{int(c):02d}z" for c in cycles]
+
+            # Insert the new option at the top of the list
+            cycle_choices.insert(0, 'Most recent cycle available')
+
+            cycle_chosen['values'] = tuple(cycle_choices)
+
+            # Auto-select the first available option
+            if cycle_choices:
+                cycle_var.set(cycle_choices[0])
+        else:
+            cycle_chosen['values'] = ('Select an OFS first...',)
+            cycle_var.set('Select an OFS first...')
+
+    def toggle_cycle_state():
+        '''Enables or disables the Model Cycle dropdown based on Forecast_a selection.'''
+        if var_forea.get() == 'forecast_a':
+            cycle_chosen.config(state='readonly')
+        else:
+            cycle_chosen.config(state='disabled')
 
     root = tk.Tk()
     root.title('Skill assessment inputs')
     # Set the protocol for handling the window close event
     root.protocol('WM_DELETE_WINDOW', on_closing)
+    root.geometry('850x500') # Restrict the height to make the window shorter
+
     style = ttk.Style(root)
     style.theme_use('clam') # modified from vista to clam for cross OS compatibility
+
     # STYLING
     # Change the icon
     try:
@@ -120,6 +209,9 @@ def create_gui(parser):
         root.iconphoto(False, icon_image)
     except:
         print('GUI logo not found! Defaulting to tkinter logo...')
+    # retrieve current datum list
+    datum_list = (utils.Utils(None).read_config_section('datums', None)\
+                       ['datum_list']).split(' ')
 
     # Window-wide colors, text, and stuff
     anchor='e'
@@ -131,6 +223,42 @@ def create_gui(parser):
     padx = 3
     pady = 10
     root.config(bg=themecolor)
+
+    # --- SCROLLBAR AND CANVAS SETUP ---
+    # Create a main container frame
+    container = tk.Frame(root, bg=themecolor)
+    container.pack(fill='both', expand=True)
+
+    # Create a canvas inside the container
+    canvas = tk.Canvas(container, bg=themecolor, highlightthickness=0)
+
+    # Create the vertical scrollbar
+    scrollbar = ttk.Scrollbar(container, orient='vertical', command=canvas.yview)
+
+    # Create the scrollable frame that will hold all widgets
+    scrollable_frame = tk.Frame(canvas, bg=themecolor)
+
+    # Bind the frame size changes to update the canvas scroll region
+    scrollable_frame.bind(
+        "<Configure>",
+        lambda e: canvas.configure(
+            scrollregion=canvas.bbox("all")
+        )
+    )
+
+    # Put the frame inside a window within the canvas
+    canvas.create_window((0, 0), window=scrollable_frame, anchor="nw")
+    canvas.configure(yscrollcommand=scrollbar.set)
+
+    # Pack the canvas and scrollbar
+    canvas.pack(side="left", fill="both", expand=True)
+    scrollbar.pack(side="right", fill="y")
+
+    # Bind mousewheel scrolling to the canvas
+    def _on_mousewheel(event):
+        canvas.yview_scroll(int(-1*(event.delta/120)), "units")
+    root.bind_all("<MouseWheel>", _on_mousewheel)
+
     # Style for each widget type
     style = ttk.Style()
     style.configure('TButton',
@@ -161,6 +289,8 @@ def create_gui(parser):
     args_values.Horizon_Skill = parser.get_default('Horizon_Skill')
     args_values.Forecast_Hr = parser.get_default('Forecast_Hr')
     args_values.Var_Selection = parser.get_default('Var_Selection')
+    args_values.Currents_Bins_Csv = parser.get_default('Currents_Bins_Csv')
+    args_values.Disable_Model_File_Check = parser.get_default('Disable_Model_File_Check')
     args_values.config = None
 
     # Set row initial value
@@ -170,73 +300,108 @@ def create_gui(parser):
     row += 1
     # Create a StringVar to hold the selected directory path
     directory_path_var = tk.StringVar()
-    tk.Label(root,
+    tk.Label(scrollable_frame,
              text='Home directory',
              bg=themecolor,
              fg=textcolor,
              font=(fontfamily, labelfontsize),
              anchor=anchor).grid(row=row, column=0,  sticky='w',
                                  padx=padx, pady=pady)
-    ttk.Button(root, text='Browse...', command=browse_directory,
+    ttk.Button(scrollable_frame, text='Browse...', command=browse_directory,
                style='TButton').grid(row=row, column=1,  sticky='w',
                                      padx=padx, pady=pady)
-    ttk.Entry(root, textvariable=directory_path_var).grid(row=row, column=2,
+    ttk.Entry(scrollable_frame, textvariable=directory_path_var).grid(row=row, column=2,
                                                           sticky='w',
                                                           padx=padx, pady=pady)
 
     # OFS input, -o
     row += 1
     ofs_entry = tk.StringVar()
-    choices = ('Select an OFS...','cbofs', 'dbofs', 'gomofs', 'tbofs', 'ciofs',
-               'wcofs', 'ngofs2', 'ngofs', 'leofs', 'lmhofs', 'loofs', 'loofs2',
-               'lsofs', 'sfbofs', 'sscofs','stofs_3d_atl', 'stofs_3d_pac',
-               'loofs-nextgen')
+    choices = ('Select an OFS...',
+               'cbofs',
+               'ciofs',
+               'dbofs',
+               'gomofs',
+               'leofs',
+               'lmhofs',
+               'loofs',
+               'loofs2',
+               'lsofs',
+               'necofs',
+               'ngofs2',
+               'secofs',
+               'sfbofs',
+               'sscofs',
+               'stofs_2d_glo',
+               'stofs_3d_atl',
+               'stofs_3d_pac',
+               'tbofs',
+               'wcofs',
+               )
+
     ofs_entry.set('Select an OFS...')
-    tk.Label(root,
+    tk.Label(scrollable_frame,
              text='OFS',
              bg=themecolor,
              fg=textcolor,
              font=(fontfamily, labelfontsize),
              anchor=anchor).grid(row=row, column=0,  sticky='w',
                                  padx=padx, pady=pady)
-    ofs_chosen = ttk.Combobox(root, width = 15, textvariable = ofs_entry,
+    ofs_chosen = ttk.Combobox(scrollable_frame, width = 15, textvariable = ofs_entry,
                               font=('Helvetica', 12))
     ofs_chosen['values'] = choices
     ofs_chosen.grid(row=row, column=1,  sticky='w', padx=padx, pady=pady)
+    ofs_chosen.bind('<<ComboboxSelected>>', update_cycles)
+
+    row += 1
+    tk.Label(scrollable_frame,
+             text='Quick run mode assesses the most recent model cycle ➡️',
+             bg=themecolor,
+             fg=textcolor,
+             font=(fontfamily, 9, 'italic'),
+             anchor=anchor).grid(
+                 row=row, column=0, sticky='w', padx=padx, pady=(0, pady))
+    # QUICK RUN BUTTON!
+    ttk.Button(scrollable_frame, text='⚡ Quick Run Mode', command=quick_run_submit,
+               style='TButton').grid(row=row, column=1, sticky='w', padx=padx, pady=(0, pady))
+
+    row += 1
+    ttk.Separator(scrollable_frame, orient='horizontal').grid(
+        row=row, column=0, columnspan=4, sticky='ew', pady=(15, 10))
 
     # Start date, -s
     row += 1
-    tk.Label(root,
+    tk.Label(scrollable_frame,
              text='Start date & hour',
              bg=themecolor,
              fg=textcolor,
              font=(fontfamily, labelfontsize),
              anchor=anchor).grid(row=row, column=0, sticky='w',
                                  padx=padx, pady=pady)
-    start_entry = DateEntry(root, width=16, background='darkblue',
+    start_entry = DateEntry(scrollable_frame, width=16, background='darkblue',
                     foreground='white', bd=2, date_pattern='yyyy-mm-dd',
                     font=('Helvetica', 12))
     start_entry.grid(row=row, column=1,  sticky='w', padx=padx, pady=pady)
     # Create scale widget for hour selection
-    s_hour_scale = tk.Scale(root, from_=0, to=23, orient=tk.HORIZONTAL,
+    s_hour_scale = tk.Scale(scrollable_frame, from_=0, to=23, orient=tk.HORIZONTAL,
                           length=100)
     s_hour_scale.grid(row=row, column=2,  sticky='w', padx=padx, pady=pady)
 
     # End date, -e
     row += 1
-    tk.Label(root,
+    tk.Label(scrollable_frame,
              text='End date & hour',
              bg=themecolor,
              fg=textcolor,
              font=(fontfamily, labelfontsize),
              anchor=anchor).grid(row=row, column=0,  sticky='w',
                                  padx=padx, pady=pady)
-    end_entry = DateEntry(root, width=16, background='darkblue',
+    end_entry = DateEntry(scrollable_frame, width=16, background='darkblue',
                     foreground='white', bd=2, date_pattern='yyyy-mm-dd',
                     font=('Helvetica', 12))
     end_entry.grid(row=row, column=1,  sticky='w', padx=padx, pady=pady)
     # Create scale widget for hour selection
-    e_hour_scale = tk.Scale(root, from_=0, to=23, orient=tk.HORIZONTAL,
+    e_hour_scale = tk.Scale(scrollable_frame, from_=0, to=23, orient=tk.HORIZONTAL,
                           length=100)
     e_hour_scale.grid(row=row, column=2,  sticky='w', padx=padx, pady=pady)
 
@@ -245,42 +410,67 @@ def create_gui(parser):
     var_now = tk.StringVar()
     var_fore = tk.StringVar()
     var_hind = tk.StringVar()
+    var_forea = tk.StringVar()
     var_now.set('nowcast')
     var_fore.set('forecast_b')
-    var_hind.set('hindcast')
-    tk.Label(root,
-             text='Whichcasts (choose one or more)',
+
+    # Set these to '0' so they are unchecked by default
+    var_forea.set('0')
+    var_hind.set('0')
+
+    tk.Label(scrollable_frame,
+             text='Whichcasts',
              bg=themecolor,
              fg=textcolor,
              font=(fontfamily, labelfontsize),
              anchor=anchor).grid(row=row, column=0, sticky='w',
                                  padx=padx, pady=pady)
-    ttk.Checkbutton(root, text='Nowcast', variable=var_now, onvalue='nowcast',
+    ttk.Checkbutton(scrollable_frame, text='Nowcast', variable=var_now, onvalue='nowcast',
                    offvalue=0).grid(row=row, column=1, sticky='w',
                                     padx=padx, pady=pady)
-    ttk.Checkbutton(root, text='Forecast', variable=var_fore, onvalue=
+    ttk.Checkbutton(scrollable_frame, text='Forecast_b', variable=var_fore, onvalue=
                    'forecast_b', offvalue=0).grid(row=row, column=2,
                                                   sticky='w', padx=padx,
                                                   pady=pady)
     row += 1
-    ttk.Checkbutton(root, text='Hindcast (LOOFS2 only)', variable=var_hind, onvalue=
-                   'hindcast', offvalue=0).grid(row=row, column=1,
+    ttk.Checkbutton(scrollable_frame, text='Forecast_a', variable=var_forea, onvalue=
+                   'forecast_a', offvalue=0, command=toggle_cycle_state).grid(
+                                                  row=row, column=1,
                                                   sticky='w', padx=padx,
                                                   pady=pady)
+    ttk.Checkbutton(scrollable_frame, text='Hindcast (LOOFS2 only)', variable=var_hind, onvalue=
+                   'hindcast', offvalue=0).grid(row=row, column=2,
+                                                  sticky='w', padx=padx,
+                                                  pady=pady)
+
+    # Model Cycle input, -f
+    row += 1
+    cycle_var = tk.StringVar()
+    cycle_var.set('Select an OFS first...')
+    tk.Label(scrollable_frame,
+             text='Model cycle (forecast_a only)',
+             bg=themecolor,
+             fg=textcolor,
+             font=(fontfamily, labelfontsize),
+             anchor=anchor).grid(row=row, column=0,  sticky='w',
+                                 padx=padx, pady=pady)
+    cycle_chosen = ttk.Combobox(scrollable_frame, width=22, textvariable=cycle_var,
+                              font=('Helvetica', 12), state='readonly')
+    cycle_chosen.grid(row=row, column=1,  sticky='w', padx=padx, pady=pady)
+
     # Datums, -d
     row += 1
     datum_var = tk.StringVar()
-    dchoices = ('Select a datum...','MLLW', 'MLW', 'MHW', 'MHHW', 'XGEOID20b',
-               'IGLD85', 'LWD')
+    dchoices = ('Select a datum...',) + tuple(datum_list)
     datum_var.set('Select a datum...')
-    tk.Label(root,
+    tk.Label(scrollable_frame,
              text='Vertical datum',
              bg=themecolor,
              fg=textcolor,
              font=(fontfamily, labelfontsize),
              anchor=anchor).grid(row=row, column=0, sticky='w',
                                  padx=padx, pady=pady)
-    datum_chosen = ttk.Combobox(root, width = 15, textvariable = datum_var,
+    datum_chosen = ttk.Combobox(scrollable_frame, width = 15, textvariable = datum_var,
                                 font=('Helvetica', 12))
     datum_chosen['values'] = dchoices
     datum_chosen.grid(row=row, column=1, sticky='w', padx=padx, pady=pady)
@@ -288,17 +478,17 @@ def create_gui(parser):
     # File type, -t
     row += 1
     filetype_var = tk.StringVar(value='stations') # Default selection
-    tk.Label(root,
+    tk.Label(scrollable_frame,
              text='Model output file type',
              bg=themecolor,
              fg=textcolor,
              font=(fontfamily, labelfontsize),
              anchor=anchor).grid(row=row, column=0, sticky='w',
                                  padx=padx, pady=pady)
-    ttk.Radiobutton(root, text='Station', variable=filetype_var,
+    ttk.Radiobutton(scrollable_frame, text='Station', variable=filetype_var,
                    value='stations').grid(row=row, column=1,
                                           sticky='w', padx=padx, pady=pady)
-    ttk.Radiobutton(root, text='Field', variable=filetype_var, value='fields').\
+    ttk.Radiobutton(scrollable_frame, text='Field', variable=filetype_var, value='fields').\
         grid(row=row, column=2, sticky='w', padx=padx, pady=pady)
 
     # Station provider, -so
@@ -311,34 +501,34 @@ def create_gui(parser):
     var_ndbc.set('ndbc')
     var_usgs.set('usgs')
     var_list.set(0)
-    tk.Label(root,
-             text='Station providers (choose one or more)',
+    tk.Label(scrollable_frame,
+             text='Station providers',
              bg=themecolor,
              fg=textcolor,
              font=(fontfamily, labelfontsize),
              anchor=anchor).grid(
         row=row, column=0, sticky='w', padx=padx, pady=pady)
-    tk.Label(root,
+    tk.Label(scrollable_frame,
              text='If adding stations from list, provider selection is optional',
              bg=themecolor,
              fg=textcolor,
              font=(fontfamily, 9, 'italic'),
              anchor=anchor).grid(
         row=row+1, column=0, sticky='w', padx=padx, pady=(0,pady))
-    ttk.Checkbutton(root, text='CO-OPS',
+    ttk.Checkbutton(scrollable_frame, text='CO-OPS',
                    variable=var_coops, onvalue='co-ops', offvalue=0).grid(
                               row=row, column=1, sticky='w',
                               padx=padx, pady=(pady,2))
-    ttk.Checkbutton(root, text='NDBC',
+    ttk.Checkbutton(scrollable_frame, text='NDBC',
                    variable=var_ndbc, onvalue='ndbc', offvalue=0).grid(
                               row=row, column=2, sticky='w',
                               padx=padx, pady=(pady,2))
     row += 1
-    ttk.Checkbutton(root, text='USGS',
+    ttk.Checkbutton(scrollable_frame, text='USGS',
                    variable=var_usgs, onvalue='usgs', offvalue=0).grid(
                               row=row, column=1, sticky='w',
                               padx=padx, pady=(0,pady))
-    ttk.Checkbutton(root, text='Add from list',
+    ttk.Checkbutton(scrollable_frame, text='Add from conf file',
                    variable=var_list, onvalue='list', offvalue=0).grid(
                               row=row, column=2, sticky='w',
                               padx=padx, pady=(0,pady))
@@ -353,27 +543,27 @@ def create_gui(parser):
     var_temp.set('water_temperature')
     var_salt.set('salinity')
     var_cu.set('currents')
-    tk.Label(root,
-             text='Variables (choose one or more)',
+    tk.Label(scrollable_frame,
+             text='Variables',
              bg=themecolor,
              fg=textcolor,
              font=(fontfamily, labelfontsize),
              anchor=anchor).grid(
         row=row, column=0, sticky='w', padx=padx, pady=pady)
-    ttk.Checkbutton(root, text='Water level',
+    ttk.Checkbutton(scrollable_frame, text='Water level',
                    variable=var_wl, onvalue='water_level', offvalue=0).grid(
                               row=row, column=1, sticky='w',
                               padx=padx, pady=(pady,2))
-    ttk.Checkbutton(root, text='Temperature',
+    ttk.Checkbutton(scrollable_frame, text='Temperature',
                    variable=var_temp, onvalue='water_temperature', offvalue=0).grid(
                               row=row, column=2, sticky='w',
                               padx=padx, pady=(pady,2))
     row += 1
-    ttk.Checkbutton(root, text='Salinity',
+    ttk.Checkbutton(scrollable_frame, text='Salinity',
                    variable=var_salt, onvalue='salinity', offvalue=0).grid(
                               row=row, column=1, sticky='w',
                               padx=padx, pady=(0,pady))
-    ttk.Checkbutton(root, text='Current velocity',
+    ttk.Checkbutton(scrollable_frame, text='Current velocity',
                    variable=var_cu, onvalue='currents', offvalue=0).grid(
                               row=row, column=2, sticky='w',
                               padx=padx, pady=(0,pady))
@@ -381,28 +571,60 @@ def create_gui(parser):
     # Forecast horizon skill, -hs
     row += 1
     horizon_var = tk.BooleanVar(value=False) # Default selection
-    tk.Label(root,
+    tk.Label(scrollable_frame,
              text='Assess all forecast horizons?',
              bg=themecolor,
              fg=textcolor,
              font=(fontfamily, labelfontsize),
              anchor=anchor).grid(
         row=row, column=0, sticky='w', padx=padx, pady=pady)
-    ttk.Radiobutton(root, text='No', variable=horizon_var, value=False).grid(
+    ttk.Radiobutton(scrollable_frame, text='No (default)', variable=horizon_var, value=False).grid(
         row=row, column=1, sticky='w', padx=padx, pady=pady)
-    ttk.Radiobutton(root, text='Yes', variable=horizon_var, value=True).grid(
+    ttk.Radiobutton(scrollable_frame, text='Yes', variable=horizon_var, value=True).grid(
+        row=row, column=2, sticky='w', padx=padx, pady=pady)
+
+    # Currents bins CSV, -cb
+    row += 1
+    cb_var = tk.StringVar()
+    tk.Label(scrollable_frame,
+             text='Currents bins CSV (Optional)',
+             bg=themecolor,
+             fg=textcolor,
+             font=(fontfamily, labelfontsize),
+             anchor=anchor).grid(row=row, column=0, sticky='w',
+                                 padx=padx, pady=pady)
+    ttk.Button(scrollable_frame, text='Browse...', command=browse_csv_file,
+               style='TButton').grid(row=row, column=1, sticky='w',
+                                     padx=padx, pady=pady)
+    ttk.Entry(scrollable_frame, textvariable=cb_var).grid(row=row, column=2,
+                                              sticky='w',
+                                              padx=padx, pady=pady)
+
+    # Model file check, -df
+    row += 1
+    df_var = tk.BooleanVar(value=True) # Default is True (perform the file check)
+    tk.Label(scrollable_frame,
+             text='Pre-check for model output files?',
+             bg=themecolor,
+             fg=textcolor,
+             font=(fontfamily, labelfontsize),
+             anchor=anchor).grid(
+        row=row, column=0, sticky='w', padx=padx, pady=pady)
+    ttk.Radiobutton(scrollable_frame, text='No (disable check)', variable=df_var, value=False).grid(
+        row=row, column=1, sticky='w', padx=padx, pady=pady)
+    ttk.Radiobutton(scrollable_frame, text='Yes (default)', variable=df_var, value=True).grid(
         row=row, column=2, sticky='w', padx=padx, pady=pady)
 
     # Horizontal separator
     row += 1
-    separator = ttk.Separator(root, orient='horizontal')
+    separator = ttk.Separator(scrollable_frame, orient='horizontal')
     separator.grid(row=row, column=0, columnspan=4, sticky='ew', pady=pady)
 
     # Submit button
     row += 1
-    submit_button = ttk.Button(root, text='Run skill assessment!',
+    submit_button = ttk.Button(scrollable_frame, text='Run skill assessment!',
                               command=submit_and_close)
     submit_button.grid(row=row, column=0, columnspan=4, pady=10)
-
+    toggle_cycle_state()
     root.mainloop()
     return args_values

--- a/src/ofs_skill/visualization/create_gui.py
+++ b/src/ofs_skill/visualization/create_gui.py
@@ -3,18 +3,103 @@ Created on Wed Nov 12 08:39:35 2025
 
 @author: PWL
 """
+import logging
 import os
 import sys
 import tkinter as tk
+from datetime import datetime, timedelta, timezone
 from tkinter import filedialog, messagebox, ttk
 from tkinter.font import Font
 from types import SimpleNamespace
 
 from tkcalendar import DateEntry
 
+from ofs_skill.model_processing.get_fcst_cycle import get_fcst_hours
+
 # Import from ofs_skill package
 from ofs_skill.obs_retrieval import utils
-from ofs_skill.model_processing.get_fcst_cycle import get_fcst_hours
+
+# UI sentinel strings — used in multiple places, must match exactly.
+_OFS_PLACEHOLDER = 'Select an OFS...'
+_OFS_FIRST_PLACEHOLDER = 'Select an OFS first...'
+_DATUM_PLACEHOLDER = 'Select a datum...'
+_MOST_RECENT_LABEL = 'Most recent cycle available'
+_WINDOW_GEOMETRY = '850x500'
+
+# Datum fallback if conf cannot be read.
+_DEFAULT_DATUMS = (
+    'MHHW', 'MHW', 'MLLW', 'MLW', 'NAVD88', 'IGLD85', 'LWD', 'XGEOID20B'
+)
+
+# Per-OFS Quick Run datum defaults. Great Lakes use IGLD85; STOFS systems
+# don't have a uniform tidal datum so fall back to NAVD88; tidal coastal
+# OFSes use MLLW.
+_GREAT_LAKES_OFS = ('leofs', 'lmhofs', 'loofs', 'loofs2', 'lsofs')
+_STOFS_OFS = ('stofs_2d_glo', 'stofs_3d_atl', 'stofs_3d_pac')
+
+
+def _quick_run_datum(ofs):
+    """Return a sensible default datum for the given OFS in Quick Run mode."""
+    if ofs in _GREAT_LAKES_OFS:
+        return 'IGLD85'
+    if ofs in _STOFS_OFS:
+        return 'NAVD88'
+    return 'MLLW'
+
+
+def _compute_recent_cycle(ofs):
+    """Compute the most recent forecast cycle that should be available.
+
+    Returns
+    -------
+    (start_iso, forecast_hr) : tuple of str
+        ``start_iso`` is YYYY-MM-DDTHH:MM:SSZ at the chosen cycle, and
+        ``forecast_hr`` is the cycle as ``'06z'`` etc. Allows a 2h delay
+        for file arrival on NODD before considering a cycle "available".
+    """
+    _, fcstcycles = get_fcst_hours(ofs)
+    cycles = sorted(int(c) for c in fcstcycles)
+    now_utc = datetime.now(timezone.utc).replace(
+        minute=0, second=0, microsecond=0
+    )
+    cutoff = now_utc - timedelta(hours=2)
+    today = now_utc.replace(hour=0)
+    chosen = None
+    for offset_days in (0, 1):
+        day = today - timedelta(days=offset_days)
+        for hr in reversed(cycles):
+            cyc_dt = day.replace(hour=hr)
+            if cyc_dt <= cutoff:
+                chosen = cyc_dt
+                break
+        if chosen is not None:
+            break
+    if chosen is None:
+        chosen = today.replace(hour=cycles[-1]) - timedelta(days=1)
+    return (
+        chosen.strftime('%Y-%m-%dT%H:%M:%SZ'),
+        f'{chosen.hour:02d}z',
+    )
+
+
+def _read_datum_list():
+    """Read [datums] datum_list from conf, falling back to a hardcoded list.
+
+    The shared ``read_config_section`` helper logs via the logger argument
+    on failure; we pass a real logger so a missing section doesn't crash
+    the GUI on launch.
+    """
+    log = logging.getLogger(__name__)
+    try:
+        section = utils.Utils(None).read_config_section('datums', log)
+        raw = section.get('datum_list')
+        if raw:
+            return tuple(raw.split())
+    except (KeyError, AttributeError, OSError):
+        log.warning(
+            'Could not read [datums] from conf; falling back to defaults.'
+        )
+    return _DEFAULT_DATUMS
 
 
 def create_gui(parser):
@@ -27,7 +112,13 @@ def create_gui(parser):
             sys.exit()
 
     def quick_run_submit():
-        '''Bypasses standard validation and executes a pre-configured quick run.'''
+        '''Bypasses standard validation and executes a pre-configured quick run.
+
+        Defaults are tailored per-OFS where it matters: datum picks IGLD85
+        for Great Lakes / NAVD88 for STOFS / MLLW for tidal coastal, and the
+        forecast cycle is computed from current UTC time so the run does not
+        depend on the optional S3 fallback setting.
+        '''
         if not directory_path_var.get():
             messagebox.showerror('Error', 'Please select your home directory for Quick Run.')
             return
@@ -35,24 +126,30 @@ def create_gui(parser):
             messagebox.showerror('Error', 'Please select an OFS for Quick Run.')
             return
 
-        # Assign user inputs
-        args_values.Path = directory_path_var.get()
-        args_values.OFS = ofs_entry.get()
+        ofs = ofs_entry.get()
+        start_iso, forecast_hr = _compute_recent_cycle(ofs)
+        end_iso = (
+            datetime.strptime(start_iso, '%Y-%m-%dT%H:%M:%SZ')
+            + timedelta(hours=24)
+        ).strftime('%Y-%m-%dT%H:%M:%SZ')
 
-        # Auto-set the remaining arguments
+        args_values.Path = directory_path_var.get()
+        args_values.OFS = ofs
         args_values.Whichcasts = ['nowcast', 'forecast_a']
-        args_values.Forecast_Hr = 'now'
-        args_values.StartDate_full = None
-        args_values.EndDate_full = None
-        args_values.Datum = 'MLLW'
+        args_values.Forecast_Hr = forecast_hr
+        args_values.StartDate_full = start_iso
+        args_values.EndDate_full = end_iso
+        args_values.Datum = _quick_run_datum(ofs)
         args_values.FileType = 'stations'
         args_values.Station_Owner = ['co-ops', 'ndbc', 'usgs']
-        args_values.Var_Selection = ['water_level', 'water_temperature', 'salinity', 'currents']
+        args_values.Var_Selection = [
+            'water_level', 'water_temperature', 'salinity', 'currents'
+        ]
         args_values.Horizon_Skill = False
         args_values.Currents_Bins_Csv = None
-        args_values.Disable_Model_File_Check = True # True means the check IS performed
+        # Mirrors argparse: True means the model-file pre-check is performed.
+        args_values.Disable_Model_File_Check = True
 
-        # Close the GUI and pass values to the main script
         root.destroy()
 
     def submit_and_close():
@@ -64,7 +161,7 @@ def create_gui(parser):
         elif ofs_entry.get() == choices[0]:
             messagebox.showerror('Error', 'Please select the OFS.')
             error = 1
-        elif cycle_var.get() in ['Select an OFS first...', '']:
+        elif cycle_var.get() in (_OFS_FIRST_PLACEHOLDER, ''):
             messagebox.showerror('Error', 'Please select a model cycle.')
             error = 1
         elif datum_var.get() == dchoices[0]:
@@ -77,64 +174,76 @@ def create_gui(parser):
             messagebox.showerror('Error', 'Please enter an end date.')
             error = 1
         elif var_now.get() == '0' and var_fore.get() == '0':
-             messagebox.showerror('Error', 'Please select at least one '
-                                  'whichcast.')
-             error = 1
-        elif var_coops.get() == '0' and var_ndbc.get() == '0' and \
-                 var_usgs.get() == '0' and var_list.get() == '0':
-             messagebox.showerror('Error', 'Please select at least one '
-                                  'station provider, or provide a list of '
-                                  'station IDs.')
-             error = 1
-        elif var_salt.get() == '0' and var_cu.get() == '0' and \
-                 var_temp.get() == '0' and var_wl.get() == '0':
-             messagebox.showerror('Error', 'Please select at least one '
-                                  'variable to assess.')
-             error = 1
+            messagebox.showerror(
+                'Error', 'Please select at least one whichcast.'
+            )
+            error = 1
+        elif (var_coops.get() == '0' and var_ndbc.get() == '0'
+              and var_usgs.get() == '0' and var_list.get() == '0'):
+            messagebox.showerror(
+                'Error',
+                'Please select at least one station provider, or provide '
+                'a list of station IDs.'
+            )
+            error = 1
+        elif (var_salt.get() == '0' and var_cu.get() == '0'
+              and var_temp.get() == '0' and var_wl.get() == '0'):
+            messagebox.showerror(
+                'Error', 'Please select at least one variable to assess.'
+            )
+            error = 1
 
         args_values.Path = directory_path_var.get()
         args_values.OFS = ofs_entry.get()
-        args_values.StartDate_full = format_date(start_entry.get_date(),
-                                                 s_hour_scale.get())
-        args_values.EndDate_full = format_date(end_entry.get_date(),
-                                               e_hour_scale.get())
-        args_values.Whichcasts = [item for item in [var_now.get(), \
-                var_fore.get(), var_forea.get(), var_hind.get()] if item != '0']
+        args_values.StartDate_full = format_date(
+            start_entry.get_date(), s_hour_scale.get()
+        )
+        args_values.EndDate_full = format_date(
+            end_entry.get_date(), e_hour_scale.get()
+        )
+        args_values.Whichcasts = [
+            item for item in (
+                var_now.get(), var_fore.get(),
+                var_forea.get(), var_hind.get(),
+            ) if item != '0'
+        ]
         args_values.Datum = datum_var.get()
         args_values.FileType = filetype_var.get()
-        args_values.Station_Owner = [item for item in [var_coops.get(), \
-                                var_ndbc.get(), var_usgs.get(), var_list.get()] if \
-                                     item != '0']
+        args_values.Station_Owner = [
+            item for item in (
+                var_coops.get(), var_ndbc.get(),
+                var_usgs.get(), var_list.get(),
+            ) if item != '0'
+        ]
         args_values.Horizon_Skill = horizon_var.get()
-        args_values.Var_Selection = [item for item in [var_wl.get(), \
-                                var_temp.get(), var_salt.get(), var_cu.get()] if \
-                                     item != '0']
+        args_values.Var_Selection = [
+            item for item in (
+                var_wl.get(), var_temp.get(),
+                var_salt.get(), var_cu.get(),
+            ) if item != '0'
+        ]
 
-        # Add the cycle selection to args_values
         selected_cycle = cycle_var.get()
-        if selected_cycle == 'Most recent available':
+        if selected_cycle == _MOST_RECENT_LABEL:
             args_values.Forecast_Hr = 'now'
         else:
             args_values.Forecast_Hr = selected_cycle
 
-        # Add the CSV path. None if blank
-        args_values.Currents_Bins_Csv = cb_var.get() if cb_var.get() != "" else None
+        args_values.Currents_Bins_Csv = cb_var.get() or None
 
-        args_values.Disable_Model_File_Check = df_var.get()
+        # GUI variable is named for clarity; the namespace attribute keeps
+        # the argparse name. True means the model-file pre-check runs.
+        args_values.Disable_Model_File_Check = enable_file_check_var.get()
 
         if error is None:
             root.destroy() # Close the GUI window
 
     def format_date(date, hour):
-        from datetime import date as date_type
         # DateEntry.get_date() returns a datetime.date object
+        from datetime import date as date_type
         if isinstance(date, date_type):
-            # Format date object as YYYY-MM-DDThh:mm:ssZ
-            formatted_date = date.strftime('%Y-%m-%d')
-            return formatted_date + 'T' + str(hour).zfill(2) + ':00:00Z'
-        else:
-            # Fallback: if it's a string, raise an error with helpful message
-            raise TypeError(f'Expected date object, got {type(date)}: {date}')
+            return f"{date.strftime('%Y-%m-%d')}T{int(hour):02d}:00:00Z"
+        raise TypeError(f'Expected date object, got {type(date)}: {date}')
 
     def browse_directory():
         '''
@@ -150,37 +259,29 @@ def create_gui(parser):
         Opens a file selection dialog for the currents bins CSV.
         '''
         chosen_file = filedialog.askopenfilename(
-            title="Select Currents Bins CSV",
-            filetypes=(("CSV files", "*.csv"), ("All files", "*.*"))
+            title='Select Currents Bins CSV',
+            filetypes=(('CSV files', '*.csv'), ('All files', '*.*'))
         )
         if chosen_file:
             cb_var.set(chosen_file)
 
-    def get_selected_date():
-        selected_date = start_entry.get_date()
-        print(f'Selected date: {selected_date}')
-
-    def update_cycles(event=None):
+    def update_cycles(_event=None):
         '''Updates the cycle combobox based on the selected OFS.'''
         selected_ofs = ofs_entry.get()
-        if selected_ofs and selected_ofs != 'Select an OFS...':
-            # get_fcst_hours returns max forecast length and cycle hours
-            _, cycles = get_fcst_hours(selected_ofs)
-
-            # Format the integer array into strings like '00z', '06z'
-            cycle_choices = [f"{int(c):02d}z" for c in cycles]
-
-            # Insert the new option at the top of the list
-            cycle_choices.insert(0, 'Most recent cycle available')
-
+        if selected_ofs and selected_ofs != _OFS_PLACEHOLDER:
+            try:
+                _, cycles = get_fcst_hours(selected_ofs)
+            except (KeyError, ValueError):
+                cycle_chosen['values'] = (_OFS_FIRST_PLACEHOLDER,)
+                cycle_var.set(_OFS_FIRST_PLACEHOLDER)
+                return
+            cycle_choices = [f'{int(c):02d}z' for c in cycles]
+            cycle_choices.insert(0, _MOST_RECENT_LABEL)
             cycle_chosen['values'] = tuple(cycle_choices)
-
-            # Auto-select the first available option
-            if cycle_choices:
-                cycle_var.set(cycle_choices[0])
+            cycle_var.set(cycle_choices[0])
         else:
-            cycle_chosen['values'] = ('Select an OFS first...',)
-            cycle_var.set('Select an OFS first...')
+            cycle_chosen['values'] = (_OFS_FIRST_PLACEHOLDER,)
+            cycle_var.set(_OFS_FIRST_PLACEHOLDER)
 
     def toggle_cycle_state():
         '''Enables or disables the Model Cycle dropdown based on Forecast_a selection.'''
@@ -193,25 +294,26 @@ def create_gui(parser):
     root.title('Skill assessment inputs')
     # Set the protocol for handling the window close event
     root.protocol('WM_DELETE_WINDOW', on_closing)
-    root.geometry('850x500') # Restrict the height to make the window shorter
+    root.geometry(_WINDOW_GEOMETRY)
 
     style = ttk.Style(root)
     style.theme_use('clam') # modified from vista to clam for cross OS compatibility
 
+    log = logging.getLogger(__name__)
+
     # STYLING
     # Change the icon
     try:
-        # GUI: no prop available
-        dir_params = utils.Utils().read_config_section('directories', None)
-        iconpath = os.path.join(dir_params['home'],
-                                'readme_images','noaa_logo.png')
+        dir_params = utils.Utils().read_config_section('directories', log)
+        iconpath = os.path.join(
+            dir_params['home'], 'readme_images', 'noaa_logo.png'
+        )
         icon_image = tk.PhotoImage(file=iconpath)
         root.iconphoto(False, icon_image)
-    except:
-        print('GUI logo not found! Defaulting to tkinter logo...')
-    # retrieve current datum list
-    datum_list = (utils.Utils(None).read_config_section('datums', None)\
-                       ['datum_list']).split(' ')
+    except (KeyError, tk.TclError, OSError):
+        log.info('GUI logo not found; defaulting to tkinter logo.')
+
+    datum_list = _read_datum_list()
 
     # Window-wide colors, text, and stuff
     anchor='e'
@@ -240,24 +342,24 @@ def create_gui(parser):
 
     # Bind the frame size changes to update the canvas scroll region
     scrollable_frame.bind(
-        "<Configure>",
+        '<Configure>',
         lambda e: canvas.configure(
-            scrollregion=canvas.bbox("all")
+            scrollregion=canvas.bbox('all')
         )
     )
 
     # Put the frame inside a window within the canvas
-    canvas.create_window((0, 0), window=scrollable_frame, anchor="nw")
+    canvas.create_window((0, 0), window=scrollable_frame, anchor='nw')
     canvas.configure(yscrollcommand=scrollbar.set)
 
     # Pack the canvas and scrollbar
-    canvas.pack(side="left", fill="both", expand=True)
-    scrollbar.pack(side="right", fill="y")
+    canvas.pack(side='left', fill='both', expand=True)
+    scrollbar.pack(side='right', fill='y')
 
     # Bind mousewheel scrolling to the canvas
     def _on_mousewheel(event):
-        canvas.yview_scroll(int(-1*(event.delta/120)), "units")
-    root.bind_all("<MouseWheel>", _on_mousewheel)
+        canvas.yview_scroll(int(-1*(event.delta/120)), 'units')
+    root.bind_all('<MouseWheel>', _on_mousewheel)
 
     # Style for each widget type
     style = ttk.Style()
@@ -317,29 +419,29 @@ def create_gui(parser):
     # OFS input, -o
     row += 1
     ofs_entry = tk.StringVar()
-    choices = ('Select an OFS...',
-               'cbofs',
-               'ciofs',
-               'dbofs',
-               'gomofs',
-               'leofs',
-               'lmhofs',
-               'loofs',
-               'loofs2',
-               'lsofs',
-               'necofs',
-               'ngofs2',
-               'secofs',
-               'sfbofs',
-               'sscofs',
-               'stofs_2d_glo',
-               'stofs_3d_atl',
-               'stofs_3d_pac',
-               'tbofs',
-               'wcofs',
-               )
+    choices = (
+        _OFS_PLACEHOLDER,
+        'cbofs',
+        'ciofs',
+        'dbofs',
+        'gomofs',
+        'leofs',
+        'lmhofs',
+        'loofs',
+        'loofs2',
+        'lsofs',
+        'necofs',
+        'ngofs2',
+        'sfbofs',
+        'sscofs',
+        'stofs_2d_glo',
+        'stofs_3d_atl',
+        'stofs_3d_pac',
+        'tbofs',
+        'wcofs',
+    )
 
-    ofs_entry.set('Select an OFS...')
+    ofs_entry.set(_OFS_PLACEHOLDER)
     tk.Label(scrollable_frame,
              text='OFS',
              bg=themecolor,
@@ -347,10 +449,12 @@ def create_gui(parser):
              font=(fontfamily, labelfontsize),
              anchor=anchor).grid(row=row, column=0,  sticky='w',
                                  padx=padx, pady=pady)
-    ofs_chosen = ttk.Combobox(scrollable_frame, width = 15, textvariable = ofs_entry,
-                              font=('Helvetica', 12))
+    ofs_chosen = ttk.Combobox(
+        scrollable_frame, width=15, textvariable=ofs_entry,
+        font=('Helvetica', 12), state='readonly',
+    )
     ofs_chosen['values'] = choices
-    ofs_chosen.grid(row=row, column=1,  sticky='w', padx=padx, pady=pady)
+    ofs_chosen.grid(row=row, column=1, sticky='w', padx=padx, pady=pady)
     ofs_chosen.bind('<<ComboboxSelected>>', update_cycles)
 
     row += 1
@@ -361,9 +465,10 @@ def create_gui(parser):
              font=(fontfamily, 9, 'italic'),
              anchor=anchor).grid(
                  row=row, column=0, sticky='w', padx=padx, pady=(0, pady))
-    # QUICK RUN BUTTON!
-    ttk.Button(scrollable_frame, text='⚡ Quick Run Mode', command=quick_run_submit,
-               style='TButton').grid(row=row, column=1, sticky='w', padx=padx, pady=(0, pady))
+    ttk.Button(
+        scrollable_frame, text='⚡ Quick Run Mode',
+        command=quick_run_submit, style='TButton',
+    ).grid(row=row, column=1, sticky='w', padx=padx, pady=(0, pady))
 
     row += 1
     ttk.Separator(scrollable_frame, orient='horizontal').grid(
@@ -446,7 +551,7 @@ def create_gui(parser):
     # Model Cycle input, -f
     row += 1
     cycle_var = tk.StringVar()
-    cycle_var.set('Select an OFS first...')
+    cycle_var.set(_OFS_FIRST_PLACEHOLDER)
     tk.Label(scrollable_frame,
              text='Model cycle (forecast_a only)',
              bg=themecolor,
@@ -461,8 +566,8 @@ def create_gui(parser):
     # Datums, -d
     row += 1
     datum_var = tk.StringVar()
-    dchoices = ('Select a datum...',) + tuple(datum_list)
-    datum_var.set('Select a datum...')
+    dchoices = (_DATUM_PLACEHOLDER,) + tuple(datum_list)
+    datum_var.set(_DATUM_PLACEHOLDER)
     tk.Label(scrollable_frame,
              text='Vertical datum',
              bg=themecolor,
@@ -601,8 +706,10 @@ def create_gui(parser):
                                               padx=padx, pady=pady)
 
     # Model file check, -df
+    # NOTE: True means the pre-check IS performed (matches the
+    # action='store_false' semantics of -df in create_1dplot.py).
     row += 1
-    df_var = tk.BooleanVar(value=True) # Default is True (perform the file check)
+    enable_file_check_var = tk.BooleanVar(value=True)
     tk.Label(scrollable_frame,
              text='Pre-check for model output files?',
              bg=themecolor,
@@ -610,10 +717,14 @@ def create_gui(parser):
              font=(fontfamily, labelfontsize),
              anchor=anchor).grid(
         row=row, column=0, sticky='w', padx=padx, pady=pady)
-    ttk.Radiobutton(scrollable_frame, text='No (disable check)', variable=df_var, value=False).grid(
-        row=row, column=1, sticky='w', padx=padx, pady=pady)
-    ttk.Radiobutton(scrollable_frame, text='Yes (default)', variable=df_var, value=True).grid(
-        row=row, column=2, sticky='w', padx=padx, pady=pady)
+    ttk.Radiobutton(
+        scrollable_frame, text='No (disable check)',
+        variable=enable_file_check_var, value=False,
+    ).grid(row=row, column=1, sticky='w', padx=padx, pady=pady)
+    ttk.Radiobutton(
+        scrollable_frame, text='Yes (default)',
+        variable=enable_file_check_var, value=True,
+    ).grid(row=row, column=2, sticky='w', padx=padx, pady=pady)
 
     # Horizontal separator
     row += 1


### PR DESCRIPTION
### Description of Changes

This PR fixes the GUI, which was broken and lagging behind recent updates to input arguments. The refactored interface provides users with more flexibility in running skill assessments, including support for additional forecast cycles, model cycle selection, and optional CSV configurations.

<img width="528" height="423" alt="Screenshot 2026-05-01 124405" src="https://github.com/user-attachments/assets/ade0314b-81ec-4e34-9dff-2e1a7b35a04b" />


**1. New Quick Run Mode**
- Added `quick_run_submit()` function that provides a streamlined, one-click assessment with pre-configured settings
- Automatically selects nowcast and forecast_a cycles
- Sets datum to MLLW and includes standard station providers (CO-OPS, NDBC, USGS)
- Reduces setup time for routine assessments

**2. Enhanced Forecast Cycle Support**
- Integrated `get_fcst_hours()` from the model processing pipeline to dynamically populate available model cycles based on selected OFS
- New Model Cycle dropdown (forecast_a only) displays available cycles (e.g., '00z', '06z', '12z', '18z')

**3. Improved Whichcast Selection**
- Separated forecast options into Forecast_b and Forecast_a with individual controls
- Forecast_a is now a separate toggle that enables the Model Cycle dropdown

**4. Scrollable GUI Interface**
- Added canvas and scrollbar to handle longer form layouts
- Window height now restricted to 500px with scrolling support
- Mousewheel scrolling support for improved usability

**5. Dynamic Datum Selection**
- Datums are now read from the configuration file (`datums` section) instead of being hard-coded

**6. Additional Configuration Options**
- **Currents Bins CSV**: Optional file browser to select a custom currents bins CSV file (e.g., for per-bin ADCP assessments)
- **Model File Check Toggle**: New option to disable pre-run model output file validation (`-df` flag support)

**7. UI/UX Refinements**
- Updated OFS list to include additional models (necofs, secofs, stofs_2d_glo)
- Reorganized OFS list in alphabetical order for easier navigation
- Changed "Forecast" label to "Forecast_b" for clarity
- Changed "Add from list" to "Add from conf file" for better semantics


### Expected Outcome of Changes

- Users can now conduct skill assessments much faster with the Quick Run mode, ideal for routine operational assessments
- More intuitive forecast cycle selection with dynamic population based on OFS capabilities
- Better support for advanced configurations like custom currents bins CSV files
- Improved GUI usability on systems with limited screen space via scrolling support
- Configuration-driven datum selection allows ops to update supported datums without code changes
- Optional model file check provides flexibility for runs on systems with connectivity issues to model data sources

### Developer Questions and Checklist

**Is this a high priority PR? If yes, why and is there a date by which it needs to be merged?**
Yes, to get the GUI ready for GSOC

**Are there any changes needed to how the code should be run for operational runs? (Commands, flags, job timings, etc.)**
No. The GUI enhancements are backward compatible. All changes are additive and don't modify existing CLI behavior. New flags (`-f`, `-cb`, `-df`) are optional.

**Does this update need to be deployed for operational runs?**
No, this is an optional enhancement. Operational runs can continue using existing methods.

**Does this update require front end/web app changes? (If yes, provide documentation to Min)**
No.

**Does this impact code development work on adding SCHISM? (If yes, tag Atieh)**
No.

**Does this impact code development work on adding ADCIRC?**
No.

**Does this impact the expected number of output files for integration tests (i.e., will the integration test fail even though code changes result in desired change in the number of outputs?)**
No. This is a GUI-only change and does not affect output file generation.

- [x] Developer's name is removed throughout the code?
- [x] Did you add relevant labels to the PR?
- [x] Have you run pylint and is the code at an acceptable pylint score (>8.0)?
- [x] Jobs contain the appropriate file checking and handle errors for any missing data?
- [x] Is log free of critical ERRORs or WARNINGs?

### Testing Instructions

**1. GUI Launch and Appearance**

`python ./bin/visualization/create_1dplot.py`

Expected: Window appears with scrollbar on right side, height is constrained to ~500px, all form elements are visible and properly formatted.

**2. Quick Run Mode**

- Launch GUI
- Select a directory (e.g., ./)
- Select an OFS (e.g., cbofs)
- Click "⚡ Quick Run Mode" button 

Expected: GUI closes and assessment begins with pre-configured settings (nowcast + forecast_a, all variables, CO-OPS/NDBC/USGS stations)

**3. Forecast Cycle Selection (forecast_a)**

- Launch GUI
- Select an OFS (e.g., cbofs)

Expected: Model Cycle dropdown populates with available cycles ('Most recent cycle available', '00z', '06z', '12z', '18z')

- Verify dropdown is disabled until forecast_a checkbox is selected
- Check forecast_a and verify cycle dropdown becomes enabled
- Select a specific cycle (e.g., '06z')
- Complete normal form submission and verify the cycle is passed correctly

**4. Currents Bins CSV (Optional)**

- Launch GUI
- Click "Browse..." button next to "Currents bins CSV"
- Select a CSV file from filesystem

Expected: File path appears in the entry field

- Submit form and verify CSV path is passed to the main script

**5. Model File Check Toggle**

- Launch GUI
- Verify "Pre-check for model output files?" defaults to "Yes (default)"
- Select "No (disable check)"
- Submit form with a time range that might not have data

Expected: Script continues without checking for file availability

**6. Datum Selection**

- Launch GUI
- Open Vertical datum dropdown

Expected: Datums should match those in conf/ofs_dps.conf under [datums] section, not hard-coded list

**7. OFS List Completeness**

- Verify new OFS entries (necofs, secofs, stofs_2d_glo) appear in the sorted list

**8. Scrolling Functionality**

- Launch GUI
- Scroll with mousewheel over form area

Expected: Form content scrolls smoothly, scrollbar position updates


