### PR TITLE
Align get_hf_radar.py CLI with package date format (closes #131)

### DIFF
--- a/bin/obs_retrieval/get_hf_radar.py
+++ b/bin/obs_retrieval/get_hf_radar.py
@@ -14,16 +14,17 @@ future HF radar or OFS additions.
         2.5) Average the u/v data for the daily average mode.
     3) Convert it to mag/dir data.
     4) Output ASCII files from NetCDF.
-        - For 25-hr daily average, expected file output looks like this:
+        - For each fully-covered UTC date in the requested window, a daily
+          average set is written:
             {ofs_name}_hfradar_dir_YYYYMMDD.asc
             {ofs_name}_hfradar_dir_YYYYMMDD.prj
             {ofs_name}_hfradar_mag_YYYYMMDD.asc
             {ofs_name}_hfradar_mag_YYYYMMDD.prj
         - For hourly, expected file output looks like this per hour:
-            {ofs_name}_hfradar_dir_YYYYMMDD_HH00.asc
-            {ofs_name}_hfradar_dir_YYYYMMDD_HH00.prj
-            {ofs_name}_hfradar_mag_YYYYMMDD_HH00.asc
-            {ofs_name}_hfradar_mag_YYYYMMDD_HH00.prj
+            {ofs_name}_hfradar_dir_YYYYMMDD-HHz.asc
+            {ofs_name}_hfradar_dir_YYYYMMDD-HHz.prj
+            {ofs_name}_hfradar_mag_YYYYMMDD-HHz.asc
+            {ofs_name}_hfradar_mag_YYYYMMDD-HHz.prj
 
 HF Radar sources and times available per source (as of March 11, 2026):
     USEGC (US East Coast and Gulf of America)
@@ -37,14 +38,10 @@ HF Radar sources and corresponding OFSes:
     GLNA -> LMHOFS
     GAK -> CIOFS
 
-Example daily average call:
-    python ./bin/obs_retrieval/get_hf_radar.py -d 20260310 \\
+Example call:
+    python ./bin/obs_retrieval/get_hf_radar.py \\
+        -s 2026-03-10T00:00:00Z -e 2026-03-11T00:00:00Z \\
         -C ./data/observations/ -b ./ofs_extents/sfbofs.shp
-
-Example hourly call:
-    python ./bin/obs_retrieval/get_hf_radar.py -d 20260310 \\
-        -C ./data/observations/ -b ./ofs_extents/sfbofs.shp \\
-        -m hourly -s 2026030900 -e 2026031023
 """
 from __future__ import annotations
 
@@ -162,9 +159,9 @@ def get_geospatial_bounds(nc_file):
 
 
 def parse_utc_timestamp(timestr):
-    """Parse a UTC timestamp string in YYYYMMDDHH format to a datetime object."""
+    """Parse a UTC timestamp string in YYYY-MM-DDTHH:MM:SSZ format to a datetime."""
     try:
-        return datetime.strptime(timestr, '%Y%m%d%H')
+        return datetime.strptime(timestr, '%Y-%m-%dT%H:%M:%SZ')
     except Exception as e:
         logger.error("Error parsing timestamp '%s': %s", timestr, e)
         return None
@@ -507,7 +504,12 @@ def process_files(
     """
     today = datetime.now(timezone.utc).date()
 
-    if date_obj.date() == today:
+    explicit_window = start_time is not None and end_time is not None
+
+    if explicit_window:
+        start_dt = start_time
+        end_dt = end_time
+    elif date_obj.date() == today:
         end_dt = (datetime.now(timezone.utc) - NRT_DELAY).replace(
             minute=0, second=0, microsecond=0
         )
@@ -515,11 +517,6 @@ def process_files(
     else:
         start_dt = datetime.combine(date_obj.date(), datetime.min.time())
         end_dt = start_dt + timedelta(hours=24)
-
-    # Override time window if explicit start/end provided
-    if start_time is not None and end_time is not None:
-        start_dt = start_time
-        end_dt = end_time
 
     logger.info('Got start time and end time')
 
@@ -556,8 +553,6 @@ def process_files(
 
         logger.info('Clipped u/v data to study area')
 
-        date_str = date_obj.strftime('%Y%m%d')
-
         # --- Hourly outputs ---
         logger.info('Starting hourly u/v -> mag/dir file creation')
 
@@ -569,7 +564,9 @@ def process_files(
             dir_rad = np.arctan2(u_hour, v_hour)
             direction = (np.degrees(dir_rad) + 360) % 360
 
-            timestamp = pd.to_datetime(u_hour.time.values).strftime('%Y%m%d_%H%M')
+            ts = pd.to_datetime(u_hour.time.values)
+            timestamp = ts.strftime('%Y%m%d-%Hz')
+            hour_date_str = ts.strftime('%Y%m%d')
             mag_outfile = data_dir / f'{ofs}_hfradar_mag_{timestamp}.asc'
             dir_outfile = data_dir / f'{ofs}_hfradar_dir_{timestamp}.asc'
 
@@ -578,7 +575,7 @@ def process_files(
 
             # Write hourly JSON + ASCII grid txt
             hourly_paths = _build_hfradar_output_paths(
-                data_dir, ofs, date_str, timestamp,
+                data_dir, ofs, hour_date_str, timestamp,
             )
             _write_leaflet_outputs(
                 u_hour, v_hour, hourly_paths, logger,
@@ -588,43 +585,55 @@ def process_files(
             logger.info('Finished writing hourly files for %s', timestamp)
 
         # --- Daily averaged outputs ---
-        # Require at least 13 of 25 hourly observations for a valid
-        # daily average (tidal filtering needs sufficient coverage).
-        valid_count = u_data.count(dim='time')
-        u_avg = u_data.mean(dim='time', skipna=True)
-        v_avg = v_data.mean(dim='time', skipna=True)
+        # Group hourly slices by UTC date and emit a daily set per date
+        # spanned by the window. The per-cell ≥13-hour threshold filters
+        # out cells with insufficient coverage (tidal filtering needs at
+        # least 13 of 25 hourly observations).
+        if explicit_window:
+            time_index = pd.to_datetime(u_data.time.values)
+            unique_dates = pd.Index(time_index.normalize()).unique()
+        else:
+            # Single-date fallback (legacy path): emit one daily for date_obj
+            unique_dates = pd.Index([pd.Timestamp(date_obj.date())])
 
-        u_avg = u_avg.where(valid_count >= 13)
-        v_avg = v_avg.where(valid_count >= 13)
+        for day in unique_dates:
+            day_str = pd.Timestamp(day).strftime('%Y%m%d')
 
-        u_avg = u_avg.astype('float64')
-        v_avg = v_avg.astype('float64')
+            if explicit_window:
+                day_mask = pd.to_datetime(u_data.time.values).normalize() == day
+                day_idx = np.where(day_mask)[0]
+                u_day = u_data.isel(time=day_idx)
+                v_day = v_data.isel(time=day_idx)
+            else:
+                u_day = u_data
+                v_day = v_data
 
-        logger.info('Created u and v averages for daily average')
+            valid_count = u_day.count(dim='time')
+            u_avg = u_day.mean(dim='time', skipna=True).where(valid_count >= 13)
+            v_avg = v_day.mean(dim='time', skipna=True).where(valid_count >= 13)
 
-        mag = np.sqrt(u_avg**2 + v_avg**2)
-        dir_rad = np.arctan2(u_avg, v_avg)
-        direction = (np.degrees(dir_rad) + 360) % 360
+            u_avg = u_avg.astype('float64')
+            v_avg = v_avg.astype('float64')
 
-        direction = direction.where(np.isfinite(direction))
+            mag = np.sqrt(u_avg**2 + v_avg**2)
+            dir_rad = np.arctan2(u_avg, v_avg)
+            direction = (np.degrees(dir_rad) + 360) % 360
+            direction = direction.where(np.isfinite(direction))
 
-        mag_outfile = data_dir / f'{ofs}_hfradar_mag_{date_str}.asc'
-        dir_outfile = data_dir / f'{ofs}_hfradar_dir_{date_str}.asc'
+            mag_outfile = data_dir / f'{ofs}_hfradar_mag_{day_str}.asc'
+            dir_outfile = data_dir / f'{ofs}_hfradar_dir_{day_str}.asc'
 
-        logger.info('Translated u/v into mag/dir data')
+            export_ascii(mag, mag_outfile)
+            export_ascii(direction, dir_outfile)
 
-        export_ascii(mag, mag_outfile)
-        export_ascii(direction, dir_outfile)
+            daily_paths = _build_hfradar_output_paths(data_dir, ofs, day_str)
+            _write_leaflet_outputs(
+                u_avg, v_avg, daily_paths, logger,
+                static_plots=static_plots, ofs=ofs,
+                title_tag=f'{day_str} Daily Avg',
+            )
 
-        # Write daily JSON + ASCII grid txt
-        daily_paths = _build_hfradar_output_paths(data_dir, ofs, date_str)
-        _write_leaflet_outputs(
-            u_avg, v_avg, daily_paths, logger,
-            static_plots=static_plots, ofs=ofs,
-            title_tag=f'{date_str} Daily Avg',
-        )
-
-        logger.info('Finished writing daily average files')
+            logger.info('Finished writing daily average files for %s', day_str)
 
     logger.info('Finished get_hf_radar.py!')
 
@@ -637,9 +646,15 @@ if __name__ == '__main__':
     )
 
     parser.add_argument(
-        '-d', '--date',
+        '-s', '--StartDate_full',
         required=True,
-        help='Date for daily data collection (YYYYMMDD)'
+        help="Start Date_full YYYY-MM-DDThh:mm:ssZ e.g.'2026-03-10T00:00:00Z'",
+    )
+
+    parser.add_argument(
+        '-e', '--EndDate_full',
+        required=True,
+        help="End Date_full YYYY-MM-DDThh:mm:ssZ e.g.'2026-03-11T00:00:00Z'",
     )
 
     parser.add_argument(
@@ -664,32 +679,11 @@ if __name__ == '__main__':
         help='OFS of interest (used to derive shapefile path if -b not given)'
     )
 
-    parser.add_argument(
-        '-m', '--mode',
-        choices=['daily', 'hourly'],
-        default='daily',
-        help='Choose daily or hourly period'
-    )
-
-    parser.add_argument(
-        '-s', '--start',
-        help='Start time for hourly period in format YYYYMMDDHH (UTC)'
-    )
-
-    parser.add_argument(
-        '-e', '--end',
-        help='End time for hourly period in format YYYYMMDDHH (UTC)'
-    )
-
     args = parser.parse_args()
 
     # Validate that -b or -o is provided
     if args.bounds is None and args.ofs is None:
         parser.error('Either -b/--bounds or -o/--ofs must be provided.')
-
-    # Validate hourly mode requires start and end
-    if args.mode == 'hourly' and (args.start is None or args.end is None):
-        parser.error('Hourly mode requires both -s/--start and -e/--end.')
 
     # Set up logging
     config_file = utils.Utils().get_config_file()
@@ -707,21 +701,27 @@ if __name__ == '__main__':
     logger.info('Using config %s', config_file)
     logger.info('Using log config %s', log_config_file)
 
-    date_obj = datetime.strptime(args.date, '%Y%m%d')
+    start_time = parse_utc_timestamp(args.StartDate_full)
+    end_time = parse_utc_timestamp(args.EndDate_full)
+
+    if start_time is None or end_time is None:
+        parser.error(
+            'Both -s/--StartDate_full and -e/--EndDate_full must be in '
+            'YYYY-MM-DDTHH:MM:SSZ format (UTC).'
+        )
+
+    if start_time >= end_time:
+        parser.error(
+            f'End Date {args.EndDate_full} is not after Start Date '
+            f'{args.StartDate_full}.'
+        )
+
+    # Anchor date used by the legacy default-window branch when callers
+    # invoke process_files programmatically without start/end.
+    date_obj = start_time
 
     data_dir = Path(args.catalogue)
     data_dir.mkdir(parents=True, exist_ok=True)
-
-    mode = args.mode
-
-    start_time = None
-    end_time = None
-
-    if args.start:
-        start_time = parse_utc_timestamp(args.start)
-
-    if args.end:
-        end_time = parse_utc_timestamp(args.end)
 
     # Determine OFS name and shapefile path
     if args.bounds is not None:
@@ -743,5 +743,9 @@ if __name__ == '__main__':
         'static_plots', 'False',
     ).lower() in ('true', '1', 'yes')
 
-    check_for_overlap(date_obj, data_dir, gdf, ofs, mode, start_time, end_time,
+    # mode is retained as a positional argument for process_files but no
+    # longer affects which outputs are produced — both hourly and daily are
+    # always emitted.
+    check_for_overlap(date_obj, data_dir, gdf, ofs, 'daily',
+                      start_time, end_time,
                       static_plots=static_plots)

--- a/tests/hf_radar_test.py
+++ b/tests/hf_radar_test.py
@@ -146,8 +146,17 @@ class TestParseWktPolygon:
 # ===========================================================================
 class TestParseUtcTimestamp:
     def test_valid_timestamp(self):
-        result = hf.parse_utc_timestamp('2026031512')
+        result = hf.parse_utc_timestamp('2026-03-15T12:00:00Z')
         assert result == datetime(2026, 3, 15, 12)
+
+    def test_valid_timestamp_with_minutes_seconds(self):
+        result = hf.parse_utc_timestamp('2026-03-15T12:34:56Z')
+        assert result == datetime(2026, 3, 15, 12, 34, 56)
+
+    def test_legacy_format_returns_none(self):
+        # Old YYYYMMDDHH form is no longer accepted
+        result = hf.parse_utc_timestamp('2026031512')
+        assert result is None
 
     def test_invalid_returns_none(self):
         result = hf.parse_utc_timestamp('not-a-date')
@@ -353,13 +362,17 @@ class TestProcessFilesDaily:
         assert (obs_2d / 'sfbofs_dir_20260315_hfradar.txt').exists()
 
         # Hourly .asc files should also be created (both modes always produced)
-        # 25 hours span 00:00-24:00; the 25th (00:00 next day) has date 20260316
-        hourly_asc = list(out_dir.glob('sfbofs_hfradar_mag_*_*.asc'))
+        # 25 hours span 00:00-24:00; new stamp format is YYYYMMDD-HHz
+        hourly_asc = list(out_dir.glob('sfbofs_hfradar_mag_*-*z.asc'))
         assert len(hourly_asc) == 25
 
         # Hourly JSON files should also be created
-        hourly_json = list(obs_2d.glob('sfbofs_*_*_ssu_hfradar.json'))
+        hourly_json = list(obs_2d.glob('sfbofs_*-*z_ssu_hfradar.json'))
         assert len(hourly_json) == 25
+
+        # Spot-check the new stamp format on a specific hour
+        assert (out_dir / 'sfbofs_hfradar_mag_20260315-00z.asc').exists()
+        assert (obs_2d / 'sfbofs_20260315-00z_ssu_hfradar.json').exists()
 
     def test_daily_min_count_threshold(self, tmp_path):
         """Cells with < 13 valid observations should be NaN in output."""
@@ -417,17 +430,17 @@ class TestProcessFilesHourly:
         hf.process_files(matching, datetime(2026, 3, 15), tmp_path, gdf,
                          'sfbofs', 'hourly', start, end)
 
-        # Hourly .asc files
-        assert (tmp_path / 'sfbofs_hfradar_mag_20260315_0000.asc').exists()
-        assert (tmp_path / 'sfbofs_hfradar_mag_20260315_0100.asc').exists()
-        assert (tmp_path / 'sfbofs_hfradar_mag_20260315_0200.asc').exists()
+        # Hourly .asc files (new YYYYMMDD-HHz stamp)
+        assert (tmp_path / 'sfbofs_hfradar_mag_20260315-00z.asc').exists()
+        assert (tmp_path / 'sfbofs_hfradar_mag_20260315-01z.asc').exists()
+        assert (tmp_path / 'sfbofs_hfradar_mag_20260315-02z.asc').exists()
 
         # Hourly JSON + txt files
         obs_2d = tmp_path / '2d'
-        assert (obs_2d / 'sfbofs_20260315_0000_ssu_hfradar.json').exists()
-        assert (obs_2d / 'sfbofs_20260315_0100_ssu_hfradar.json').exists()
-        assert (obs_2d / 'sfbofs_20260315_0200_ssu_hfradar.json').exists()
-        assert (obs_2d / 'sfbofs_mag_20260315_0000_hfradar.txt').exists()
+        assert (obs_2d / 'sfbofs_20260315-00z_ssu_hfradar.json').exists()
+        assert (obs_2d / 'sfbofs_20260315-01z_ssu_hfradar.json').exists()
+        assert (obs_2d / 'sfbofs_20260315-02z_ssu_hfradar.json').exists()
+        assert (obs_2d / 'sfbofs_mag_20260315-00z_hfradar.txt').exists()
 
         # Daily averaged files should also be created
         assert (tmp_path / 'sfbofs_hfradar_mag_20260315.asc').exists()
@@ -662,23 +675,49 @@ class TestCLIValidation:
     def test_help_flag(self):
         result = self._run(['--help'])
         assert result.returncode == 0
-        assert '-d' in result.stdout
+        assert '-s' in result.stdout
+        assert '-e' in result.stdout
         assert '-C' in result.stdout
+        # Old -d/--date flag should be gone
+        assert '--date' not in result.stdout
+        # Help text should advertise the ISO 8601 format
+        assert 'YYYY-MM-DDT' in result.stdout
 
     def test_missing_required_args(self):
         result = self._run([])
         assert result.returncode == 2
         assert 'required' in result.stderr
 
-    def test_hourly_without_start_end(self):
+    def test_legacy_date_flag_rejected(self):
+        # The old -d/--date flag has been removed in favor of -s/-e ISO 8601.
+        # Supply valid -s/-e so argparse reaches the unknown-arg check.
         result = self._run([
-            '-d', '20260315', '-C', '/tmp/test', '-o', 'sfbofs', '-m', 'hourly',
+            '-s', '2026-03-15T00:00:00Z', '-e', '2026-03-16T00:00:00Z',
+            '-d', '20260315', '-C', '/tmp/test', '-o', 'sfbofs',
         ])
         assert result.returncode == 2
-        assert 'start' in result.stderr.lower() or 'end' in result.stderr.lower()
+        assert 'unrecognized' in result.stderr.lower() or '-d' in result.stderr
+
+    def test_legacy_yyyymmddhh_format_rejected(self):
+        # The old YYYYMMDDHH form for -s/-e is no longer accepted
+        result = self._run([
+            '-s', '2026031500', '-e', '2026031523',
+            '-C', '/tmp/test', '-o', 'sfbofs',
+        ])
+        assert result.returncode == 2
+
+    def test_end_before_start_rejected(self):
+        result = self._run([
+            '-s', '2026-03-16T00:00:00Z', '-e', '2026-03-15T00:00:00Z',
+            '-C', '/tmp/test', '-o', 'sfbofs',
+        ])
+        assert result.returncode == 2
 
     def test_neither_bounds_nor_ofs(self):
-        result = self._run(['-d', '20260315', '-C', '/tmp/test'])
+        result = self._run([
+            '-s', '2026-03-15T00:00:00Z', '-e', '2026-03-16T00:00:00Z',
+            '-C', '/tmp/test',
+        ])
         assert result.returncode == 2
         assert 'bounds' in result.stderr.lower() or 'ofs' in result.stderr.lower()
 


### PR DESCRIPTION
### Description of Changes

Closes #131.

`bin/obs_retrieval/get_hf_radar.py` was the odd one out — it took `-d YYYYMMDD` (with optional `-s/-e YYYYMMDDHH`) while the rest of the package (`get_satellite_observations.py`, `create_1dplot.py`, `create_2dplot.py`, `get_model_data.py`, `get_station_observations_cli.py`) takes `-s YYYY-MM-DDTHH:MM:SSZ -e YYYY-MM-DDTHH:MM:SSZ`. This PR aligns it.

I also tweaked the intermediate `.asc` filename stamps for hourly outputs so they line up with the satellite intermediates' `-HHz` convention. The PR #106 `.json` and `.txt` filename conventions are left exactly as-is. 

Concretely:
- `-d/--date` is gone. `-s/--StartDate_full` and `-e/--EndDate_full` are now required, in `YYYY-MM-DDThh:mm:ssZ` form. Help text mirrors the satellite script.
- `parse_utc_timestamp` parses ISO 8601 UTC; the legacy `YYYYMMDDHH` form is rejected.
- End-before-start is caught at parse time with a clear error.
- `-m/--mode` is removed — both hourly and daily outputs were always produced regardless, so the flag was misleading.
- Hourly intermediate `.asc` files now use the `YYYYMMDD-HHz` stamp (e.g. `cbofs_hfradar_mag_20260315-06z.asc`), matching the satellite-side convention. Daily `.asc` filenames are unchanged.
- `.json` and `.txt` outputs from PR #106 are untouched.
- When an explicit window is supplied, daily averages are grouped by UTC date and one daily set is emitted per date covered by the window. The per-cell ≥13-hour threshold for tidal filtering is preserved.

### Expected Outcome of Changes

Existing call:
```
python ./bin/obs_retrieval/get_hf_radar.py -d 20260310 -C ./data/observations/ -o sfbofs
```
becomes:
```
python ./bin/obs_retrieval/get_hf_radar.py \
  -s 2026-03-10T00:00:00Z -e 2026-03-11T00:00:00Z \
  -C ./data/observations/ -o sfbofs
```

No web app impact — the `.json` files in `data/observations/2d/` keep their PR #106 names. The only output change is hourly `.asc` filenames, which aren't consumed in-tree (`processing_2d` and `create_2dplot.py` don't read them — verified via `grep`).

### Developer Questions and Checklist
**Is this a high priority PR? If yes, why and is there a date by which it needs to be merged?**
No.

**Are there any changes needed to how the code should be run for operational runs? (Commands, flags, job timings, etc.)**
Yes — any cron/runner that invokes `get_hf_radar.py` needs to switch from `-d YYYYMMDD` to `-s YYYY-MM-DDTHH:MM:SSZ -e YYYY-MM-DDTHH:MM:SSZ`. Also the `-m` flag should be dropped if present.

**Does this update need to be deployed for operational runs?**
Yes (after the calling scripts are updated).

**Does this update require front end/web app changes? (If yes, provide documentation to Min)**
No — the front-end-facing `.json` filenames are unchanged.

**Does this impact code development work on adding SCHISM?**
No.

**Does this impact code development work on adding ADCIRC?**
No.

**Does this impact the expected number of output files for integration tests (i.e., will the integration test fail even though code changes result in desired change in outputs?)**
Hourly `.asc` filenames change (`_HH00.asc` → `-HHz.asc`); count is the same. If an integration test pattern-matches on the old `_HHMM` stamp it would need updating.

- [x] Developer's name is removed throughout the code?
- [x] Did you add relevant labels to the PR?
- [x] Have you run pylint and is the code at an acceptable pylint score (>8)? — 8.79/10 (up from 6.88/10).
- [x] Jobs contain the appropriate file checking and handle errors for any missing data?
- [x] Is log free of critical ERRORs or WARNINGs? For errors that are not critical and can remain in code, is there sufficient handling and logging? — yes; warning fires when a HF radar source has no timesteps in the requested window or no valid obs within the OFS boundary, both of which are handled non-fatally.

### Testing Instructions

```
conda activate ofs_dps
pytest tests/hf_radar_test.py -v
pytest -q --no-cov
```

Live e2e against NDBC THREDDS:
```
python ./bin/obs_retrieval/get_hf_radar.py \
  -s 2026-04-20T00:00:00Z -e 2026-04-21T00:00:00Z \
  -C ./data/observations/ -o lmhofs
```
Expected outputs:
- `data/observations/lmhofs_hfradar_{mag,dir}_20260420-HHz.asc` — hourly intermediates with the new `-HHz` stamp (count depends on GLNA coverage that day; ~17 on 2026-04-20).
- `data/observations/lmhofs_hfradar_{mag,dir}_20260420.asc` — daily intermediate (unchanged).
- `data/observations/2d/lmhofs_20260420-HHz_ssu_hfradar.json` and `_ssv_hfradar.json` — hourly Leaflet JSONs (PR #106 names preserved).
- `data/observations/2d/lmhofs_20260420_ssu_hfradar.json` / `_ssv_hfradar.json` — daily Leaflet JSONs.
- `data/observations/2d/lmhofs_{mag,dir}_20260420[-HHz]_hfradar.txt` — ASCII-grid txts.

Old-syntax regression check (should each error out cleanly):
```
python ./bin/obs_retrieval/get_hf_radar.py -d 20260420 -C ./data/observations/ -o lmhofs
python ./bin/obs_retrieval/get_hf_radar.py -s 2026042000 -e 2026042100 -C ./data/observations/ -o lmhofs
python ./bin/obs_retrieval/get_hf_radar.py -s 2026-04-21T00:00:00Z -e 2026-04-20T00:00:00Z -C ./data/observations/ -o lmhofs
```

### Reminder checklist for PR reviewer
- [ ] Run PEP8 compliance tests to ensure the code follows best practices
- [ ] Check that documentation in the script is sufficient
- [ ] Validate the output values (if applicable) to make sure the calculations are correct and make scientific/physical sense; include a comment on the pull request including what validation you performed, for replicability.
- [ ] Test code both on Windows and Linux (and MacOS, if available), using several OFS as test cases
- [ ] **Test for all 'cast' options: forecast_a, forecast_b, and nowcast** — N/A for HF radar.
- [ ] When approving or commenting on a pull request, add information on the calls you use in case they need to be replicated or referenced.