### PR TITLE
Exclude HF radar files from 2D JSON file search

### DIFF
--- a/src/ofs_skill/visualization/plotting_2d.py
+++ b/src/ofs_skill/visualization/plotting_2d.py
@@ -136,7 +136,7 @@ def list_of_json_files(filepath, prop1, logger):
                 and prop1.whichcast in af_name.split('.')[-2]):
                 spltstr.append(af_name.split('_')[1])  # Date info for sorting
                 files.append(filepath + '/' + af_name)  # Full file path
-        elif 'model' not in af_name and 'daily' not in af_name and 'lnc' not in af_name:  # ignore daily avg
+        elif 'model' not in af_name and 'daily' not in af_name and 'lnc' not in af_name and 'mag' not in af_name and 'dir' not in af_name:  # ignore daily avg
             if ((datetime.strptime(af_name.split('_')[1], '%Y%m%d-%Hz') >=
                   datetime.strptime(prop1.start_date_full, '%Y%m%d-%H:%M:%S'))
                 and (datetime.strptime(af_name.split('_')[1], '%Y%m%d-%Hz') <=


### PR DESCRIPTION
### Description of Changes

The function `plotting_2d.list_of_json_files` is intended to return a list of 2D JSON files. However it was finding HF radar files instead. This caused an error when parsing the (incorrect) filename for a date string. As a result, skill map generation was being skipped for the server cron jobs.

A fix was added to exclude HF radar files from the search logic within `plotting_2d.list_of_json_files`.

### Expected Outcome of Changes

Restored 2D skill map functionality.

### Developer Questions and Checklist
**Is this a high priority PR? If yes, why and is there a date by which it needs to be merged?**
Yes. It will fix the skill maps for the web app.

**Are there any changes needed to how the code should be run on the server? (Commands, flags, job timings, etc.)**
No.

**Does this update need to be installed on the server?**
Yes.

**Does this update require front end/web app changes? (If yes, provide documentation to Min)**
No.

**Does this impact code development work on adding SCHISM? (If yes, tag Atieh)**
No.

**Does this impact code development work on adding ADCIRC?**
_No/Yes + tag Jack if yes_
No.

**Does this impact the expected number of output files for integration tests (i.e., will the integration test fail even though code changes result in desired change in the number of outputs?)**
No.

- [x] Developer's name is removed throughout the code?
- [x] Did you add relevant labels to the PR?
- [x] Have you run pylint and is the code at an acceptable pylint score? (>8.0)
- [x] Jobs contain the appropriate file checking and handle errors for any missing data?
- [x] Is log free of critical ERRORs or WARNINGs? For errors that are not critical and can remain in code, is there sufficient handling and logging?

### Testing Instructions

1) Download some HF radar files from the server, and store them locally in `./data/model/2D/`. 
2) Run the full 2D pipeline.
3) Check for errors. and verify is all expected 2D output is generated, including JSON skill maps.

### Reminder checklist for PR reviewer:
- [x] Run PEP8 compliance tests to ensure the code follows best practices
- [x] Check that documentation in the script is sufficient
- [x] Validate the output values (if applicable) to make sure the calculations are correct and make scientific/physical sense; include a comment on the pull request including what validation you performed, for replicability.
- [x] Test code both locally and on the linux server, using several OFS as test cases
- [x] **Test for all ‘cast’ options: forecast_a, forecast_b, and nowcast**
- [x] When approving or commenting on a pull request, add information on the calls you use in case they need to be replicated.
