### PR TITLE
Fix HF radar ASCII grid lat/lon offset on front end (#144)

### DIFF
--- a/src/ofs_skill/visualization/processing_2d.py
+++ b/src/ofs_skill/visualization/processing_2d.py
@@ -1161,34 +1161,52 @@ def write_2d_array_to_ascii_grid(
     """
     Write a 2D data array as an ESRI ASCII Grid (.asc/.txt) file.
 
-    Creates a geospatial raster file with a 6-line header followed by
-    space-separated grid data. Data rows are written north-to-south
-    per the ESRI ASCII Grid convention.
+    Coordinates in ``lon_grid`` / ``lat_grid`` are treated as CELL
+    CENTERS. The header ``xllcorner`` / ``yllcorner`` are emitted as
+    true cell corners (cell center minus half the cell size in each
+    axis). Cell sizes are computed from node spacing along each axis,
+    so non-square grids (e.g. HF radar feeds where dx != dy) are
+    written with separate ``dx`` / ``dy`` keywords matching the
+    format rasterio's AAIGrid driver produces. Square grids keep the
+    single ``cellsize`` keyword for backward compatibility.
+
+    Data rows are reordered north-to-south as required by the
+    ESRI ASCII Grid convention regardless of the input axis order.
 
     Args:
         data: 2D array of data values (same shape as lon_grid/lat_grid)
-        lon_grid: 2D meshgrid of longitudes
-        lat_grid: 2D meshgrid of latitudes
+        lon_grid: 2D meshgrid of longitudes (cell centers)
+        lat_grid: 2D meshgrid of latitudes (cell centers)
         filename: Output file path
         nodata_value: Value to represent missing data (default -9999)
     """
     nrows, ncols = data.shape
-    xllcorner = float(lon_grid[0, 0])
-    yllcorner = float(lat_grid[0, 0])
-    cellsize = float(lon_grid[0, 1] - lon_grid[0, 0])
+    lons_1d = np.asarray(lon_grid[0, :], dtype=float)
+    lats_1d = np.asarray(lat_grid[:, 0], dtype=float)
 
-    # Replace NaN with nodata_value
+    dx = float(abs(lons_1d[-1] - lons_1d[0]) / (ncols - 1)) if ncols > 1 else 0.0
+    dy = float(abs(lats_1d[-1] - lats_1d[0]) / (nrows - 1)) if nrows > 1 else 0.0
+    xllcorner = float(min(lons_1d[0], lons_1d[-1])) - dx / 2
+    yllcorner = float(min(lats_1d[0], lats_1d[-1])) - dy / 2
+
     out_data = np.where(np.isnan(data), nodata_value, data)
+    if nrows > 1 and lats_1d[0] < lats_1d[-1]:
+        out_data = out_data[::-1]
+    if ncols > 1 and lons_1d[0] > lons_1d[-1]:
+        out_data = out_data[:, ::-1]
 
-    # Flip rows so first row is northernmost (ESRI convention)
-    out_data = out_data[::-1]
+    square = abs(dx - dy) <= 1e-9 * max(dx, dy, 1.0)
 
     with open(filename, 'w', encoding='utf-8') as f:
         f.write(f'ncols        {ncols}\n')
         f.write(f'nrows        {nrows}\n')
         f.write(f'xllcorner    {xllcorner:.12f}\n')
         f.write(f'yllcorner    {yllcorner:.12f}\n')
-        f.write(f'cellsize     {cellsize:.12f}\n')
+        if square:
+            f.write(f'cellsize     {dx:.12f}\n')
+        else:
+            f.write(f'dx           {dx:.12f}\n')
+            f.write(f'dy           {dy:.12f}\n')
         f.write(f'NODATA_value {nodata_value}\n')
         for row in out_data:
             f.write(' '.join(f'{v:g}' for v in row) + '\n')

--- a/tests/ascii_grid_output_test.py
+++ b/tests/ascii_grid_output_test.py
@@ -18,7 +18,11 @@ class TestWrite2dArrayToAsciiGrid:
     """Tests for write_2d_array_to_ascii_grid."""
 
     def test_basic_write_and_read(self, tmp_path):
-        """Round-trip: write a grid, read it back, verify header and data."""
+        """Round-trip: write a grid, read it back, verify header and data.
+
+        Inputs are cell centers; xllcorner/yllcorner are the SW corner
+        of the SW cell (cell center minus half cellsize).
+        """
         lon = np.array([[10.0, 10.5, 11.0], [10.0, 10.5, 11.0]])
         lat = np.array([[20.0, 20.0, 20.0], [20.5, 20.5, 20.5]])
         data = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
@@ -29,18 +33,16 @@ class TestWrite2dArrayToAsciiGrid:
         with open(outfile) as f:
             lines = f.readlines()
 
-        # Check header
         assert lines[0].strip() == 'ncols        3'
         assert lines[1].strip() == 'nrows        2'
         assert 'xllcorner' in lines[2]
-        assert float(lines[2].split()[-1]) == pytest.approx(10.0)
+        assert float(lines[2].split()[-1]) == pytest.approx(9.75)
         assert 'yllcorner' in lines[3]
-        assert float(lines[3].split()[-1]) == pytest.approx(20.0)
+        assert float(lines[3].split()[-1]) == pytest.approx(19.75)
         assert 'cellsize' in lines[4]
         assert float(lines[4].split()[-1]) == pytest.approx(0.5)
         assert lines[5].strip() == 'NODATA_value -9999'
 
-        # Check data (6 header lines + 2 data rows)
         assert len(lines) == 8
 
     def test_nan_replaced_with_nodata(self, tmp_path):
@@ -69,9 +71,13 @@ class TestWrite2dArrayToAsciiGrid:
 
     def test_row_order_north_to_south(self, tmp_path):
         """First data row should be northernmost latitude."""
+        # Square cells (dx == dy) so the header keeps the single
+        # ``cellsize`` keyword (6-line header). Non-square cells would
+        # add a separate ``dy`` line -- covered separately in
+        # test_non_square_cells_emit_dx_dy.
         lon = np.array([[0.0, 1.0], [0.0, 1.0], [0.0, 1.0]])
-        lat = np.array([[10.0, 10.0], [20.0, 20.0], [30.0, 30.0]])
-        # Row 0 is south (lat=10), row 2 is north (lat=30)
+        lat = np.array([[10.0, 10.0], [11.0, 11.0], [12.0, 12.0]])
+        # Row 0 is south (lat=10), row 2 is north (lat=12)
         data = np.array([[100.0, 100.0], [200.0, 200.0], [300.0, 300.0]])
 
         outfile = str(tmp_path / 'order_test.txt')
@@ -104,6 +110,92 @@ class TestWrite2dArrayToAsciiGrid:
         # The NaN in south row (row 0, flipped to last)
         south_row = lines[7].strip().split()
         assert south_row[1] == '-999'
+
+    def test_non_square_cells_emit_dx_dy(self, tmp_path):
+        """Non-square cells (HF radar shape) write dx/dy, not cellsize.
+
+        Issue #144: cell-centered grids with dx != dy were silently
+        collapsed onto a single ``cellsize = dx``, dropping dy and
+        biasing every row's latitude.
+        """
+        # USEGC-shape: dx=0.058 deg, dy=0.054 deg
+        lons1d = np.array([-77.0, -76.942, -76.884])
+        lats1d = np.array([37.0, 37.054, 37.108])
+        lon, lat = np.meshgrid(lons1d, lats1d)
+        data = np.arange(9, dtype=float).reshape(3, 3)
+
+        outfile = str(tmp_path / 'nonsquare.txt')
+        write_2d_array_to_ascii_grid(data, lon, lat, outfile)
+
+        hdr = {}
+        with open(outfile) as f:
+            for _ in range(7):
+                key, val = f.readline().split()
+                hdr[key] = val
+        assert 'dx' in hdr and 'dy' in hdr
+        assert 'cellsize' not in hdr
+        assert float(hdr['dx']) == pytest.approx(0.058, abs=1e-9)
+        assert float(hdr['dy']) == pytest.approx(0.054, abs=1e-9)
+        # SW cell center is (-77.0, 37.0); SW corner is half-cell SW.
+        assert float(hdr['xllcorner']) == pytest.approx(-77.0 - 0.058/2)
+        assert float(hdr['yllcorner']) == pytest.approx(37.0 - 0.054/2)
+
+    def test_xllcorner_yllcorner_match_asc_writer(self, tmp_path):
+        """The .txt header corners must match what the .asc writer would
+        emit for the same source grid (issue #144 root cause).
+
+        ``bin/obs_retrieval/get_hf_radar.export_ascii`` uses
+        ``rasterio.from_origin(lons.min() - dx/2, lats.max() + dy/2)``
+        which makes ``xllcorner == lons.min() - dx/2`` and
+        ``yllcorner == lats.min() - dy/2``. The .txt writer must
+        agree so vector arrows render at the same geographic location
+        as the .asc raster on the front end.
+        """
+        # Mimic an HFR-style cell-center grid (south-up source axis).
+        lons1d = np.linspace(-76.0, -75.0, 11)
+        lats1d = np.linspace(37.0, 38.0, 11)
+        lon, lat = np.meshgrid(lons1d, lats1d)
+        data = np.zeros_like(lon)
+
+        outfile = str(tmp_path / 'corners.txt')
+        write_2d_array_to_ascii_grid(data, lon, lat, outfile)
+
+        hdr = {}
+        with open(outfile) as f:
+            for _ in range(6):
+                key, val = f.readline().split()
+                hdr[key] = val
+        cellsize = float(hdr['cellsize'])
+        assert float(hdr['xllcorner']) == pytest.approx(
+            lons1d.min() - cellsize / 2,
+        )
+        assert float(hdr['yllcorner']) == pytest.approx(
+            lats1d.min() - cellsize / 2,
+        )
+
+    def test_descending_lats_handled(self, tmp_path):
+        """North-up source (lats descending along axis 0) must still
+        produce north-first data rows and a correct yllcorner.
+        """
+        lons1d = np.array([0.0, 1.0])
+        lats1d = np.array([3.0, 2.0, 1.0])  # descending = north-up
+        lon, lat = np.meshgrid(lons1d, lats1d)
+        # Row 0 (lat=3, north) is the largest values
+        data = np.array([[300.0, 300.0], [200.0, 200.0], [100.0, 100.0]])
+
+        outfile = str(tmp_path / 'descending.txt')
+        write_2d_array_to_ascii_grid(data, lon, lat, outfile)
+
+        with open(outfile) as f:
+            lines = f.readlines()
+        hdr = {ln.split()[0]: ln.split()[1] for ln in lines[:6]}
+        # SW cell center = (0.0, 1.0); cellsize = 1.0
+        assert float(hdr['xllcorner']) == pytest.approx(-0.5)
+        assert float(hdr['yllcorner']) == pytest.approx(0.5)
+        assert float(hdr['cellsize']) == pytest.approx(1.0)
+        # First written row is northernmost (300s)
+        assert [float(v) for v in lines[6].split()] == [300.0, 300.0]
+        assert [float(v) for v in lines[8].split()] == [100.0, 100.0]
 
 
 class TestComputeCurrentMagDir:


### PR DESCRIPTION
### Description of Changes

Closes #144. The Leaflet front-end renders HF radar vector arrows from the `mag`/`dir` `.txt` ASCII grid files written by `write_2d_array_to_ascii_grid` in `processing_2d.py`. Two compounding bugs in that writer placed every arrow half a cell northeast of where the underlying data actually sits:

1. `xllcorner` / `yllcorner` were written as `lon_grid[0,0]` / `lat_grid[0,0]` — the **center** of the SW cell, not the **corner**. Shift: `+dx/2` east, `+dy/2` north.
2. `cellsize` was set to `lon_grid[0,1] - lon_grid[0,0]` (dx only); `dy` was silently dropped. HF radar cells are non-square (USEGC dx/dy ≈ 1.08; GLNA ≈ 1.30), so any reader that uses `cellsize` for the y-axis biases every row's latitude.

At USEGC 6 km resolution (5.08 km × 5.99 km cells) the half-cell offset is ~2.5 km east + ~3.0 km north, which matches the visible offset in the screenshot attached to #144 — arrows intruding onto the Eastern Shore peninsula and Lower Chesapeake Bay shoreline.

The fix mirrors the corner-handling convention already used by the `.asc` writer at `bin/obs_retrieval/get_hf_radar.py:189-211` (rasterio's `from_origin(lons.min() - dx/2, lats.max() + dy/2, dx, dy)`):

- Treat input `lon_grid` / `lat_grid` as cell centers (documented in the new docstring).
- Compute `dx`, `dy` from node spacing (`abs((end - start) / (n - 1))`) along each axis, robust to ascending or descending input.
- Subtract half-cell to write true SW corners.
- Conditionally flip rows / columns so written data is always north-first west-first regardless of input axis order (the old code unconditionally `[::-1]`-flipped which would silently corrupt data if a north-up source ever reached it).
- Emit single `cellsize` keyword when cells are square (within `1e-9`) for backward compatibility; emit separate `dx` / `dy` keywords when non-square — matches the format rasterio's AAIGrid driver already writes for the companion `.asc` files in the same pipeline.

Test changes: updated two existing tests (`test_basic_write_and_read`, `test_row_order_north_to_south`) that encoded the old buggy behavior, and added three regression tests: `test_non_square_cells_emit_dx_dy`, `test_xllcorner_yllcorner_match_asc_writer`, `test_descending_lats_handled`.

Labels: bug.

### Expected Outcome of Changes

`mag` / `dir` `.txt` files produced by `get_hf_radar.py` (HF radar observations) and by the model 2D pipeline (`processing_2d.py:435/442/556/563` — model current `mag`/`dir` exports from PR #72) will have geographically correct headers from this PR forward. On the Leaflet front-end, HF radar vector arrows that previously rendered ~3 km NE of their true position will move back onto the water where they belong.

| File | Header field | BEFORE | AFTER (matches `.asc`) |
|---|---|---|---|
| cbofs daily mag .txt | xllcorner | -97.883850097656 | -97.912887698582 |
| cbofs daily mag .txt | yllcorner | 21.735960006714 | 21.708990007704 |
| cbofs daily mag .txt | dx | (cellsize 0.0581 only) | 0.058075201852 |
| cbofs daily mag .txt | dy | dropped | 0.053939998020 |
| lmhofs daily mag .txt | xllcorner | -85.358703613281 | -85.393833609188 |
| lmhofs daily mag .txt | yllcorner | 45.627109527588 | 45.599998474121 |

After the fix, `.txt` corners match `.asc` corners to ≤ 4e-6° (within float-rounding from `(end-start)/(n-1)` vs first-pair-spacing). HF radar JSON output (`*_ssu_hfradar.json`, `*_ssv_hfradar.json`) is **unchanged** — its `lats` / `lons` arrays were already faithful cell centers and need no fix.

Side-by-side visual proof (simulated front-end render of the `.txt` headers for cbofs 2026-04-20 12Z) attached below.

### Developer Questions and Checklist

**Is this a high priority PR? If yes, why and is there a date by which it needs to be merged?**
Medium — closes a user-reported visible bug (#144) but no hard deadline.

**Are there any changes needed to how the code should be run for operational runs? (Commands, flags, job timings, etc.)**
No — same CLI, same outputs at the same paths, corrected header values.

**Does this update need to be deployed for operational runs?**
Yes — to make front-end HF radar arrows render in the correct location.

**Does this update require front end/web app changes? (If yes, provide documentation to Min)**
Yes — Min should verify the front-end `.txt` parser handles the `dx` / `dy` header variant that the writer now emits for HF radar (non-square cells), in addition to the existing single `cellsize` line. For HF radar mag/dir files the 6-line header (`cellsize`) becomes a 7-line header (`dx` + `dy`). Model 2D current mag/dir files (square cells from `resample_latlon`) continue to use the single `cellsize` line.

Min: header parsing should read `cellsize` if present, else read both `dx` and `dy`. Cell-center coordinate for column `j`, row `i` (i = 0 is northernmost) is:

```
lon[j] = xllcorner + (j + 0.5) * dx_or_cellsize
lat[i] = yllcorner + (nrows - 1 - i + 0.5) * dy_or_cellsize
```

The same parser pattern works for the `.asc` files rasterio writes in `data/observations/`, which have always used the `dx` / `dy` variant.

**Does this impact code development work on adding SCHISM?**
No.

**Does this impact code development work on adding ADCIRC?**
No.

**Does this impact the expected number of output files for integration tests (i.e., will the integration test fail even though code changes result in desired change in outputs?)**
No — same file counts and same paths. Header content differs.

- [x] Developer's name is removed throughout the code?
- [x] Did you add relevant labels to the PR?
- [x] Have you run pylint and is the code at an acceptable pylint score (>8)?
- [x] Jobs contain the appropriate file checking and handle errors for any missing data?
- [x] Is log free of critical ERRORs or WARNINGs? For errors that are not critical and can remain in code, is there sufficient handling and logging?

Pylint: `src/ofs_skill/visualization/processing_2d.py` 8.52 (origin/main baseline) → 8.53 (this PR).

### Testing Instructions

**Branch:** `fix-issue-144-hfradar-ascii-grid-corner`

**Unit tests (75 tests across the two affected modules):**

```bash
eval "$(~/miniforge3/bin/conda shell.bash hook)" && conda activate ofs_dps
pip install -e .
python -m pytest tests/ascii_grid_output_test.py tests/hf_radar_test.py -v
```

Expected: 75 passed (19 ascii grid + 56 hf radar). Full repo suite still passes (573).

**E2E header verification (requires THREDDS network access):**

```bash
# CBOFS — USEGC source, non-square cells
python ./bin/obs_retrieval/get_hf_radar.py \
    -s 2026-04-20T00:00:00Z -e 2026-04-21T00:00:00Z \
    -C ./data/observations/ -o cbofs

# Daily mag .txt header should now read:
#   xllcorner    -97.912887698582    (was -97.883850097656 on main)
#   yllcorner    21.708990007704     (was  21.735960006714 on main)
#   dx           0.058075201852
#   dy           0.053939998020
# matching the companion .asc file in data/observations/
head -8 ./data/observations/2d/cbofs_mag_20260421_hfradar.txt
head -8 ./data/observations/cbofs_hfradar_mag_20260421.asc
```

**E2E header verification on a different OFS (Great Lakes, GLNA source):**

```bash
python ./bin/obs_retrieval/get_hf_radar.py \
    -s 2026-04-20T00:00:00Z -e 2026-04-21T00:00:00Z \
    -C ./data/observations/ -o lmhofs

head -8 ./data/observations/2d/lmhofs_mag_20260420_hfradar.txt
# Expect xllcorner=-85.393833609188 (was -85.358703613281 on main).
```

**Visual front-end check (no network required, runs after E2E):**

```bash
# Static cartopy plot from JSON (unchanged code path, sanity check):
python ./bin/utils/plot_leafletJSON.py \
    -fu ./data/observations/2d/cbofs_20260420-12z_ssu_hfradar.json \
    -fv ./data/observations/2d/cbofs_20260420-12z_ssv_hfradar.json \
    -o /tmp/cbofs_hfradar_post_fix.png
```

Min: deploy the branch to the staging web app and confirm the HF radar arrows over Delaware Bay / lower Chesapeake Bay no longer intrude onto the Eastern Shore peninsula.

### Reminder checklist for PR reviewer

- [ ] Run PEP8 compliance tests to ensure the code follows best practices
- [ ] Check that documentation in the script is sufficient
- [ ] Validate the output values (if applicable) to make sure the calculations are correct and make scientific/physical sense; include a comment on the pull request including what validation you performed, for replicability.
- [ ] Test code both on Windows and Linux (and MacOS, if available), using several OFS as test cases
- [ ] **Test for all 'cast' options: forecast_a, forecast_b, and nowcast**
- [ ] When approving or commenting on a pull request, add information on the calls you use in case they need to be replicated or referenced.

### Visual proof

Same `.txt` headers, rendered using a Leaflet-style center-of-cell parse (`lon[j] = xllcorner + (j + 0.5) * cellsize`) over a Delmarva basemap for cbofs 2026-04-20 12Z:

- **BEFORE:** vector arrows visibly intrude onto the Eastern Shore peninsula and Lower Bay shoreline.
- **AFTER:** vector arrows sit cleanly offshore in the open Atlantic and Chesapeake Bay mouth.

(Image to be attached after PR creation: `/tmp/issue144_before_after.png`.)
