### PR TITLE
Point CHS calls at the new IWLS host

### DIFF
--- a/bin/obs_retrieval/ofs_inventory_stations_cli.py
+++ b/bin/obs_retrieval/ofs_inventory_stations_cli.py
@@ -77,11 +77,8 @@ Remarks:
 """
 # Libraries:
 import argparse
-from pathlib import Path
-
 
 from ofs_skill.obs_retrieval.ofs_inventory_stations import ofs_inventory_stations
-
 
 # Execution:
 if __name__ == '__main__':
@@ -123,8 +120,8 @@ if __name__ == '__main__':
         '-so',
         '--Station_Owner',
         required=False,
-        default = 'co-ops,ndbc,usgs',
-        help="'CO-OPS','NDBC','USGS',", )
+        default = 'co-ops,ndbc,usgs,chs',
+        help="'CO-OPS','NDBC','USGS', 'CHS'", )
     parser.add_argument(
         '-c', '--config',
         help='Path to configuration file (default: conf/ofs_dps.conf)')

--- a/src/ofs_skill/obs_retrieval/inventory_chs_station.py
+++ b/src/ofs_skill/obs_retrieval/inventory_chs_station.py
@@ -12,7 +12,12 @@ from logging import Logger
 from typing import Optional
 
 import pandas as pd
+from searvey import _chs_api
 from searvey._chs_api import get_chs_stations
+
+# TEMP: CHS retired the old IWLS host (returns 301 to the line below); searvey
+# still hard-codes the old URL. Remove this override once upstream ships the fix.
+_chs_api.CHS_BASE_URL = 'https://api-iwls.dfo-mpo.gc.ca/api/v1'
 
 
 def inventory_chs_station(

--- a/src/ofs_skill/obs_retrieval/retrieve_chs_station.py
+++ b/src/ofs_skill/obs_retrieval/retrieve_chs_station.py
@@ -19,7 +19,12 @@ from logging import Logger
 from typing import Optional
 
 import pandas as pd
+from searvey import _chs_api
 from searvey._chs_api import fetch_chs_station
+
+# TEMP: CHS retired the old IWLS host (returns 301 to the line below); searvey
+# still hard-codes the old URL. Remove this override once upstream ships the fix.
+_chs_api.CHS_BASE_URL = 'https://api-iwls.dfo-mpo.gc.ca/api/v1'
 
 # CHS time series codes per variable, in priority order (try first, fallback)
 _SCALAR_CODE_MAP = {


### PR DESCRIPTION
### Description of Changes
CHS quietly moved their IWLS API from `api.iwls-sine.azure.cloud-nuage.dfo-mpo.gc.ca` to `api-iwls.dfo-mpo.gc.ca`. The old host now returns a 301, and searvey's `httpx.get` doesn't follow redirects, so `response.json()` tries to parse the HTML 301 body and dies with `Expecting value: line 1 column 1 (char 0)`. That kills the whole CHS inventory step for any OFS that uses it (loofs2, loofs, lsofs, leofs2, etc.).

This is a temporary fix: I override `searvey._chs_api.CHS_BASE_URL` to the new host at import time in our two CHS-touching modules. searvey reads that constant inside the function bodies, so both the inventory call and the per-station data fetch pick it up without any other change. Will rip the override out once the upstream searvey fix lands.

10 lines added across two files, no logic changes.

Labels: bug

### Expected Outcome of Changes
CHS inventory and station data retrieval start working again. No effect on any other data source, no change to outputs.

### Developer Questions and Checklist
**Is this a high priority PR? If yes, why and is there a date by which it needs to be merged?**
Medium — it's blocking anything that touches CHS (Great Lakes Canadian-side stations), but folks running US-only OFS aren't affected.

**Are there any changes needed to how the code should be run for operational runs? (Commands, flags, job timings, etc.)**
No.

**Does this update need to be deployed for operational runs?**
Yes, if ops touches any GL OFS that hits CHS.

**Does this update require front end/web app changes? (If yes, provide documentation to Min)**
No.

**Does this impact code development work on adding SCHISM?**
No.

**Does this impact code development work on adding ADCIRC?**
No.

**Does this impact the expected number of output files for integration tests (i.e., will the integration test fail even though code changes result in desired change in outputs?)**
No.

- [x] Developer's name is removed throughout the code?
- [x] Did you add relevant labels to the PR?
- [x] Have you run pylint and is the code at an acceptable pylint score (>8)? — 9.92/10 on the two patched files.
- [x] Jobs contain the appropriate file checking and handle errors for any missing data? — the existing `try/except` around `get_chs_stations` already handles failures.
- [x] Is log free of critical ERRORs or WARNINGs? — yes, the previous `CHS data download failed!` ERROR is gone.

### Testing Instructions
1. `pytest tests/chs_retrieval_test.py -v` → 22 passed (existing mock-based tests still pass; the override is inert for them).
2. Quick live inventory check (Lake Ontario bbox):
   ```
   python -c "
   import logging
   from ofs_skill.obs_retrieval.inventory_chs_station import inventory_chs_station
   df = inventory_chs_station(43.0, 44.5, -80.0, -76.0, logging.getLogger('s'))
   print('rows:', None if df is None else len(df))
   "
   ```
   Should print `rows: 15` (or similar) and log a 200 against `api-iwls.dfo-mpo.gc.ca`.
3. Live data fetch (Toronto wlo, 7 days):
   ```
   python -c "
   import logging
   from ofs_skill.obs_retrieval.retrieve_chs_station import retrieve_chs_station
   df = retrieve_chs_station('20250101', '20250108',
                             '5cebf1e43d0f4a073c4bc3e5',
                             'water_level', logging.getLogger('s'))
   print('rows:', None if df is None else len(df))
   "
   ```
   Should print `rows: 3361`.
4. End-to-end against the original failing call:
   ```
   python ./bin/visualization/create_1dplot.py -o loofs2 -p ./ \
       -s 2025-01-01T00:00:00Z -e 2025-03-31T23:59:59Z \
       -vs water_temperature -ws hindcast -d IGLD85
   ```
   Look for `Calling CHS service for inventory...` → `inventory_chs_station.py ran successfully` → `Finished retrieving CHS inventory!` and no `CHS data download failed!` line.