### PR TITLE
GUI: add SECOFS, config picker, calendar popup fix, date/horizon validation, and LOOFS2 whichcast UI blocker

### DIFF
--- a/src/ofs_skill/model_processing/get_fcst_cycle.py
+++ b/src/ofs_skill/model_processing/get_fcst_cycle.py
@@ -197,7 +197,7 @@ def get_fcst_hours(ofs):
     if ofs in (
         'cbofs', 'dbofs', 'gomofs', 'ciofs', 'leofs',
         'lmhofs', 'loofs', 'loofs2', 'lsofs', 'tbofs',
-        'necofs','stofs_2d_glo'
+        'necofs', 'secofs', 'stofs_2d_glo'
     ):
         fcstcycles = np.array([0, 6, 12, 18])
     elif ofs in ('creofs', 'ngofs2', 'sfbofs', 'sscofs'):

--- a/src/ofs_skill/visualization/create_gui.py
+++ b/src/ofs_skill/visualization/create_gui.py
@@ -12,7 +12,7 @@ from tkinter import filedialog, messagebox, ttk
 from tkinter.font import Font
 from types import SimpleNamespace
 
-from tkcalendar import DateEntry
+from tkcalendar import DateEntry as _TkDateEntry
 
 from ofs_skill.model_processing.get_fcst_cycle import get_fcst_hours
 
@@ -36,6 +36,50 @@ _DEFAULT_DATUMS = (
 # OFSes use MLLW.
 _GREAT_LAKES_OFS = ('leofs', 'lmhofs', 'loofs', 'loofs2', 'lsofs')
 _STOFS_OFS = ('stofs_2d_glo', 'stofs_3d_atl', 'stofs_3d_pac')
+
+
+class DateEntry(_TkDateEntry):
+    """Drop-in replacement for ``tkcalendar.DateEntry`` with cross-platform
+    calendar-popup fixes."""
+
+    _CAL_COLOR_DEFAULTS = {
+        'normalbackground':     'white',
+        'normalforeground':     'black',
+        'selectbackground':     '#1a73e8',
+        'selectforeground':     'white',
+        'weekendbackground':    '#f0f0f0',
+        'weekendforeground':    'black',
+        'headersbackground':    '#e0e0e0',
+        'headersforeground':    'black',
+        'othermonthbackground': '#fafafa',
+        'othermonthforeground': 'gray50',
+        'bordercolor':          'gray60',
+    }
+
+    def __init__(self, master=None, **kw):
+        for key, value in self._CAL_COLOR_DEFAULTS.items():
+            kw.setdefault(key, value)
+        super().__init__(master, **kw)
+        if sys.platform == 'darwin':
+            try:
+                self._top_cal.overrideredirect(False)
+            except (tk.TclError, AttributeError):
+                pass
+
+    def drop_down(self):
+        super().drop_down()
+        try:
+            top = self._top_cal
+            if not top.winfo_ismapped():
+                return
+            top.update_idletasks()
+            top.update()
+            top.lift()
+            if sys.platform != 'darwin':
+                top.attributes('-topmost', True)
+                top.focus_force()
+        except (tk.TclError, AttributeError):
+            pass
 
 
 def _quick_run_datum(ofs):
@@ -149,12 +193,30 @@ def create_gui(parser):
         args_values.Currents_Bins_Csv = None
         # Mirrors argparse: True means the model-file pre-check is performed.
         args_values.Disable_Model_File_Check = True
+        args_values.config = config_path_var.get().strip() or None
 
         root.destroy()
 
     def submit_and_close():
         # First check for required arguments and display error if not present
         error = None
+
+        # Build UTC-aware datetimes once for the date-ordering / future
+        # checks so comparisons are unambiguous.
+        start_date = start_entry.get_date()
+        end_date = end_entry.get_date()
+        try:
+            start_dt = datetime(
+                start_date.year, start_date.month, start_date.day,
+                int(s_hour_scale.get()), tzinfo=timezone.utc,
+            ) if start_date else None
+            end_dt = datetime(
+                end_date.year, end_date.month, end_date.day,
+                int(e_hour_scale.get()), tzinfo=timezone.utc,
+            ) if end_date else None
+        except (TypeError, ValueError):
+            start_dt = end_dt = None
+
         if directory_path_var.get() is None:
             messagebox.showerror('Error', 'Please select your home directory.')
             error = 1
@@ -173,7 +235,20 @@ def create_gui(parser):
         elif not end_entry.get_date():
             messagebox.showerror('Error', 'Please enter an end date.')
             error = 1
-        elif var_now.get() == '0' and var_fore.get() == '0':
+        elif start_dt is not None and end_dt is not None and start_dt >= end_dt:
+            messagebox.showerror(
+                'Error', 'Start date/hour must be before end date/hour.'
+            )
+            error = 1
+        elif (start_dt is not None
+              and start_dt > datetime.now(timezone.utc)):
+            messagebox.showerror(
+                'Error',
+                'Start date/hour cannot be in the future (UTC).'
+            )
+            error = 1
+        elif (var_now.get() == '0' and var_fore.get() == '0'
+              and var_forea.get() == '0' and var_hind.get() == '0'):
             messagebox.showerror(
                 'Error', 'Please select at least one whichcast.'
             )
@@ -190,6 +265,15 @@ def create_gui(parser):
               and var_temp.get() == '0' and var_wl.get() == '0'):
             messagebox.showerror(
                 'Error', 'Please select at least one variable to assess.'
+            )
+            error = 1
+        elif horizon_var.get() and filetype_var.get() != 'stations':
+            messagebox.showerror(
+                'Error',
+                '"Assess all forecast horizons?" is only supported with '
+                'the "Station" model output file type. Either change the '
+                'file type to Station, or set "Assess all forecast '
+                'horizons?" to No.'
             )
             error = 1
 
@@ -230,6 +314,7 @@ def create_gui(parser):
             args_values.Forecast_Hr = selected_cycle
 
         args_values.Currents_Bins_Csv = cb_var.get() or None
+        args_values.config = config_path_var.get().strip() or None
 
         # GUI variable is named for clarity; the namespace attribute keeps
         # the argparse name. True means the model-file pre-check runs.
@@ -253,6 +338,17 @@ def create_gui(parser):
         chosen_directory = filedialog.askdirectory()
         if chosen_directory:  # Only update if a directory was selected
             directory_path_var.set(chosen_directory)
+
+    def browse_config_file():
+        '''
+        Opens a file selection dialog for the .conf configuration file.
+        '''
+        chosen_file = filedialog.askopenfilename(
+            title='Select configuration file',
+            filetypes=(('Config files', '*.conf'), ('All files', '*.*')),
+        )
+        if chosen_file:
+            config_path_var.set(chosen_file)
 
     def browse_csv_file():
         '''
@@ -289,6 +385,56 @@ def create_gui(parser):
             cycle_chosen.config(state='readonly')
         else:
             cycle_chosen.config(state='disabled')
+
+    # Track the previously selected OFS so we can restore the default
+    # whichcast set when the user switches AWAY from LOOFS2 (where we
+    # forced hindcast-only). Closure-captured list lets the nested
+    # handler mutate the value without `nonlocal` gymnastics.
+    _last_ofs = ['']
+
+    def update_whichcast_state(_event=None):
+        '''Restrict whichcast checkboxes based on the selected OFS.
+
+        LOOFS2 currently only supports the hindcast whichcast — nowcast,
+        forecast_a and forecast_b are not yet implemented. When LOOFS2
+        is selected we force-uncheck the three unsupported whichcasts
+        and disable their checkboxes so the user can't pick them. When
+        switching away from LOOFS2, we restore the original defaults
+        (nowcast + forecast_b on, forecast_a + hindcast off).
+        '''
+        current = ofs_entry.get()
+        is_loofs2 = current == 'loofs2'
+        was_loofs2 = _last_ofs[0] == 'loofs2'
+
+        if is_loofs2:
+            var_now.set('0')
+            var_fore.set('0')
+            var_forea.set('0')
+            var_hind.set('hindcast')
+            now_chk.config(state='disabled')
+            fore_chk.config(state='disabled')
+            forea_chk.config(state='disabled')
+            hind_chk.config(state='normal')
+            toggle_cycle_state()
+        else:
+            now_chk.config(state='normal')
+            fore_chk.config(state='normal')
+            forea_chk.config(state='normal')
+            hind_chk.config(state='normal')
+            if was_loofs2:
+                var_now.set('nowcast')
+                var_fore.set('forecast_b')
+                var_forea.set('0')
+                var_hind.set('0')
+                toggle_cycle_state()
+
+        _last_ofs[0] = current
+
+    def on_ofs_changed(_event=None):
+        '''Single handler for the OFS combobox: refreshes both the cycle
+        dropdown and the whichcast checkbox enable/disable state.'''
+        update_cycles(_event)
+        update_whichcast_state(_event)
 
     root = tk.Tk()
     root.title('Skill assessment inputs')
@@ -416,6 +562,24 @@ def create_gui(parser):
                                                           sticky='w',
                                                           padx=padx, pady=pady)
 
+    # Config file, -c. Empty/default value means "use the default
+    # conf/ofs_dps.conf"; submit_and_close() converts blanks to None
+    # so create_1dplot.py's argparse default kicks in.
+    row += 1
+    config_path_var = tk.StringVar(value='conf/ofs_dps.conf')
+    tk.Label(scrollable_frame,
+             text='Config file',
+             bg=themecolor,
+             fg=textcolor,
+             font=(fontfamily, labelfontsize),
+             anchor=anchor).grid(row=row, column=0, sticky='w',
+                                 padx=padx, pady=pady)
+    ttk.Button(scrollable_frame, text='Browse...', command=browse_config_file,
+               style='TButton').grid(row=row, column=1, sticky='w',
+                                     padx=padx, pady=pady)
+    ttk.Entry(scrollable_frame, textvariable=config_path_var).grid(
+        row=row, column=2, sticky='w', padx=padx, pady=pady)
+
     # OFS input, -o
     row += 1
     ofs_entry = tk.StringVar()
@@ -432,6 +596,7 @@ def create_gui(parser):
         'lsofs',
         'necofs',
         'ngofs2',
+        'secofs',
         'sfbofs',
         'sscofs',
         'stofs_2d_glo',
@@ -455,7 +620,7 @@ def create_gui(parser):
     )
     ofs_chosen['values'] = choices
     ofs_chosen.grid(row=row, column=1, sticky='w', padx=padx, pady=pady)
-    ofs_chosen.bind('<<ComboboxSelected>>', update_cycles)
+    ofs_chosen.bind('<<ComboboxSelected>>', on_ofs_changed)
 
     row += 1
     tk.Label(scrollable_frame,
@@ -483,9 +648,11 @@ def create_gui(parser):
              font=(fontfamily, labelfontsize),
              anchor=anchor).grid(row=row, column=0, sticky='w',
                                  padx=padx, pady=pady)
-    start_entry = DateEntry(scrollable_frame, width=16, background='darkblue',
-                    foreground='white', bd=2, date_pattern='yyyy-mm-dd',
-                    font=('Helvetica', 12))
+    start_entry = DateEntry(
+        scrollable_frame, width=16, background='darkblue',
+        foreground='white', bd=2, date_pattern='yyyy-mm-dd',
+        font=('Helvetica', 12),
+    )
     start_entry.grid(row=row, column=1,  sticky='w', padx=padx, pady=pady)
     # Create scale widget for hour selection
     s_hour_scale = tk.Scale(scrollable_frame, from_=0, to=23, orient=tk.HORIZONTAL,
@@ -501,9 +668,11 @@ def create_gui(parser):
              font=(fontfamily, labelfontsize),
              anchor=anchor).grid(row=row, column=0,  sticky='w',
                                  padx=padx, pady=pady)
-    end_entry = DateEntry(scrollable_frame, width=16, background='darkblue',
-                    foreground='white', bd=2, date_pattern='yyyy-mm-dd',
-                    font=('Helvetica', 12))
+    end_entry = DateEntry(
+        scrollable_frame, width=16, background='darkblue',
+        foreground='white', bd=2, date_pattern='yyyy-mm-dd',
+        font=('Helvetica', 12),
+    )
     end_entry.grid(row=row, column=1,  sticky='w', padx=padx, pady=pady)
     # Create scale widget for hour selection
     e_hour_scale = tk.Scale(scrollable_frame, from_=0, to=23, orient=tk.HORIZONTAL,
@@ -530,23 +699,27 @@ def create_gui(parser):
              font=(fontfamily, labelfontsize),
              anchor=anchor).grid(row=row, column=0, sticky='w',
                                  padx=padx, pady=pady)
-    ttk.Checkbutton(scrollable_frame, text='Nowcast', variable=var_now, onvalue='nowcast',
-                   offvalue=0).grid(row=row, column=1, sticky='w',
-                                    padx=padx, pady=pady)
-    ttk.Checkbutton(scrollable_frame, text='Forecast_b', variable=var_fore, onvalue=
-                   'forecast_b', offvalue=0).grid(row=row, column=2,
-                                                  sticky='w', padx=padx,
-                                                  pady=pady)
+    now_chk = ttk.Checkbutton(
+        scrollable_frame, text='Nowcast', variable=var_now,
+        onvalue='nowcast', offvalue=0,
+    )
+    now_chk.grid(row=row, column=1, sticky='w', padx=padx, pady=pady)
+    fore_chk = ttk.Checkbutton(
+        scrollable_frame, text='Forecast_b', variable=var_fore,
+        onvalue='forecast_b', offvalue=0,
+    )
+    fore_chk.grid(row=row, column=2, sticky='w', padx=padx, pady=pady)
     row += 1
-    ttk.Checkbutton(scrollable_frame, text='Forecast_a', variable=var_forea, onvalue=
-                   'forecast_a', offvalue=0, command=toggle_cycle_state).grid(
-                                                  row=row, column=1,
-                                                  sticky='w', padx=padx,
-                                                  pady=pady)
-    ttk.Checkbutton(scrollable_frame, text='Hindcast (LOOFS2 only)', variable=var_hind, onvalue=
-                   'hindcast', offvalue=0).grid(row=row, column=2,
-                                                  sticky='w', padx=padx,
-                                                  pady=pady)
+    forea_chk = ttk.Checkbutton(
+        scrollable_frame, text='Forecast_a', variable=var_forea,
+        onvalue='forecast_a', offvalue=0, command=toggle_cycle_state,
+    )
+    forea_chk.grid(row=row, column=1, sticky='w', padx=padx, pady=pady)
+    hind_chk = ttk.Checkbutton(
+        scrollable_frame, text='Hindcast (LOOFS2 only)', variable=var_hind,
+        onvalue='hindcast', offvalue=0,
+    )
+    hind_chk.grid(row=row, column=2, sticky='w', padx=padx, pady=pady)
 
     # Model Cycle input, -f
     row += 1

--- a/src/ofs_skill/visualization/create_gui.py
+++ b/src/ofs_skill/visualization/create_gui.py
@@ -56,10 +56,16 @@ class DateEntry(_TkDateEntry):
         'bordercolor':          'gray60',
     }
 
+    # Grace period (ms) after opening during which a transient FocusOut on
+    # the calendar is ignored. Prevents the popup from immediately closing
+    # when the platform briefly redirects focus while mapping the window.
+    _FOCUS_GRACE_MS = 200
+
     def __init__(self, master=None, **kw):
         for key, value in self._CAL_COLOR_DEFAULTS.items():
             kw.setdefault(key, value)
         super().__init__(master, **kw)
+        self._drop_down_time = 0
         if sys.platform == 'darwin':
             try:
                 self._top_cal.overrideredirect(False)
@@ -67,6 +73,7 @@ class DateEntry(_TkDateEntry):
                 pass
 
     def drop_down(self):
+        self._drop_down_time = self.winfo_toplevel().tk.call('clock', 'milliseconds')
         super().drop_down()
         try:
             top = self._top_cal
@@ -77,9 +84,18 @@ class DateEntry(_TkDateEntry):
             top.lift()
             if sys.platform != 'darwin':
                 top.attributes('-topmost', True)
-                top.focus_force()
         except (tk.TclError, AttributeError):
             pass
+
+    def _on_focus_out_cal(self, event):
+        """Ignore transient FocusOut events fired right after the popup
+        opens, before the user has had a chance to interact with it."""
+        now = self.winfo_toplevel().tk.call('clock', 'milliseconds')
+        elapsed = now - self._drop_down_time
+        if elapsed < self._FOCUS_GRACE_MS:
+            self._calendar.focus_set()
+            return
+        super()._on_focus_out_cal(event)
 
 
 def _quick_run_datum(ofs):


### PR DESCRIPTION
### Description of Changes

This PR is the first slice of GUI work for the GSoC roadmap (issue #138, Phase 1). It adds dynamic OFS-driven validation, surfaces the `-c/--config` flag in the GUI, fixes a long-standing cross-platform calendar popup bug, and adds SECOFS to the supported OFS list. All changes are additive and backward-compatible with the existing CLI workflow.

**1. SECOFS in the OFS dropdown**

- Added `'secofs'` to the OFS combobox in alphabetical order (between `ngofs2` and `sfbofs`)
- `get_fcst_hours('secofs')` already falls through to the existing catch-all branch, so the cycle dropdown and forecast logic work without any backend change

**2. Config file picker (`-c / --config`)**

- New "Config file" row right under "Home directory" with a Browse... button + Entry, defaulting to `conf/ofs_dps.conf`
- Wires through `args_values.config` in both `submit_and_close()` and `quick_run_submit()`
- Empty/whitespace input falls back to the argparse default in `create_1dplot.py`, so behaviour is unchanged when no config file is selected
<img width="741" height="885" alt="Screenshot 2026-05-25 at 23 01 29" src="https://github.com/user-attachments/assets/bcde9915-bf45-4dd4-b57e-5436fa7629a9" />

**3. Cross-platform calendar popup fix**

- Subclassed `tkcalendar.DateEntry` (the upstream class is now imported as `_TkDateEntry`; the local subclass keeps the name `DateEntry` so call sites read identically)
- Added 11 contrasting calendar color defaults (`normalbackground`, `selectbackground`, `headersbackground`, etc.) so the day grid renders with visible labels regardless of the entry's `background` color
- Platform-aware popup setup: switches the popup `Toplevel`'s `overrideredirect` off where the window manager otherwise wouldn't realize the window
- Platform-aware `drop_down()`: forces `update_idletasks()` + `update()` + `lift()` everywhere; conditionally applies `attributes('-topmost', True)` + `focus_force()` only where they help (skipped where they steal focus from the inner Calendar and trigger upstream auto-close)
<img width="258" height="237" alt="Screenshot 2026-05-25 at 23 04 45" src="https://github.com/user-attachments/assets/cdf05dad-3c19-44c7-a54c-6590ac210f57" />


**4. Date and forecast-horizon validation**

Three new `submit_and_close()` checks. UTC-aware `datetime` objects are built from the date + hour pair so the comparisons are unambiguous:

- Start date/hour must be strictly before end date/hour
- Start date/hour cannot be in the future (UTC)
<img width="260" height="194" alt="Screenshot 2026-05-25 at 23 02 57" src="https://github.com/user-attachments/assets/843d88d3-b4f3-47dd-9768-26c669813a99" />

- "Assess all forecast horizons?" requires `FileType = stations` (not `fields`)
<img width="260" height="260" alt="Screenshot 2026-05-25 at 23 03 22" src="https://github.com/user-attachments/assets/cb76efa8-fc19-4342-ad52-eea727ebc178" />


**5. LOOFS2 enforced as a UI-level blocker**

When `OFS = loofs2`:

- Nowcast / Forecast_b / Forecast_a checkboxes are auto-unchecked and disabled (greyed out, can't be clicked)
- Hindcast checkbox is auto-checked and enabled
- Forecast_a model-cycle dropdown is disabled accordingly

When the user switches away from LOOFS2, all four whichcast checkboxes are re-enabled and the original defaults are restored (Nowcast✓ + Forecast_b✓, Forecast_a✗, Hindcast✗). A closure-captured `_last_ofs` tracks the previous selection so non-LOOFS2 → non-LOOFS2 transitions don't surprise the user. The OFS combobox event now binds to a chained `on_ofs_changed()` handler that calls both `update_cycles()` and the new `update_whichcast_state()`.
<img width="668" height="83" alt="Screenshot 2026-05-25 at 23 01 59" src="https://github.com/user-attachments/assets/3e0919c3-e9f8-4c6a-9b2e-e2dee9de8d0c" />


**6. Side-fix: relaxed the existing whichcast check**

The pre-existing "at least one whichcast" check only counted nowcast and forecast_b — meaning a LOOFS2 hindcast-only run could never submit. Relaxed to count all four whichcasts (`var_now | var_fore | var_forea | var_hind`).

### Expected Outcome of Changes

- LOOFS2 users can no longer pick whichcasts that aren't yet implemented for that OFS — the offending checkboxes are greyed out at the UI level
- SECOFS is available in the GUI dropdown with a working cycle picker
- The config file path can be set from the GUI without dropping to CLI for a single flag
- Date pickers render correctly and stay open on macOS Sonoma+ (previously the popup either appeared blank or self-closed on click)
- Common configuration mistakes (`start ≥ end`, future start date, horizon-skill on field files) are caught in the GUI before reaching the backend pipeline

### Testing Instructions

**1. GUI Launch and Appearance**

```
python ./bin/visualization/create_1dplot.py
```

Expected: Window appears as before, with a new "Config file" row under "Home directory" defaulting to `conf/ofs_dps.conf`. Date pickers open a fully-rendered calendar grid (no blank/dark popup) and stay open until a date is picked or the user clicks elsewhere.

**2. SECOFS dropdown entry**

- Open the OFS dropdown
- Verify `secofs` appears between `ngofs2` and `sfbofs`
- Select `secofs` and verify the Model Cycle dropdown populates without error

**3. Config file picker**

- Click Browse... next to "Config file"
- Select an alternate `.conf` file
- Submit the form and verify the path propagates to `prop1.config_file` (logged on startup as "Using config <path>")
- Clear the entry and submit; verify it falls back to the default `conf/ofs_dps.conf`

**4. LOOFS2 UI blocker**

- Select OFS = `loofs2`
- Expected: Nowcast / Forecast_b / Forecast_a checkboxes greyed out and unchecked; Hindcast auto-checked
- Try clicking the disabled checkboxes — expected: nothing happens
- Switch OFS to `cbofs`
- Expected: all four checkboxes re-enabled; defaults restored (Nowcast✓ + Forecast_b✓, Forecast_a✗, Hindcast✗)
- Switch `cbofs` → `dbofs` (non-LOOFS2 → non-LOOFS2)
- Expected: whichcast state preserved (no surprise resets)

**5. Date validation**

- Set start date to a value AFTER end date, click Submit
- Expected: error popup "Start date/hour must be before end date/hour."
- Set start date to a future date (UTC-aware), click Submit
- Expected: error popup "Start date/hour cannot be in the future (UTC)."

**6. Forecast-horizon + station filetype**

- Set "Model output file type" = Field
- Set "Assess all forecast horizons?" = Yes
- Click Submit
- Expected: error popup "'Assess all forecast horizons?' is only supported with the 'Station' model output file type…"

**7. Calendar popup (cross-platform smoke)**

- Click both date pickers; verify the calendar grid renders with white day cells, dark text, and a visible selection highlight
- Verify the popup stays open until a date is clicked or focus moves elsewhere
- Verified manually on macOS Sonoma+; expected to also work unchanged on Linux/Windows since the platform-specific branches only kick in where needed

**8. Existing test suite**

```
pytest -m "not network and not manual"
```

Expected: all 560 tests pass, no regressions.