### PR TITLE
Add force-NODD-streaming mode to use_s3_fallback config option

### DIFF
--- a/conf/ofs_dps.conf.example
+++ b/conf/ofs_dps.conf.example
@@ -187,7 +187,12 @@ parallel_2d_interp=False
 # False = just interactive plots
 static_plots=False
 
-# Use S3 fallback for missing model files?
-# True = automatically read from NODD S3 bucket if local files are missing
-# False = exit with error if local files are missing (original behavior)
+# NODD S3 bucket usage for model files. Three modes:
+#   True  = prefer local model files; read from the NODD S3 bucket only
+#           when local files are missing (recommended default)
+#   False = local files only; exit with error if local files are missing
+#           (original behavior)
+#   force = always read model files from the NODD S3 bucket, even when
+#           local files are present (useful for validating against the
+#           canonical NODD copy)
 use_s3_fallback=True

--- a/src/ofs_skill/model_processing/list_of_files.py
+++ b/src/ofs_skill/model_processing/list_of_files.py
@@ -494,17 +494,24 @@ def list_of_dir(prop: Any, logger: Logger) -> list[str]:
     >>> print(dir_list)
     ['../cbofs/netcdf/2025/01/01', '../cbofs/netcdf/2025/01/02']
     """
-    # Check if S3 fallback is enabled
+    # Parse use_s3_fallback (tri-valued: True / False / force)
     _conf = getattr(prop, 'config_file', None)
     try:
         conf_settings = utils.Utils(_conf).read_config_section('settings', logger)
-        use_s3_fallback = conf_settings.get('use_s3_fallback', 'False').lower() in ('true', '1', 'yes')
+        s3_setting = conf_settings.get('use_s3_fallback', 'False').strip().lower()
+        force_nodd_streaming = s3_setting in ('force', 'forced')
+        use_s3_fallback = force_nodd_streaming or s3_setting in ('true', '1', 'yes')
     except Exception:
         use_s3_fallback = False
+        force_nodd_streaming = False
+
+    if force_nodd_streaming:
+        logger.info('use_s3_fallback=force: skipping local model dir checks; NODD S3 URLs will be used for all model files.')
 
     # Deal with LOOFS2 -- switch off
     if prop.ofs == 'loofs2' and prop.whichcast == 'hindcast':
         use_s3_fallback = False
+        force_nodd_streaming = False
 
     dir_list = []
     if prop.whichcast != 'forecast_a':
@@ -540,7 +547,11 @@ def list_of_dir(prop: Any, logger: Logger) -> list[str]:
                 raise SystemExit(-1)
 
         # Switch to backup directory if files are not in primary directory
-        if not os.path.exists(model_dir) or not os.listdir(model_dir):
+        # (skip entirely if forcing NODD streaming -- model_dir is used only
+        # as an S3-URL template downstream)
+        if force_nodd_streaming:
+            pass
+        elif not os.path.exists(model_dir) or not os.listdir(model_dir):
             logger.info(
                 'Model data path ' + model_dir + ' not found, or is empty. ')
 
@@ -633,22 +644,34 @@ def list_of_files(prop: Any, dir_list: list[str], logger: Logger) -> list[str]:
     >>> print(len(file_list))
     48
     """
-    # Check if S3 fallback is enabled
+    # Parse use_s3_fallback (tri-valued: True / False / force)
     _conf = getattr(prop, 'config_file', None)
     try:
         conf_settings = utils.Utils(_conf).read_config_section('settings', logger)
-        use_s3_fallback = conf_settings.get('use_s3_fallback', 'False').lower() in ('true', '1', 'yes')
+        s3_setting = conf_settings.get('use_s3_fallback', 'False').strip().lower()
+        force_nodd_streaming = s3_setting in ('force', 'forced')
+        use_s3_fallback = force_nodd_streaming or s3_setting in ('true', '1', 'yes')
     except Exception:
         use_s3_fallback = False
+        force_nodd_streaming = False
 
     # Deal with LOOFS2 -- switch off if hindcast
     if prop.ofs == 'loofs2' and prop.whichcast == 'hindcast':
         use_s3_fallback = False
+        force_nodd_streaming = False
 
     list_files = []
     try:
         dir_list_len = len(dir_list)
         for i_index in range(0, dir_list_len):
+
+            # If forcing NODD streaming, skip local enumeration entirely and
+            # construct expected (NODD) file names for this directory.
+            if force_nodd_streaming:
+                logger.info(f'use_s3_fallback=force: constructing expected NODD file names for {dir_list[i_index]}')
+                files = construct_expected_files(prop, dir_list[i_index], logger)
+                list_files.append(files)
+                continue  # Skip to next directory
 
             # Check if directory exists; if not and S3 fallback enabled, construct expected file names
             if not os.path.exists(dir_list[i_index]):
@@ -1240,26 +1263,34 @@ def list_of_files(prop: Any, dir_list: list[str], logger: Logger) -> list[str]:
 
     # Now check individual files and use S3 fallback if enabled
     if use_s3_fallback:
-        logger.info('S3 fallback is enabled - checking for missing local files...')
+        if force_nodd_streaming:
+            logger.info('use_s3_fallback=force - converting all model files to NODD S3 URLs...')
+        else:
+            logger.info('S3 fallback is enabled - checking for missing local files...')
         final_list: list[str] = []
         missing_count = 0
+        s3_count = 0
         for file_path in flat_files:
             # Normalize path for checking
             normalized_path = file_path.replace('//', '/')
-            if os.path.isfile(normalized_path):
+            if not force_nodd_streaming and os.path.isfile(normalized_path):
                 # File exists locally, use it
                 final_list.append(file_path)
             else:
-                # File doesn't exist locally, construct S3 URL
+                # File doesn't exist locally (or NODD is forced), construct S3 URL
                 s3_url = construct_s3_url(file_path, prop, logger)
                 if s3_url:
-                    logger.info(f'Local file not found, using S3: {os.path.basename(file_path)}')
+                    if not force_nodd_streaming:
+                        logger.info(f'Local file not found, using S3: {os.path.basename(file_path)}')
+                        missing_count += 1
+                    s3_count += 1
                     final_list.append(s3_url)
-                    missing_count += 1
                 else:
                     logger.error(f'Could not construct S3 URL for: {file_path}')
 
-        if missing_count > 0:
+        if force_nodd_streaming:
+            logger.info(f'Forced NODD streaming: using S3 URLs for {s3_count} model files')
+        elif missing_count > 0:
             logger.info(f'Using S3 URLs for {missing_count} missing local files')
         else:
             logger.info('All model files found locally, or are unavailable '

--- a/tests/force_nodd_streaming_test.py
+++ b/tests/force_nodd_streaming_test.py
@@ -1,0 +1,205 @@
+"""
+Unit tests for the `use_s3_fallback=force` tri-value mode (issue #58).
+
+Validates that:
+- `use_s3_fallback=False` returns local file paths and never calls S3 helpers.
+- `use_s3_fallback=True` returns local paths when files are present locally
+  (regression guard for the default behavior).
+- `use_s3_fallback=force` skips local enumeration entirely, calls
+  `construct_expected_files` for each directory, and converts every file
+  to an S3 URL via `construct_s3_url` regardless of whether a local copy
+  exists.
+"""
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+from ofs_skill.model_processing.list_of_files import list_of_files
+
+
+class MockLogger:
+    """Mock logger that records all messages."""
+
+    def __init__(self):
+        self.infos = []
+        self.warnings = []
+        self.errors = []
+        self.debugs = []
+
+    def info(self, msg, *args, **kwargs):
+        self.infos.append(msg % args if args else msg)
+
+    def warning(self, msg, *args, **kwargs):
+        self.warnings.append(msg % args if args else msg)
+
+    def error(self, msg, *args, **kwargs):
+        self.errors.append(msg % args if args else msg)
+
+    def debug(self, msg, *args, **kwargs):
+        self.debugs.append(msg % args if args else msg)
+
+
+class MockProps:
+    """Mock ModelProperties for testing."""
+
+    def __init__(self, ofs='cbofs', whichcast='nowcast', ofsfiletype='fields',
+                 startdate='2024090100', enddate='2024090123',
+                 forecast_hr='00z'):
+        self.ofs = ofs
+        self.whichcast = whichcast
+        self.ofsfiletype = ofsfiletype
+        self.startdate = startdate
+        self.enddate = enddate
+        self.forecast_hr = forecast_hr
+
+
+@pytest.fixture
+def logger():
+    return MockLogger()
+
+
+@pytest.fixture
+def props():
+    return MockProps()
+
+
+def _local_files_in(tmp_path):
+    """Create a fake local model dir with two real netCDF files and return
+    the directory plus the file basenames."""
+    netcdf_dir = tmp_path / 'cbofs' / 'netcdf' / '2024' / '09' / '01'
+    netcdf_dir.mkdir(parents=True)
+    files = [
+        'cbofs.t00z.20240901.fields.n001.nc',
+        'cbofs.t00z.20240901.fields.n002.nc',
+    ]
+    for name in files:
+        (netcdf_dir / name).write_bytes(b'')
+    return str(netcdf_dir), files
+
+
+@patch('ofs_skill.model_processing.list_of_files.utils')
+def test_fallback_false_returns_local_only(mock_utils, props, logger, tmp_path):
+    """use_s3_fallback=False with local files present -> local paths returned."""
+    mock_utils.Utils.return_value.read_config_section.return_value = {
+        'use_s3_fallback': 'False'
+    }
+    netcdf_dir, files = _local_files_in(tmp_path)
+
+    result = list_of_files(props, [netcdf_dir], logger)
+
+    assert len(result) == len(files)
+    for path in result:
+        assert path.startswith(netcdf_dir)
+        assert not path.startswith('http')
+    assert any('S3 fallback is disabled' in m for m in logger.infos)
+
+
+@patch('ofs_skill.model_processing.list_of_files.utils')
+@patch('ofs_skill.model_processing.list_of_files.construct_s3_url')
+def test_fallback_true_prefers_local(mock_construct_s3, mock_utils,
+                                     props, logger, tmp_path):
+    """use_s3_fallback=True with local files present -> local paths, S3 not invoked."""
+    mock_utils.Utils.return_value.read_config_section.return_value = {
+        'use_s3_fallback': 'True'
+    }
+    netcdf_dir, files = _local_files_in(tmp_path)
+
+    result = list_of_files(props, [netcdf_dir], logger)
+
+    assert len(result) == len(files)
+    for path in result:
+        # Local files exist, so even with fallback enabled they should be kept
+        assert os.path.isfile(path.replace('//', '/'))
+        assert not path.startswith('http')
+    # construct_s3_url is invoked only for missing files; none should be missing
+    assert mock_construct_s3.call_count == 0
+
+
+@patch('ofs_skill.model_processing.list_of_files.utils')
+@patch('ofs_skill.model_processing.list_of_files.construct_s3_url')
+@patch('ofs_skill.model_processing.list_of_files.construct_expected_files')
+def test_force_uses_nodd_even_when_local_present(mock_construct_expected,
+                                                  mock_construct_s3,
+                                                  mock_utils,
+                                                  props, logger, tmp_path):
+    """use_s3_fallback=force with local files present -> S3 URLs only."""
+    mock_utils.Utils.return_value.read_config_section.return_value = {
+        'use_s3_fallback': 'force'
+    }
+    netcdf_dir, files = _local_files_in(tmp_path)
+    expected_local_paths = [os.path.join(netcdf_dir, f).replace('\\', '/') for f in files]
+    mock_construct_expected.return_value = expected_local_paths
+
+    def fake_s3(local_path, prop, _logger):
+        # Mimic construct_s3_url: convert local path to a NODD URL
+        basename = os.path.basename(local_path.replace('//', '/'))
+        return f'https://noaa-nos-ofs-pds.s3.amazonaws.com/cbofs/netcdf/2024/09/01/{basename}'
+
+    mock_construct_s3.side_effect = fake_s3
+
+    result = list_of_files(props, [netcdf_dir], logger)
+
+    # construct_expected_files must be called instead of listdir
+    assert mock_construct_expected.call_count == 1
+    # Every returned entry must be an S3 URL, even though local copies exist
+    assert len(result) == len(files)
+    for path in result:
+        assert path.startswith('https://noaa-')
+        assert not os.path.isfile(path.replace('//', '/'))
+    # construct_s3_url called once per file
+    assert mock_construct_s3.call_count == len(files)
+    # Confirm the new log line fires
+    assert any('Forced NODD streaming' in m for m in logger.infos)
+
+
+@patch('ofs_skill.model_processing.list_of_files.utils')
+@patch('ofs_skill.model_processing.list_of_files.construct_s3_url')
+@patch('ofs_skill.model_processing.list_of_files.construct_expected_files')
+def test_force_value_is_case_insensitive(mock_construct_expected,
+                                         mock_construct_s3, mock_utils,
+                                         props, logger, tmp_path):
+    """'FORCE' and 'forced' should both trigger the forced-NODD path."""
+    mock_utils.Utils.return_value.read_config_section.return_value = {
+        'use_s3_fallback': 'FORCE'
+    }
+    netcdf_dir, files = _local_files_in(tmp_path)
+    mock_construct_expected.return_value = [
+        os.path.join(netcdf_dir, f).replace('\\', '/') for f in files
+    ]
+    mock_construct_s3.side_effect = (
+        lambda p, _prop, _lg:
+        f'https://noaa-nos-ofs-pds.s3.amazonaws.com/cbofs/netcdf/x/{os.path.basename(p)}'
+    )
+
+    result = list_of_files(props, [netcdf_dir], logger)
+
+    assert mock_construct_expected.called
+    assert all(r.startswith('https://noaa-') for r in result)
+
+
+@patch('ofs_skill.model_processing.list_of_files.utils')
+@patch('ofs_skill.model_processing.list_of_files.construct_expected_files')
+def test_loofs2_hindcast_disables_force(mock_construct_expected, mock_utils,
+                                         logger, tmp_path):
+    """loofs2 + hindcast guards: force never triggers construct_expected_files."""
+    mock_utils.Utils.return_value.read_config_section.return_value = {
+        'use_s3_fallback': 'force'
+    }
+    props_loofs2 = MockProps(ofs='loofs2', whichcast='hindcast',
+                             ofsfiletype='stations',
+                             startdate='2024090100', enddate='2024090123')
+    netcdf_dir = tmp_path / 'loofs2' / 'netcdf' / '2024' / '09' / '01'
+    netcdf_dir.mkdir(parents=True)
+    # Empty dir is fine here -- we only care that the force path isn't taken
+    try:
+        list_of_files(props_loofs2, [str(netcdf_dir)], logger)
+    except SystemExit:
+        # Empty dir with S3 disabled -> SystemExit is the documented behavior;
+        # the important assertion is below.
+        pass
+
+    # If force had remained active, construct_expected_files would have fired
+    # at the top of the per-directory loop. Loofs2-hindcast guard must clear it.
+    assert mock_construct_expected.call_count == 0


### PR DESCRIPTION
### Description of Changes
Closes #58. Promotes the existing `use_s3_fallback` setting in `conf/ofs_dps.conf.example` from a boolean to a tri-valued option so we can force NODD S3 streaming even when local model files are present. Motivation: NODD is now reliable enough that I want to validate runs against the canonical copy without renaming or moving local files first.

Accepted values:

| Value   | Behavior                                                                                 |
| ------- | ---------------------------------------------------------------------------------------- |
| `True`  | Prefer local model files; fall back to NODD S3 when local files are missing (default).   |
| `False` | Local model files only; error out if local files are missing.                            |
| `force` | Always read model files from the NODD S3 bucket, even when local copies exist (new).     |

`True` and `False` keep their existing semantics — this PR is additive.

Implementation lives entirely in `src/ofs_skill/model_processing/list_of_files.py`:
- The two existing config-read sites (in `list_of_dir` and `list_of_files`) now parse `use_s3_fallback` as a string and derive both a `use_s3_fallback` boolean and a `force_nodd_streaming` boolean.
- When forcing NODD, `list_of_dir` skips the local-existence / backup-dir checks and just emits the computed directory path as an S3-URL template.
- When forcing NODD, `list_of_files` short-circuits each directory's enumeration to `construct_expected_files(...)` and routes every file through `construct_s3_url(...)`, so the local presence check is bypassed.
- The existing loofs2/hindcast guard still disables S3 access entirely for that combination (force is also cleared).

### Expected Outcome of Changes
- Existing runs that set `use_s3_fallback=True` or `False` are byte-for-byte unchanged.
- Runs that set `use_s3_fallback=force` will issue NODD S3 reads for every model file, regardless of local cache state. Expect more S3 calls and corresponding NODD bandwidth.

### Developer Questions and Checklist
**Is this a high priority PR? If yes, why and is there a date by which it needs to be merged?**
No.

**Are there any changes needed to how the code should be run for operational runs? (Commands, flags, job timings, etc.)**
No. 

**Does this update need to be deployed for operational runs?**
No.

**Does this update require front end/web app changes? (If yes, provide documentation to Min)**
No.

**Does this impact code development work on adding SCHISM?**
No.

**Does this impact code development work on adding ADCIRC?**
No.

**Does this impact the expected number of output files for integration tests (i.e., will the integration test fail even though code changes result in desired change in outputs?)**
No.

- [x] Developer's name is removed throughout the code?
- [x] Did you add relevant labels to the PR?
- [x] Have you run pylint and is the code at an acceptable pylint score (>8)? `list_of_files.py` scores 8.89/10 (was 8.87/10, +0.02).
- [x] Jobs contain the appropriate file checking and handle errors for any missing data?
- [x] Is log free of critical ERRORs or WARNINGs? For errors that are not critical and can remain in code, is there sufficient handling and logging?

### Testing Instructions

**Unit tests**

```bash
pytest tests/force_nodd_streaming_test.py -v --no-cov
pytest tests/list_of_files_error_handling_test.py tests/list_of_files_forecast_a_cycle_test.py -v --no-cov
pytest tests/ --no-cov -q
```

Expect 5 new tests to pass, 16 existing `list_of_files_*` tests to remain green, and the full suite to come in at 574 passed / 1 skipped / 0 failed.

**End-to-end demo (each mode)**

Edit `conf/ofs_dps.conf` and set `use_s3_fallback` to each value in turn. For a quick smoke test, run a tiny 1D water-level call:

```bash
python ./bin/visualization/create_1dplot.py -o cbofs -p ./ -s 2025-11-20T00:00:00Z -e 2025-11-20T23:00:00Z -d MLLW -ws nowcast -t stations -vs water_level
```

Expected log signatures per mode:

- `use_s3_fallback=False` → `S3 fallback is disabled - using only local files`. Errors out if any local file is missing.
- `use_s3_fallback=True` (default) → `S3 fallback is enabled - checking for missing local files...` followed by either `All model files found locally, or are unavailable on the S3 bucket!` or `Using S3 URLs for N missing local files`.
- `use_s3_fallback=force` → `use_s3_fallback=force: constructing expected NODD file names for ...` per directory, then `use_s3_fallback=force - converting all model files to NODD S3 URLs...` and finally `Forced NODD streaming: using S3 URLs for N model files`. File list should consist entirely of `https://noaa-nos-ofs-pds.s3.amazonaws.com/...` URLs (or the equivalent NODD bucket for STOFS), and the local copies on disk must be ignored.

**Sanity checks**
- `force`, `FORCE`, and `forced` should all trigger the new path (case-insensitive).
- A loofs2 hindcast run with `use_s3_fallback=force` should still go local-only (loofs2/hindcast is not on NODD).

### Reminder checklist for PR reviewer
- [ ] Run PEP8 compliance tests to ensure the code follows best practices
- [ ] Check that documentation in the script is sufficient
- [ ] Validate the output values (if applicable) to make sure the calculations are correct and make scientific/physical sense; include a comment on the pull request including what validation you performed, for replicability.
- [ ] Test code both on Windows and Linux (and MacOS, if available), using several OFS as test cases
- [ ] **Test for all 'cast' options: forecast_a, forecast_b, and nowcast**
- [ ] When approving or commenting on a pull request, add information on the calls you use in case they need to be replicated or referenced.