### PR TITLE
Drop in-repo CHS_BASE_URL override now that searvey ships the fix

### DIFF
--- a/src/ofs_skill/obs_retrieval/inventory_chs_station.py
+++ b/src/ofs_skill/obs_retrieval/inventory_chs_station.py
@@ -12,12 +12,7 @@ from logging import Logger
 from typing import Optional
 
 import pandas as pd
-from searvey import _chs_api
 from searvey._chs_api import get_chs_stations
-
-# TEMP: CHS retired the old IWLS host (returns 301 to the line below); searvey
-# still hard-codes the old URL. Remove this override once upstream ships the fix.
-_chs_api.CHS_BASE_URL = 'https://api-iwls.dfo-mpo.gc.ca/api/v1'
 
 
 def inventory_chs_station(

--- a/src/ofs_skill/obs_retrieval/retrieve_chs_station.py
+++ b/src/ofs_skill/obs_retrieval/retrieve_chs_station.py
@@ -19,12 +19,7 @@ from logging import Logger
 from typing import Optional
 
 import pandas as pd
-from searvey import _chs_api
 from searvey._chs_api import fetch_chs_station
-
-# TEMP: CHS retired the old IWLS host (returns 301 to the line below); searvey
-# still hard-codes the old URL. Remove this override once upstream ships the fix.
-_chs_api.CHS_BASE_URL = 'https://api-iwls.dfo-mpo.gc.ca/api/v1'
 
 # CHS time series codes per variable, in priority order (try first, fallback)
 _SCALAR_CODE_MAP = {


### PR DESCRIPTION
### Description of Changes
PR #162 monkey-patched `searvey._chs_api.CHS_BASE_URL` from the two CHS modules as a stopgap after CHS retired the old IWLS host (`api.iwls-sine.azure.cloud-nuage.dfo-mpo.gc.ca` → 301 → `api-iwls.dfo-mpo.gc.ca`). [searvey PR #197](https://github.com/oceanmodeling/searvey/pull/197) (merged 2026-05-26) bumped `CHS_BASE_URL` to the new host and enabled redirect-following in `get_chs_stations` / `_fetch_chs_station_data`, so the override is now redundant.

This PR drops the two `_chs_api.CHS_BASE_URL = ...` blocks plus the now-unused `from searvey import _chs_api` imports in `inventory_chs_station.py` and `retrieve_chs_station.py`. No functional change — the URL is identical between the override and the upstream constant.

Labels: bug-fix, cleanup.

### Expected Outcome of Changes
CHS inventory and data retrieval continue to work identically. Removes a transient workaround so future searvey upgrades don't accidentally re-introduce drift between the in-repo constant and upstream.

### Developer Questions and Checklist
**Is this a high priority PR? If yes, why and is there a date by which it needs to be merged?**
No.

**Are there any changes needed to how the code should be run for operational runs? (Commands, flags, job timings, etc.)**
No.

**Does this update need to be deployed for operational runs?**
No — equivalent behavior. Should be picked up at the next planned merge to main.

**Does this update require front end/web app changes? (If yes, provide documentation to Min)**
No.

**Does this impact code development work on adding SCHISM?**
No.

**Does this impact code development work on adding ADCIRC?**
No.

**Does this impact the expected number of output files for integration tests (i.e., will the integration test fail even though code changes result in desired change in outputs?)**
No.

- [x] Developer's name is removed throughout the code?
- [x] Did you add relevant labels to the PR?
- [x] Have you run pylint and is the code at an acceptable pylint score (>8)? — 9.91/10 on the two modified files (only flag is a pre-existing `broad-exception-caught` from PR #162).
- [x] Jobs contain the appropriate file checking and handle errors for any missing data?
- [x] Is log free of critical ERRORs or WARNINGs? For errors that are not critical and can remain in code, is there sufficient handling and logging?

### Testing Instructions
1. Activate the env: `eval "$(~/miniforge3/bin/conda shell.bash hook)" && conda activate ofs_dps`
2. Confirm the installed searvey ships the fix:
   ```
   python -c "from searvey import _chs_api; print(_chs_api.CHS_BASE_URL)"
   # expected: https://api-iwls.dfo-mpo.gc.ca/api/v1
   ```
   If pinning to a tag rather than `master`, ensure searvey is at a revision that includes [oceanmodeling/searvey#197](https://github.com/oceanmodeling/searvey/pull/197). The current pin is `searvey @ git+https://github.com/oceanmodeling/searvey.git@master` in `pyproject.toml`, which picks the fix up automatically.
3. Run the CHS unit tests:
   ```
   pytest tests/chs_retrieval_test.py -q
   ```
   Expected: 22 passed.
4. Live smoke-test (Canadian Pacific coast — Sand Heads / Vancouver have continuous water-level data):
   ```python
   import logging
   logger = logging.getLogger('chs_smoketest')
   logging.basicConfig(level=logging.INFO)
   from ofs_skill.obs_retrieval.inventory_chs_station import inventory_chs_station
   from ofs_skill.obs_retrieval.retrieve_chs_station import retrieve_chs_station

   inv = inventory_chs_station(lat1=42.0, lat2=52.0, lon1=-130.0, lon2=-50.0, logger=logger)
   sid = inv[inv['has_wl']].iloc[2]['ID']  # Sand Heads, 5cebf1de3d0f4a073c4bb93c
   df = retrieve_chs_station(start_date='20260525', end_date='20260526',
                             id_number=sid, variable='water_level', logger=logger)
   print(len(df))  # expected: 1441 rows of 1-min water-level samples in IGLD
   ```
5. End-to-end via an OFS that hits CHS — Lake Ontario/Erie pipelines exercise CHS (e.g. loofs2, leofs). Run the 1D pipeline with whichcast `nowcast` for a recent date over a small window and confirm CHS-sourced stations are in the output `.ctl` files and timeseries plots.

### Reminder checklist for PR reviewer
- [ ] Run PEP8 compliance tests to ensure the code follows best practices
- [ ] Check that documentation in the script is sufficient
- [ ] Validate the output values (if applicable) to make sure the calculations are correct and make scientific/physical sense; include a comment on the pull request including what validation you performed, for replicability.
- [ ] Test code both on Windows and Linux (and MacOS, if available), using several OFS as test cases
- [ ] **Test for all 'cast' options: forecast_a, forecast_b, and nowcast**
- [ ] When approving or commenting on a pull request, add information on the calls you use in case they need to be replicated or referenced.