### PR TITLE
Create aggregated skill table

### DIFF
--- a/bin/visualization/create_1dplot.py
+++ b/bin/visualization/create_1dplot.py
@@ -66,6 +66,7 @@ Remarks:
 import argparse
 import copy
 import gc
+import glob
 import logging
 import logging.config
 import os
@@ -94,6 +95,88 @@ warnings.filterwarnings('ignore')
 
 def parameter_validation(prop, logger):
     """ Parameter validation """
+
+def get_variable_from_filename(filename):
+    """Determine the variable type based on keywords in the filename."""
+    name = filename.lower()
+    if 'water_level_hw' in name:
+        return 'Water Level high tide'
+    elif 'water_level_lw' in name:
+        return 'Water Level low tide'
+    elif 'water_level' in name:
+        return 'Water Level'
+    elif 'temperature' in name:
+        return 'Temperature'
+    elif 'currents_dir' in name:
+        return 'Current direction'
+    elif 'currents' in name:
+        return 'Current speed'
+    elif 'salinity' in name:
+        return 'Salinity'
+    else:
+        return 'Other'
+
+def get_forecast_type_from_filename(filename):
+    """Determine if the file is a nowcast or forecast based on the filename."""
+    name = filename.lower()
+    if 'nowcast' in name:
+        return 'Nowcast'
+    elif 'forecast' in name:
+        return 'Forecast'
+    else:
+        return 'Unknown'
+
+def combine_files_by_pattern(directory_path, output_filename, search_string=''):
+    """
+    Looks in a specified directory for files matching a custom search pattern,
+    extracts variable and forecast types, combines them into a single DataFrame,
+    and saves the result to a new CSV.
+    """
+    # Create a pattern that looks for the arbitrary string anywhere in the filename
+    search_pattern = f'*{search_string}*'
+    full_pattern = os.path.join(directory_path, search_pattern)
+    matched_files = glob.glob(full_pattern)
+
+    # ignore combined files AND exclude files with '2d' in their name
+    matched_files = [
+        f for f in matched_files
+        if 'combined' not in os.path.basename(f).lower()
+        and '2d' not in os.path.basename(f).lower()
+        and 'all' not in os.path.basename(f).lower()
+    ]
+
+    dataframes = []
+
+    for file in matched_files:
+        try:
+            # Read the file into a DataFrame
+            df = pd.read_csv(file)
+            filename = os.path.basename(file)
+
+            # Add metadata columns
+            df['source_file'] = filename
+            df['variable'] = get_variable_from_filename(filename)
+            df['type'] = get_forecast_type_from_filename(filename)
+
+            dataframes.append(df)
+            print(f"Loaded: {filename} -> {df['variable'].iloc[0]} ({df['type'].iloc[0]})")
+
+        except Exception as e:
+            print(f'Error reading {file}: {e}')
+
+    if not dataframes:
+        print(f"No files matching pattern '{search_pattern}' found in '{directory_path}'.")
+        return None
+
+    # Combine all DataFrames into one, ignoring the original indices
+    combined_df = pd.concat(dataframes, ignore_index=True)
+    combined_df = combined_df.reset_index(drop=True)
+
+    # Save the combined DataFrame to the specified output file
+    output_path = os.path.join(directory_path,output_filename)
+    combined_df.to_csv(output_path, index=False)
+    print(f"\nSuccessfully combined {len(dataframes)} files into '{output_filename}'")
+
 
 def ofs_ctlfile_read(prop, name_var, logger):
     '''
@@ -400,6 +483,10 @@ def create_1dplot_2nd_part(
     except FileNotFoundError:
         logger.error('Station ctl file not found.')
         sys.exit(-1)
+
+    # Take a second and combine all skill tables!
+    filename = f'{prop.ofs}_skill_all.csv'
+    combine_files_by_pattern(prop.data_skill_stats_path, filename, search_string=prop.ofs)
 
     # Ensure all paired data files exist before parallel dispatch.
     # get_skill() mutates prop and creates shared control files, so it

--- a/bin/visualization/create_1dplot.py
+++ b/bin/visualization/create_1dplot.py
@@ -485,7 +485,7 @@ def create_1dplot_2nd_part(
         sys.exit(-1)
 
     # Take a second and combine all skill tables!
-    filename = f'{prop.ofs}_skill_all.csv'
+    filename = f'skill_{prop.ofs}_all_stations.csv'
     combine_files_by_pattern(prop.data_skill_stats_path, filename, search_string=prop.ofs)
 
     # Ensure all paired data files exist before parallel dispatch.

--- a/bin/visualization/create_1dplot.py
+++ b/bin/visualization/create_1dplot.py
@@ -96,60 +96,94 @@ warnings.filterwarnings('ignore')
 def parameter_validation(prop, logger):
     """ Parameter validation """
 
+# Ordered (keyword, label) lookups for filename classification. Order
+# matters: more specific keywords (e.g. 'water_level_hw', 'forecast_a')
+# must precede their broader prefixes.
+_VARIABLE_KEYWORDS = (
+    ('water_level_hw', 'Water Level high tide'),
+    ('water_level_lw', 'Water Level low tide'),
+    ('water_level', 'Water Level'),
+    ('temperature', 'Temperature'),
+    ('currents_dir', 'Current direction'),
+    ('currents', 'Current speed'),
+    ('salinity', 'Salinity'),
+)
+
+_CAST_KEYWORDS = (
+    ('nowcast', 'Nowcast'),
+    ('forecast_a', 'Forecast (A)'),
+    ('forecast_b', 'Forecast (B)'),
+    ('forecast', 'Forecast'),
+    ('hindcast', 'Hindcast'),
+)
+
+
 def get_variable_from_filename(filename):
     """Determine the variable type based on keywords in the filename."""
     name = filename.lower()
-    if 'water_level_hw' in name:
-        return 'Water Level high tide'
-    elif 'water_level_lw' in name:
-        return 'Water Level low tide'
-    elif 'water_level' in name:
-        return 'Water Level'
-    elif 'temperature' in name:
-        return 'Temperature'
-    elif 'currents_dir' in name:
-        return 'Current direction'
-    elif 'currents' in name:
-        return 'Current speed'
-    elif 'salinity' in name:
-        return 'Salinity'
-    else:
-        return 'Other'
+    for keyword, label in _VARIABLE_KEYWORDS:
+        if keyword in name:
+            return label
+    return 'Other'
+
 
 def get_forecast_type_from_filename(filename):
-    """Determine if the file is a nowcast or forecast based on the filename."""
+    """Determine the cast type (nowcast/forecast_a/forecast_b/hindcast)
+    from keywords in the filename."""
     name = filename.lower()
-    if 'nowcast' in name:
-        return 'Nowcast'
-    elif 'forecast' in name:
-        return 'Forecast'
-    else:
-        return 'Unknown'
+    for keyword, label in _CAST_KEYWORDS:
+        if keyword in name:
+            return label
+    return 'Unknown'
 
-def combine_files_by_pattern(directory_path, output_filename, search_string=''):
-    """
-    Looks in a specified directory for files matching a custom search pattern,
-    extracts variable and forecast types, combines them into a single DataFrame,
-    and saves the result to a new CSV.
-    """
-    # Create a pattern that looks for the arbitrary string anywhere in the filename
-    search_pattern = f'*{search_string}*'
-    full_pattern = os.path.join(directory_path, search_pattern)
-    matched_files = glob.glob(full_pattern)
 
-    # ignore combined files AND exclude files with '2d' in their name
-    matched_files = [
-        f for f in matched_files
-        if 'combined' not in os.path.basename(f).lower()
-        and 'skill_2d' not in os.path.basename(f).lower()
-        and 'all' not in os.path.basename(f).lower()
-    ]
+def combine_files_by_pattern(directory_path, output_filename,
+                             search_string='', whichcasts=None, logger=None):
+    """Combine per-variable skill-stat CSVs into one aggregate table.
+
+    Searches ``directory_path`` for CSV files whose name contains
+    ``search_string`` (typically the OFS name), tags each row with the source
+    filename, variable, and cast type, concatenates them, and writes the
+    result to ``output_filename`` inside ``directory_path``.
+
+    Args:
+        directory_path: Directory holding the individual skill-stat CSVs.
+        output_filename: Name of the combined CSV to write (in
+            ``directory_path``).
+        search_string: Substring the candidate filenames must contain.
+        whichcasts: Optional iterable of cast names (e.g.
+            ``['nowcast', 'forecast_b']``). When provided, only files whose
+            name contains one of these casts are included, so stale files
+            from other casts are not swept in.
+        logger: Optional logger; falls back to the module logger.
+
+    Returns:
+        The combined ``pandas.DataFrame``, or ``None`` if no files matched.
+    """
+    log = logger or logging.getLogger(__name__)
+
+    # Match the search string anywhere in the basename. glob.escape guards
+    # against any glob metacharacters in the OFS name.
+    matched_files = glob.glob(
+        os.path.join(directory_path, f'*{glob.escape(search_string)}*'))
+
+    # Keep only individual skill tables for the requested cast(s): drop the
+    # aggregate output itself, 2D tables, and previously combined files so
+    # re-runs stay idempotent, then (optionally) restrict to the casts the
+    # current run produced so stale files from other casts aren't folded in.
+    casts = [c.lower() for c in whichcasts] if whichcasts else None
+
+    def _wanted(path):
+        base = os.path.basename(path).lower()
+        if ('combined' in base or 'skill_2d' in base
+                or base.endswith('_all_stations.csv')):
+            return False
+        return casts is None or any(c in base for c in casts)
 
     dataframes = []
-
-    for file in matched_files:
+    skipped = 0
+    for file in filter(_wanted, matched_files):
         try:
-            # Read the file into a DataFrame
             df = pd.read_csv(file)
             filename = os.path.basename(file)
 
@@ -159,23 +193,37 @@ def combine_files_by_pattern(directory_path, output_filename, search_string=''):
             df['type'] = get_forecast_type_from_filename(filename)
 
             dataframes.append(df)
-            print(f"Loaded: {filename} -> {df['variable'].iloc[0]} ({df['type'].iloc[0]})")
-
-        except Exception as e:
-            print(f'Error reading {file}: {e}')
+            log.info('Aggregating %s -> %s (%s)', filename,
+                     df['variable'].iloc[0], df['type'].iloc[0])
+        except (OSError, ValueError, pd.errors.ParserError) as err:
+            skipped += 1
+            log.warning('Skipping unreadable skill file %s: %s', file, err)
 
     if not dataframes:
-        print(f"No files matching pattern '{search_pattern}' found in '{directory_path}'.")
+        log.warning("No skill files matching '*%s*' found in '%s'.",
+                    search_string, directory_path)
         return None
 
-    # Combine all DataFrames into one, ignoring the original indices
+    # Combine all DataFrames into one, ignoring the original indices.
     combined_df = pd.concat(dataframes, ignore_index=True)
-    combined_df = combined_df.reset_index(drop=True)
 
-    # Save the combined DataFrame to the specified output file
-    output_path = os.path.join(directory_path,output_filename)
-    combined_df.to_csv(output_path, index=False)
-    print(f"\nSuccessfully combined {len(dataframes)} files into '{output_filename}'")
+    # Drop stale duplicate rows (same station, variable, and cast) that can
+    # linger from earlier runs; keep one copy per station/variable/cast.
+    dedup_keys = [c for c in ('ID', 'variable', 'type')
+                  if c in combined_df.columns]
+    if dedup_keys:
+        n_before = len(combined_df)
+        combined_df = combined_df.drop_duplicates(
+            subset=dedup_keys, keep='last').reset_index(drop=True)
+        if n_before != len(combined_df):
+            log.info('Dropped %d duplicate skill row(s) during aggregation.',
+                     n_before - len(combined_df))
+
+    combined_df.to_csv(
+        os.path.join(directory_path, output_filename), index=False)
+    log.info("Combined %d skill file(s) into '%s'%s.", len(dataframes),
+             output_filename, f' ({skipped} skipped)' if skipped else '')
+    return combined_df
 
 
 def ofs_ctlfile_read(prop, name_var, logger):
@@ -483,10 +531,6 @@ def create_1dplot_2nd_part(
     except FileNotFoundError:
         logger.error('Station ctl file not found.')
         sys.exit(-1)
-
-    # Take a second and combine all skill tables!
-    filename = f'skill_{prop.ofs}_all_stations.csv'
-    combine_files_by_pattern(prop.data_skill_stats_path, filename, search_string=prop.ofs)
 
     # Ensure all paired data files exist before parallel dispatch.
     # get_skill() mutates prop and creates shared control files, so it
@@ -1005,6 +1049,16 @@ def create_1dplot(prop, logger):
         # the model is loaded once and shared.
         for variable in prop.var_list:
             _plot_variable(variable, prop)
+
+    # Aggregate every per-variable skill table for this OFS into a single
+    # consolidated file. Runs once here, after all variables and casts have
+    # been processed, so the combined table is complete and written only once.
+    combine_files_by_pattern(
+        prop.data_skill_stats_path,
+        f'skill_{prop.ofs}_all_stations.csv',
+        search_string=prop.ofs,
+        whichcasts=getattr(prop, 'whichcasts', None),
+        logger=logger)
 
     return logger
 

--- a/bin/visualization/create_1dplot.py
+++ b/bin/visualization/create_1dplot.py
@@ -141,7 +141,7 @@ def combine_files_by_pattern(directory_path, output_filename, search_string=''):
     matched_files = [
         f for f in matched_files
         if 'combined' not in os.path.basename(f).lower()
-        and '2d' not in os.path.basename(f).lower()
+        and 'skill_2d' not in os.path.basename(f).lower()
         and 'all' not in os.path.basename(f).lower()
     ]
 

--- a/tests/combine_skill_tables_test.py
+++ b/tests/combine_skill_tables_test.py
@@ -1,0 +1,149 @@
+"""
+Tests for the aggregated skill-table helpers added for issue #148.
+
+Covers the three helpers in ``bin/visualization/create_1dplot.py``:
+``get_variable_from_filename``, ``get_forecast_type_from_filename``, and
+``combine_files_by_pattern``. The latter must:
+  * tag each row with source_file / variable / cast type,
+  * scope by OFS substring and (optionally) by the current run's casts,
+  * stay idempotent on re-runs (never re-ingest its own output),
+  * drop stale duplicate rows, and
+  * survive glob metacharacters in the search string.
+"""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+CREATE_1DPLOT_PATH = REPO_ROOT / 'bin' / 'visualization' / 'create_1dplot.py'
+
+
+@pytest.fixture(scope='module')
+def mod():
+    spec = importlib.util.spec_from_file_location(
+        'create_1dplot_combine_under_test', CREATE_1DPLOT_PATH)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.mark.parametrize('filename, expected', [
+    ('skill_cbofs_water_level_hw_nowcast_stations.csv', 'Water Level high tide'),
+    ('skill_cbofs_water_level_lw_nowcast_stations.csv', 'Water Level low tide'),
+    ('skill_cbofs_water_level_nowcast_stations.csv', 'Water Level'),
+    ('skill_cbofs_water_temperature_nowcast_stations.csv', 'Temperature'),
+    ('skill_cbofs_currents_dir_nowcast_stations.csv', 'Current direction'),
+    ('skill_cbofs_currents_nowcast_stations.csv', 'Current speed'),
+    ('skill_cbofs_salinity_nowcast_stations.csv', 'Salinity'),
+    ('skill_cbofs_mystery_nowcast_stations.csv', 'Other'),
+])
+def test_get_variable_from_filename(mod, filename, expected):
+    assert mod.get_variable_from_filename(filename) == expected
+
+
+@pytest.mark.parametrize('filename, expected', [
+    ('skill_cbofs_water_level_nowcast_stations.csv', 'Nowcast'),
+    ('skill_cbofs_water_level_forecast_a_stations.csv', 'Forecast (A)'),
+    ('skill_cbofs_water_level_forecast_b_stations.csv', 'Forecast (B)'),
+    ('skill_cbofs_water_level_forecast_stations.csv', 'Forecast'),
+    ('skill_cbofs_water_level_hindcast_stations.csv', 'Hindcast'),
+    ('skill_cbofs_water_level_stations.csv', 'Unknown'),
+])
+def test_get_forecast_type_from_filename(mod, filename, expected):
+    assert mod.get_forecast_type_from_filename(filename) == expected
+
+
+def _write_csv(path, ids):
+    pd.DataFrame({'ID': ids, 'rmse': [0.1] * len(ids)}).to_csv(path, index=False)
+
+
+def test_combine_basic_and_metadata(mod, tmp_path):
+    _write_csv(tmp_path / 'skill_cbofs_water_level_nowcast_stations.csv',
+               ['a', 'b'])
+    _write_csv(tmp_path / 'skill_cbofs_currents_nowcast_stations.csv',
+               ['c', 'd', 'e'])
+
+    out = mod.combine_files_by_pattern(
+        str(tmp_path), 'skill_cbofs_all_stations.csv', search_string='cbofs')
+
+    assert out is not None and len(out) == 5
+    assert {'source_file', 'variable', 'type'}.issubset(out.columns)
+    assert set(out['variable']) == {'Water Level', 'Current speed'}
+    assert set(out['type']) == {'Nowcast'}
+    assert (tmp_path / 'skill_cbofs_all_stations.csv').is_file()
+
+
+def test_combine_is_idempotent_on_rerun(mod, tmp_path):
+    """The aggregate output must never be folded back into itself."""
+    _write_csv(tmp_path / 'skill_cbofs_water_level_nowcast_stations.csv',
+               ['a', 'b'])
+
+    first = mod.combine_files_by_pattern(
+        str(tmp_path), 'skill_cbofs_all_stations.csv', search_string='cbofs')
+    second = mod.combine_files_by_pattern(
+        str(tmp_path), 'skill_cbofs_all_stations.csv', search_string='cbofs')
+
+    assert len(first) == len(second) == 2
+
+
+def test_combine_scopes_by_whichcast(mod, tmp_path):
+    _write_csv(tmp_path / 'skill_cbofs_water_level_nowcast_stations.csv',
+               ['a', 'b'])
+    _write_csv(tmp_path / 'skill_cbofs_water_level_forecast_b_stations.csv',
+               ['c'])
+
+    out = mod.combine_files_by_pattern(
+        str(tmp_path), 'skill_cbofs_all_stations.csv',
+        search_string='cbofs', whichcasts=['nowcast'])
+
+    assert len(out) == 2
+    assert set(out['type']) == {'Nowcast'}
+
+
+def test_combine_scopes_by_ofs(mod, tmp_path):
+    _write_csv(tmp_path / 'skill_cbofs_water_level_nowcast_stations.csv',
+               ['a', 'b'])
+    _write_csv(tmp_path / 'skill_sfbofs_water_level_nowcast_stations.csv',
+               ['x', 'y', 'z'])
+
+    out = mod.combine_files_by_pattern(
+        str(tmp_path), 'skill_cbofs_all_stations.csv', search_string='cbofs')
+
+    assert len(out) == 2
+    assert all('cbofs' in s for s in out['source_file'])
+
+
+def test_combine_drops_stale_duplicates(mod, tmp_path):
+    """Same station/variable/cast in two files collapses to one row."""
+    _write_csv(tmp_path / 'skill_cbofs_water_level_nowcast_stations.csv',
+               ['a', 'b'])
+    # A leftover/renamed file describing the same variable+cast for station 'a'.
+    _write_csv(tmp_path / 'skill_cbofs_water_level_nowcast_stations_old.csv',
+               ['a'])
+
+    out = mod.combine_files_by_pattern(
+        str(tmp_path), 'skill_cbofs_all_stations.csv', search_string='cbofs')
+
+    assert sorted(out['ID']) == ['a', 'b']
+
+
+def test_combine_no_match_returns_none(mod, tmp_path):
+    assert mod.combine_files_by_pattern(
+        str(tmp_path), 'skill_cbofs_all_stations.csv',
+        search_string='cbofs') is None
+
+
+def test_combine_handles_glob_metacharacters(mod, tmp_path):
+    """A search string with glob metachars must not raise or mis-match."""
+    _write_csv(tmp_path / 'skill_cbofs_water_level_nowcast_stations.csv',
+               ['a'])
+
+    out = mod.combine_files_by_pattern(
+        str(tmp_path), 'skill_cbofs_all_stations.csv', search_string='c*b[o]')
+
+    assert out is None  # literal 'c*b[o]' is not a substring of any file


### PR DESCRIPTION
### Description of Changes

Closes Issue #148.

This pull request adds functionality to automatically combine individual skill assessment statistic CSV files into unified consolidated files for each OFS. Three new helper functions are introduced to `bin/visualization/create_1dplot.py`:

1. **`get_variable_from_filename(filename)`** - Extracts the oceanographic variable type from filename keywords (Water Level, Temperature, Current speed/direction, Salinity)
2. **`get_forecast_type_from_filename(filename)`** - Determines whether a file contains Nowcast or Forecast data
3. **`combine_files_by_pattern(directory_path, output_filename, search_string='')`** - Searches a directory for matching CSV files, concatenates them into a single DataFrame with metadata columns, and saves the result

The `combine_files_by_pattern()` function:
- Uses glob pattern matching to find files in the skill statistics directory
- Automatically filters out combined files, 2D data, and duplicate 'all' files
- Adds three metadata columns: `source_file`, `variable`, and `type`
- Concatenates all matching DataFrames and saves to `skill_{OFS}_all_stations.csv`

### Expected Outcome of Changes

After running the skill assessment, users will find a new consolidated CSV file (`skill_{OFS}_all_stations.csv`) in the `data/skill/stats/` directory containing all skill metrics for that OFS aggregated from individual station files. This file includes metadata columns that identify:
- The source filename for each record
- The oceanographic variable (water level, temperature, currents, salinity)
- The forecast type (nowcast or forecast)

This eliminates the need for manual file consolidation and makes downstream analysis and data integration significantly easier. It also improves skill table handling for the front-end, and **will allow addition of new columns to the web app skill tables including high/low water extrema, current direction, and max duration of positive outliers.**

### Developer Questions and Checklist

**Is this a high priority PR? If yes, why and is there a date by which it needs to be merged?**

No, this is a non-breaking enhancement feature for convenience in data post-processing.

**Are there any changes needed to how the code should be run on the server? (Commands, flags, job timings, etc.)**

No changes to existing commands or flags. The feature runs automatically as part of the existing `create_1dplot.py` workflow.

**Does this update need to be installed on the server?**

Yes, the code changes need to be deployed so the consolidated output files are generated during routine skill assessment runs.

**Does this update require front end/web app changes? (If yes, provide documentation to Min)**

Yes, this update will produce an aggregated skill table that can be parsed to populate the web app skill tables. @KongMinGit @apruessner 

**Does this impact code development work on adding SCHISM? (If yes, tag Atieh)**

No impact.

**Does this impact code development work on adding ADCIRC?**

_No/Yes + tag Jack if yes_

No.

**Does this impact the expected number of output files for integration tests (i.e., will the integration test fail even though code changes result in desired change in the number of outputs?)**

Yes - this PR adds one new consolidated CSV file per OFS per skill assessment run. Integration tests should be updated to expect this additional output file.

- [x] Developer's name is removed throughout the code?
- [x] Did you add relevant labels to the PR?
- [x] Have you run pylint and is the code at an acceptable pylint score? (>8.0)
- [x] Jobs contain the appropriate file checking and handle errors for any missing data?
- [x] Is log free of critical ERRORs or WARNINGs? For errors that are not critical and can remain in code, is there sufficient handling and logging?

### Testing Instructions

1. Download skill tables for multiple different OFS and variables from the CO-OPS server, and save them in `./data/skill/stats/`

2. Run the skill assessment with standard parameters for a chosen OFS:
`python ./bin/visualization/create_1dplot.py -p ./ -o cbofs -s 2025-10-01T00:00:00Z -e 2025-10-02T00:00:00Z -d MLLW -ws nowcast,forecast_b`

3. Verify that the consolidated file is created for the OFS specified in step 2, and not for the other OFS for which you downloaded skill tables in step 1:
ls -la data/skill/stats/skill_cbofs_all_stations.csv

4. Validate consolidated file contents:
- Check that the file contains all records from individual station CSV files
- Verify metadata columns (source_file, variable, type) are properly populated
- Confirm variable names are correctly identified (Water Level, Temperature, Current speed, Current direction, Salinity)
- Confirm forecast types are correctly identified (Nowcast, Forecast)

5. Test across all three skill assessment modes, and combined modes (e.g., nowcast,forecast_b)

6. Verify no errors or warnings are logged during the consolidation process.