### PR TITLE
Track stations through skill assessment pipeline

### DIFF
--- a/bin/utils/check_pipeline.py
+++ b/bin/utils/check_pipeline.py
@@ -1,0 +1,398 @@
+import argparse
+import csv
+import os
+from pathlib import Path
+
+from ofs_skill.obs_retrieval import utils
+
+# ==========================================
+# CONFIGURATION
+# ==========================================
+
+HTML_VAR_MAP = {
+    'cu': 'currents',
+    'wl': 'water_level',
+    'temp': 'temperature',
+    'salt': 'salinity'
+}
+
+ALLOWED_WHICHCASTS = ['nowcast', 'forecast_b', 'forecast_a', 'hindcast']
+
+# ==========================================
+# VISUALIZATION FUNCTION
+# ==========================================
+
+def generate_visualizations(csv_file_path, home_dir, ofs):
+    """
+    Reads the pipeline summary CSV and generates combined heatmaps.
+    Each box is annotated with a symbol representing its data provider.
+
+    Grouping Rule:
+    - If total stations <= MAX_STATIONS_PER_PLOT, all providers are kept together in 1 file.
+    - If total stations > MAX_STATIONS_PER_PLOT, stations are grouped by provider.
+    - If an individual provider itself has > MAX_STATIONS_PER_PLOT stations, it is
+      sub-chunked into numbered parts (e.g., _usgs_pt_1, _usgs_pt_2).
+    """
+    try:
+        import matplotlib.pyplot as plt
+        import numpy as np
+        import pandas as pd
+        import seaborn as sns
+        from matplotlib.colors import ListedColormap
+    except ImportError:
+        print('\n[Visualization Skipped] Missing required libraries.')
+        print('To generate visualizations, install them using: pip install pandas matplotlib seaborn numpy')
+        return
+
+    print('\nGenerating visual heatmaps from CSV summary...')
+
+    df = pd.read_csv(csv_file_path)
+    if df.empty:
+        print('CSV is empty. No visualizations to generate.')
+        return
+
+    stages = [
+        '1_In_Inventory', '2_In_OBS_CTL', '3_OBS_Generated',
+        '4_In_Model_CTL', '5_PRD_Generated', '6_INT_Generated', '7_HTML_Generated'
+    ]
+
+    # Convert Yes/No strings to 1 (True/Green) and 0 (False/Red) for the heatmap
+    plot_df = df.copy()
+    for stage in stages:
+        plot_df[stage] = plot_df[stage].map({'Yes': 1, 'No': 0})
+
+    # Custom Red/Green colormap
+    cmap = ListedColormap(['#ff6666', '#66cc66'])
+
+    # Helper to clean and map provider text to an abbreviated single character symbol
+    def get_symbol(provider_name):
+        if pd.isna(provider_name) or not str(provider_name).strip():
+            return ''
+        p = str(provider_name).strip().upper()
+        if 'CO-OPS' in p:
+            return 'C'
+        elif 'NDBC' in p:
+            return 'N'
+        elif 'USGS' in p:
+            return 'U'
+        else:
+            return p[0] if p else ''
+
+    variables = plot_df['Variable'].unique()
+    MAX_STATIONS_PER_PLOT = 35
+
+    for var in variables:
+        var_df = plot_df[plot_df['Variable'] == var]
+        whichcasts = var_df['Whichcast'].unique()
+
+        # Get a sorted list of all unique stations for this variable
+        all_stations = sorted(var_df['Station_ID'].unique())
+
+        # -----------------------------------------------------------------
+        # STRATEGY: Determine chunking approach based on total station counts
+        # -----------------------------------------------------------------
+        if len(all_stations) <= MAX_STATIONS_PER_PLOT:
+            # Everything fits in one heatmap -> do not split
+            station_groups = [('combined', all_stations, '_combined')]
+        else:
+            # Too many stations -> group by station provider
+            station_to_prov = var_df.set_index('Station_ID')['Provider'].to_dict()
+            prov_map_groups = {}
+            for st in all_stations:
+                prov = station_to_prov.get(st, 'Unknown')
+                prov_map_groups.setdefault(prov, []).append(st)
+
+            station_groups = []
+            # Sort providers alphabetically for consistent tracking
+            for prov in sorted(prov_map_groups.keys()):
+                st_list = sorted(prov_map_groups[prov])
+                prov_clean = prov.lower().replace('-', '_').replace(' ', '_')
+
+                if len(st_list) <= MAX_STATIONS_PER_PLOT:
+                    # Provider stations fit inside a single image
+                    station_groups.append((prov, st_list, f'_{prov_clean}'))
+                else:
+                    # NEW: Provider stations exceed max limit -> sub-chunk into parts
+                    sub_chunks = [st_list[i:i + MAX_STATIONS_PER_PLOT] for i in range(0, len(st_list), MAX_STATIONS_PER_PLOT)]
+                    for idx, sub_chunk in enumerate(sub_chunks):
+                        display_name = f'{prov} (Part {idx + 1})'
+                        group_suffix = f'_{prov_clean}_pt_{idx + 1}'
+                        station_groups.append((display_name, sub_chunk, group_suffix))
+        # -----------------------------------------------------------------
+
+        for group_name, station_chunk, group_suffix in station_groups:
+            ncols = len(whichcasts)
+
+            # Sizing for layout height scales safely to fit the entire provider block
+            fig_height = max(6.5, len(station_chunk) * 0.45)
+            fig_width = max(6, ncols * 4.5) + 2
+
+            fig, axes = plt.subplots(nrows=1, ncols=ncols, sharey=True, figsize=(fig_width, fig_height))
+            if ncols == 1:
+                axes = [axes]
+
+            # Dynamically build a clean legend subtitle from present providers in this chunk
+            chunk_df = var_df[var_df['Station_ID'].isin(station_chunk)]
+            unique_provs = sorted([str(p).strip() for p in chunk_df['Provider'].dropna().unique() if str(p).strip()])
+            prov_legend_parts = [f'{get_symbol(p)} = {p}' for p in unique_provs if get_symbol(p)]
+            prov_legend_str = f"({', '.join(prov_legend_parts)})" if prov_legend_parts else ''
+
+            for i, wc in enumerate(whichcasts):
+                ax = axes[i]
+
+                wc_df = var_df[(var_df['Whichcast'] == wc) & (var_df['Station_ID'].isin(station_chunk))]
+                provider_map = var_df.set_index('Station_ID')['Provider'].to_dict()
+                wc_df = wc_df.set_index('Station_ID').reindex(station_chunk)[stages]
+
+                # Construct cell marking matrices
+                annot_df = pd.DataFrame('', index=wc_df.index, columns=wc_df.columns)
+                for st in wc_df.index:
+                    prov = provider_map.get(st, '')
+                    annot_df.loc[st] = get_symbol(prov)
+
+                # Draw Heatmap
+                sns.heatmap(
+                    wc_df,
+                    cmap=cmap,
+                    cbar=False,
+                    linewidths=0.5,
+                    linecolor='black',
+                    vmin=0, vmax=1,
+                    annot=annot_df,
+                    fmt='',
+                    annot_kws={'fontsize': 10, 'weight': 'bold', 'color': '#333333'},
+                    ax=ax
+                )
+
+                # Set to an ultra-tight pad of 4 to squeeze out empty white space
+                ax.set_title(f'{wc.upper()}', fontsize=12, pad=4)
+                ax.set_xlabel('')
+                ax.set_ylabel('')
+
+                # Configure structured tick labels
+                clean_labels = [s.replace('_', ' ') for s in stages]
+                ax.set_xticks(np.arange(len(stages)) + 0.5)
+                ax.set_xticklabels(clean_labels)
+                ax.tick_params(axis='x', top=True, labeltop=True, bottom=True, labelbottom=True)
+
+                for label in ax.get_xticklabels():
+                    label.set_rotation(45)
+                    if label.get_position()[1] > 0.5:
+                        label.set_ha('left')
+                    else:
+                        label.set_ha('right')
+
+                # Lock down Station IDs flat/horizontal
+                for label in ax.get_yticklabels():
+                    label.set_rotation(0)
+                    label.set_va('center')
+
+            # Customize main title text depending on whether it is split or combined
+            if len(station_groups) > 1:
+                title_text = f'Pipeline Tracking: {ofs.upper()} | Variable: {var} | Provider: {group_name}\n{prov_legend_str}'
+            else:
+                title_text = f'Pipeline Tracking: {ofs.upper()} | Variable: {var}\n{prov_legend_str}'
+
+            fig.suptitle(title_text, fontsize=16, y=0.99)
+            axes[0].set_ylabel('Station ID', fontsize=12)
+
+            plt.tight_layout()
+
+            # Format output filename dynamically based on the group suffix
+            out_file = Path(home_dir) / f'pipeline_viz_{ofs}_{var}{group_suffix}.png'
+
+            plt.savefig(out_file, dpi=150, bbox_inches='tight')
+            plt.close()
+
+            print(f'  -> Saved visualization: {out_file.name}')
+
+
+# ==========================================
+# MAIN SCRIPT
+# ==========================================
+
+def main(args):
+    ofs = args.OFS.lower()
+    var_selection = args.Var_Selection.lower()
+    conf_path = args.config.lower()
+
+    raw_wc_str = ' '.join(args.Whichcasts)
+    clean_wc_str = raw_wc_str.replace('[', ' ').replace(']', ' ').replace(',', ' ')
+    parsed_whichcasts = [wc.strip().lower() for wc in clean_wc_str.split() if wc.strip()]
+
+    target_whichcasts = []
+    for wc in parsed_whichcasts:
+        if wc not in ALLOWED_WHICHCASTS:
+            print(f"Error: Invalid whichcast '{wc}'. Allowed choices are: {', '.join(ALLOWED_WHICHCASTS)}")
+            raise SystemExit
+        if wc not in target_whichcasts:
+            target_whichcasts.append(wc)
+
+    if not target_whichcasts:
+        print(f"Error: No valid whichcasts provided. Allowed choices are: {', '.join(ALLOWED_WHICHCASTS)}")
+        raise SystemExit
+
+    if var_selection == 'all':
+        target_vars = ['cu', 'wl', 'temp', 'salt']
+    else:
+        target_vars = [var_selection]
+
+    home_dir = Path(args.Path)
+    try:
+        dir_params = utils.Utils(os.path.join(home_dir, conf_path)).read_config_section('directories', None)
+    except FileNotFoundError:
+        print('No configuration file found! Please check the path.')
+        raise SystemExit
+
+    dir_ctl = Path(os.path.join(home_dir, dir_params['control_files_dir']))
+    dir_obs = Path(os.path.join(home_dir, dir_params['data_dir'], dir_params['observations_dir'], dir_params['1d_station_dir'], ))
+    dir_prd = Path(os.path.join(home_dir, dir_params['data_dir'], dir_params['model_dir'], dir_params['1d_node_dir'], ))
+    dir_int = Path(os.path.join(home_dir, dir_params['data_dir'], dir_params['skill_dir'], dir_params['1d_pair_dir'], ))
+    dir_html = Path(os.path.join(home_dir, dir_params['data_dir'], dir_params['visual_dir'], ))
+
+    output_csv = Path(os.path.join(home_dir, f'pipeline_summary_{ofs}_{var_selection}.csv'))
+
+    def get_filenames(dir_path, ext):
+        if not dir_path.exists():
+            print(f'  -> Warning: Directory {dir_path} does not exist.')
+            return []
+        return [f.name.lower() for f in dir_path.glob(f'*{ext}')]
+
+    print('Pre-fetching directory file lists...')
+    obs_files = get_filenames(dir_obs, '.obs')
+    prd_files = get_filenames(dir_prd, '.prd')
+    int_files = get_filenames(dir_int, '.int')
+    html_files = get_filenames(dir_html, '.html')
+
+    all_csv_rows = []
+
+    for var in target_vars:
+        print(f'\n================ Processing Variable: {var.upper()} ================')
+        stations_tracker = {}
+        html_var_term = HTML_VAR_MAP.get(var, var)
+
+        inv_filename = f'inventory_all_{ofs}.csv'
+        inv_path = Path(os.path.join(dir_ctl, inv_filename))
+
+        if not Path(inv_path).exists():
+            print(f'Error: Inventory file {inv_path} not found. Skipping {var} baseline.')
+            continue
+
+        print(f'Reading baseline from {inv_path}...')
+        with open(inv_path) as f:
+            reader = csv.DictReader(f)
+            var_flag_column = f'has_{var}'
+
+            for row in reader:
+                station_id = row.get('ID', '').strip().lower()
+                if not station_id:
+                    continue
+
+                if var_flag_column in row and row[var_flag_column].strip().upper() != 'TRUE':
+                    continue
+
+                # UPDATED: Capturing data source 'Source' key as 'provider'
+                stations_tracker[station_id] = {
+                    'inv': True,
+                    'obs_ctl': False,
+                    'mod_ctl': False,
+                    'provider': row.get('Source', 'Unknown').strip()
+                }
+
+        if not stations_tracker:
+            print(f"No valid stations found for variable '{var}' in the inventory. Skipping.")
+            continue
+
+        print(f'Tracking {len(stations_tracker)} baseline station(s) for {var}.')
+
+        obs_ctl_path = Path(os.path.join(dir_ctl, f'{ofs}_{var}_station.ctl'))
+        mod_ctl_path = Path(os.path.join(dir_ctl, f'{ofs}_{var}_model_station.ctl'))
+
+        obs_ctl_content = ''
+        if obs_ctl_path.exists():
+            with open(obs_ctl_path) as f:
+                obs_ctl_content = f.read().lower()
+
+        mod_ctl_content = ''
+        if mod_ctl_path.exists():
+            with open(mod_ctl_path) as f:
+                mod_ctl_content = f.read().lower()
+        else:
+            mod_ctl_path = Path(os.path.join(dir_ctl, f'{ofs}_{var}_model.ctl'))
+            if mod_ctl_path.exists():
+                with open(mod_ctl_path) as f:
+                    mod_ctl_content = f.read().lower()
+
+        for st_id in sorted(stations_tracker.keys()):
+            if st_id in obs_ctl_content:
+                stations_tracker[st_id]['obs_ctl'] = True
+            if st_id in mod_ctl_content:
+                stations_tracker[st_id]['mod_ctl'] = True
+
+            s = stations_tracker[st_id]
+
+            for wc in target_whichcasts:
+                req_obs = [st_id, ofs, var]
+                req_prd_int = [st_id, ofs, var, wc]
+                req_html = [st_id, ofs, html_var_term, wc]
+
+                obs_found = any(all(term in fname for term in req_obs) for fname in obs_files)
+                prd_found = any(all(term in fname for term in req_prd_int) for fname in prd_files)
+                int_found = any(all(term in fname for term in req_prd_int) for fname in int_files)
+                html_found = any(all(term in fname for term in req_html) for fname in html_files)
+
+                # UPDATED: Included 'Provider' key into output rows mapping
+                all_csv_rows.append({
+                    'Station_ID': st_id,
+                    'Variable': html_var_term,
+                    'Whichcast': wc,
+                    'Provider': s.get('provider', 'Unknown'),
+                    '1_In_Inventory': 'Yes' if s['inv'] else 'No',
+                    '2_In_OBS_CTL': 'Yes' if s['obs_ctl'] else 'No',
+                    '3_OBS_Generated': 'Yes' if obs_found else 'No',
+                    '4_In_Model_CTL': 'Yes' if s['mod_ctl'] else 'No',
+                    '5_PRD_Generated': 'Yes' if prd_found else 'No',
+                    '6_INT_Generated': 'Yes' if int_found else 'No',
+                    '7_HTML_Generated': 'Yes' if html_found else 'No'
+                })
+
+    if not all_csv_rows:
+        print('\nNo data was processed. Exiting without writing CSV.')
+        return
+
+    print(f'\nWriting summary to {output_csv}...')
+    # UPDATED: Included 'Provider' column in header fieldnames
+    fieldnames = [
+        'Station_ID', 'Variable', 'Whichcast', 'Provider',
+        '1_In_Inventory', '2_In_OBS_CTL', '3_OBS_Generated',
+        '4_In_Model_CTL', '5_PRD_Generated', '6_INT_Generated', '7_HTML_Generated'
+    ]
+
+    def write_csv(csv_path):
+        with open(csv_path, mode='w', newline='') as csv_file:
+            writer = csv.DictWriter(csv_file, fieldnames=fieldnames)
+            writer.writeheader()
+            writer.writerows(all_csv_rows)
+        return csv_path
+
+    final_csv_path = None
+    try:
+        final_csv_path = write_csv(output_csv)
+    except PermissionError:
+        output_csv_fallback = Path(os.path.join(home_dir, f'pipeline_summary_{ofs}_{var_selection}_2.csv'))
+        print(f'Permission denied for {output_csv}. Trying {output_csv_fallback}...')
+        final_csv_path = write_csv(output_csv_fallback)
+
+    generate_visualizations(final_csv_path, home_dir, ofs)
+    print('Pipeline check complete!')
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Track station processing through the entire 7-stage OFS pipeline.')
+    parser.add_argument('--OFS', '-o', type=str, required=True, help="Name of the Operational Forecast System (e.g., 'necofs').")
+    parser.add_argument('--Var_Selection', '-vs', type=str, required=True, choices=['cu', 'wl', 'temp', 'salt', 'all'], help='Variable type to search for.')
+    parser.add_argument('--Whichcasts', '-ws', type=str, nargs='+', required=True, help='Whichcast type(s) to search for.')
+    parser.add_argument('--Path', '-p', type=str, default='.', help='Path to the home directory.')
+    parser.add_argument('-c', '--config', type=str, default='conf/ofs_dps.conf', help='Path to configuration file.')
+
+    parsed_args = parser.parse_args()
+    main(parsed_args)

--- a/bin/utils/check_pipeline.py
+++ b/bin/utils/check_pipeline.py
@@ -1,3 +1,49 @@
+"""OFS Data Processing Pipeline Tracking and Visualization Utility.
+
+This script audits and tracks the progression of physical oceanographic and
+meteorological station data through a linear $7$-stage processing pipeline
+within an Operational Forecast System (OFS). It validates baseline inventory
+existence against configured control files and directory assets, outputs a
+structured summary matrix in CSV format, and generates highly optimized,
+dual-axis heatmap charts.
+
+Pipeline Developmental Stages:
+    1. **In Inventory**: Station is registered in the baseline inventory and
+       configured to monitor the given parameter.
+    2. **In OBS CTL**: Station is successfully declared in the observation
+       control file (`.ctl`).
+    3. **OBS Generated**: The raw observation file (`.obs`) has been pulled
+       and written to disk.
+    4. **In Model CTL**: Station is declared in the numerical model's
+       control file.
+    5. **PRD Generated**: The model prediction file (`.prd`) has been successfully
+       simulated and written.
+    6. **INT Generated**: The interpolated paired file (`.int`) mapping observation
+       to model grids has been successfully built.
+    7. **HTML Generated**: The final localized web-visualization product (`.html`)
+       is complete.
+
+Visual Chunking & Provider Grouping Rules:
+    - **Combined Mode**: If the cumulative unique stations for a variable is $\le 40$,
+      all observation data sources are consolidated into one unified master chart
+      (`_combined.png`).
+    - **Provider Split Mode**: If total stations exceed $40$, the script groups
+      stations strictly by data provider (e.g., `CO-OPS`, `NDBC`, `USGS`),
+      generating separate layout charts per supplier.
+    - **Deep Sub-Chunking**: If a single provider's underlying station list itself
+      exceeds $40$ rows, it is sub-divided into cleanly numbered multi-part files
+      (e.g., `_usgs_pt_1.png`, `_usgs_pt_2.png`).
+
+Dependencies:
+    - Standard Library: `os`, `csv`, `argparse`, `pathlib`
+    - Data Processing: `pandas`, `numpy`
+    - Visualization: `matplotlib`, `seaborn`
+    - Internal Domain: `ofs_skill.obs_retrieval.utils`
+
+Author: PWL
+Date: June 2026
+"""
+
 import argparse
 import csv
 import os
@@ -23,15 +69,52 @@ ALLOWED_WHICHCASTS = ['nowcast', 'forecast_b', 'forecast_a', 'hindcast']
 # ==========================================
 
 def generate_visualizations(csv_file_path, home_dir, ofs):
-    """
-    Reads the pipeline summary CSV and generates combined heatmaps.
-    Each box is annotated with a symbol representing its data provider.
+    """Reads the pipeline summary CSV and generates ultra-tight, side-by-side heatmaps.
 
-    Grouping Rule:
-    - If total stations <= MAX_STATIONS_PER_PLOT, all providers are kept together in 1 file.
-    - If total stations > MAX_STATIONS_PER_PLOT, stations are grouped by provider.
-    - If an individual provider itself has > MAX_STATIONS_PER_PLOT stations, it is
-      sub-chunked into numbered parts (e.g., _usgs_pt_1, _usgs_pt_2).
+    This function processes pipeline completion statuses across $7$ linear tracking
+    stages for every monitored variable and forecast type (whichcast). Each grid
+    cell represents a stage's completion status (Green/True for completed, Red/False
+    for missing) and is explicitly annotated with a bold, single-character indicator
+    denoting its original data provider (e.g., 'C' for CO-OPS, 'U' for USGS, 'N' for NDBC).
+
+    To preserve high visual fidelity and text readability:
+    1. **Adaptive Chunking Strategy**: If the total station count for a variable is
+       $\le 40$, all providers are bundled together into a single master plot file
+       (`_combined.png`). If the station count exceeds $40$, the function pivots to
+       group stations strictly by their data provider, outputting one file per source.
+    2. **Deep Sub-chunking**: If a single data provider's internal station count
+       exceeds $40$, it is sub-divided into numbered chronological files (e.g.,
+       `_usgs_pt_1.png`, `_usgs_pt_2.png`).
+    3. **Anti-Squishing Layout**: The vertical dimensions are automatically scaled
+       with a floor constraint of $6.5$ inches. This prevents sparse station selections
+       from flattening when squeezed by the top and bottom text margins.
+    4. **Dual X-Axis Layout**: Structural tick marks and stage names are mirrored
+       identically across both the top and bottom of the heatmap frame. Top labels are
+       automatically offset and aligned up-and-away from the grid to maintain space.
+    5. **Ultra-Tight Compression**: Spacing parameters (`pad=4` and `y=0.99`) are
+       tightened to squeeze out blank white space between titles, labels, and figures.
+
+    Args:
+        csv_file_path (str or pathlib.Path): Path to the generated CSV matrix output
+            containing the $7$-stage pipeline boolean data for all stations.
+        home_dir (str or pathlib.Path): Root or target destination directory where
+            the finalized visualization image assets will be compiled and written.
+        ofs (str): Name of the operational forecast system being audited
+            (e.g., 'cbofs', 'dbofs', 'necofs').
+
+    Returns:
+        None: Saves generated high-resolution ($150$ DPI) PNG visualization charts
+        directly into the target `home_dir`.
+
+    Raises:
+        ImportError: Raised and caught internally if any dependency (`pandas`,
+            `matplotlib`, `seaborn`, or `numpy`) is missing from the environment,
+            safely skipping visual generation without killing execution flow.
+
+    File Output Naming Conventions:
+        - Small Network:   `pipeline_viz_{ofs}_{variable}_combined.png`
+        - Segmented Group: `pipeline_viz_{ofs}_{variable}_{provider_name}.png`
+        - Split Part:      `pipeline_viz_{ofs}_{variable}_{provider_name}_pt_{part_number}.png`
     """
     try:
         import matplotlib.pyplot as plt

--- a/bin/utils/check_pipeline.py
+++ b/bin/utils/check_pipeline.py
@@ -1,7 +1,7 @@
 """OFS Data Processing Pipeline Tracking and Visualization Utility.
 
 This script audits and tracks the progression of physical oceanographic and
-meteorological station data through a linear $7$-stage processing pipeline
+meteorological station data through a linear 7-stage processing pipeline
 within an Operational Forecast System (OFS). It validates baseline inventory
 existence against configured control files and directory assets, outputs a
 structured summary matrix in CSV format, and generates highly optimized,
@@ -23,16 +23,16 @@ Pipeline Developmental Stages:
     7. **HTML Generated**: The final localized web-visualization product (`.html`)
        is complete.
 
-Visual Chunking & Provider Grouping Rules:
-    - **Combined Mode**: If the cumulative unique stations for a variable is $\le 40$,
-      all observation data sources are consolidated into one unified master chart
-      (`_combined.png`).
-    - **Provider Split Mode**: If total stations exceed $40$, the script groups
-      stations strictly by data provider (e.g., `CO-OPS`, `NDBC`, `USGS`),
+Visual Chunking & Provider Grouping Rules (threshold = MAX_STATIONS_PER_PLOT):
+    - **Combined Mode**: If the cumulative unique stations for a variable is at or
+      below the threshold, all observation data sources are consolidated into one
+      unified master chart (`_combined.png`).
+    - **Provider Split Mode**: If total stations exceed the threshold, the script
+      groups stations strictly by data provider (e.g., `CO-OPS`, `NDBC`, `USGS`),
       generating separate layout charts per supplier.
     - **Deep Sub-Chunking**: If a single provider's underlying station list itself
-      exceeds $40$ rows, it is sub-divided into cleanly numbered multi-part files
-      (e.g., `_usgs_pt_1.png`, `_usgs_pt_2.png`).
+      exceeds the threshold, it is sub-divided into cleanly numbered multi-part
+      files (e.g., `_usgs_pt_1.png`, `_usgs_pt_2.png`).
 
 Dependencies:
     - Standard Library: `os`, `csv`, `argparse`, `pathlib`
@@ -64,6 +64,10 @@ HTML_VAR_MAP = {
 
 ALLOWED_WHICHCASTS = ['nowcast', 'forecast_b', 'forecast_a', 'hindcast']
 
+# Maximum stations rendered in a single heatmap before the layout splits by
+# provider and, if still too dense, sub-chunks a provider into numbered parts.
+MAX_STATIONS_PER_PLOT = 35
+
 # ==========================================
 # VISUALIZATION FUNCTION
 # ==========================================
@@ -71,7 +75,7 @@ ALLOWED_WHICHCASTS = ['nowcast', 'forecast_b', 'forecast_a', 'hindcast']
 def generate_visualizations(csv_file_path, home_dir, ofs):
     """Reads the pipeline summary CSV and generates ultra-tight, side-by-side heatmaps.
 
-    This function processes pipeline completion statuses across $7$ linear tracking
+    This function processes pipeline completion statuses across 7 linear tracking
     stages for every monitored variable and forecast type (whichcast). Each grid
     cell represents a stage's completion status (Green/True for completed, Red/False
     for missing) and is explicitly annotated with a bold, single-character indicator
@@ -79,14 +83,15 @@ def generate_visualizations(csv_file_path, home_dir, ofs):
 
     To preserve high visual fidelity and text readability:
     1. **Adaptive Chunking Strategy**: If the total station count for a variable is
-       $\le 40$, all providers are bundled together into a single master plot file
-       (`_combined.png`). If the station count exceeds $40$, the function pivots to
-       group stations strictly by their data provider, outputting one file per source.
+       at or below MAX_STATIONS_PER_PLOT, all providers are bundled together into a
+       single master plot file (`_combined.png`). If the station count exceeds the
+       threshold, the function pivots to group stations strictly by their data
+       provider, outputting one file per source.
     2. **Deep Sub-chunking**: If a single data provider's internal station count
-       exceeds $40$, it is sub-divided into numbered chronological files (e.g.,
+       exceeds MAX_STATIONS_PER_PLOT, it is sub-divided into numbered files (e.g.,
        `_usgs_pt_1.png`, `_usgs_pt_2.png`).
     3. **Anti-Squishing Layout**: The vertical dimensions are automatically scaled
-       with a floor constraint of $6.5$ inches. This prevents sparse station selections
+       with a floor constraint of 6.5 inches. This prevents sparse station selections
        from flattening when squeezed by the top and bottom text margins.
     4. **Dual X-Axis Layout**: Structural tick marks and stage names are mirrored
        identically across both the top and bottom of the heatmap frame. Top labels are
@@ -96,14 +101,14 @@ def generate_visualizations(csv_file_path, home_dir, ofs):
 
     Args:
         csv_file_path (str or pathlib.Path): Path to the generated CSV matrix output
-            containing the $7$-stage pipeline boolean data for all stations.
+            containing the 7-stage pipeline boolean data for all stations.
         home_dir (str or pathlib.Path): Root or target destination directory where
             the finalized visualization image assets will be compiled and written.
         ofs (str): Name of the operational forecast system being audited
             (e.g., 'cbofs', 'dbofs', 'necofs').
 
     Returns:
-        None: Saves generated high-resolution ($150$ DPI) PNG visualization charts
+        None: Saves generated high-resolution (150 DPI) PNG visualization charts
         directly into the target `home_dir`.
 
     Raises:
@@ -124,7 +129,8 @@ def generate_visualizations(csv_file_path, home_dir, ofs):
         from matplotlib.colors import ListedColormap
     except ImportError:
         print('\n[Visualization Skipped] Missing required libraries.')
-        print('To generate visualizations, install them using: pip install pandas matplotlib seaborn numpy')
+        print('To generate visualizations, install them using: '
+              'pip install pandas matplotlib seaborn numpy')
         return
 
     print('\nGenerating visual heatmaps from CSV summary...')
@@ -154,15 +160,13 @@ def generate_visualizations(csv_file_path, home_dir, ofs):
         p = str(provider_name).strip().upper()
         if 'CO-OPS' in p:
             return 'C'
-        elif 'NDBC' in p:
+        if 'NDBC' in p:
             return 'N'
-        elif 'USGS' in p:
+        if 'USGS' in p:
             return 'U'
-        else:
-            return p[0] if p else ''
+        return p[0] if p else ''
 
     variables = plot_df['Variable'].unique()
-    MAX_STATIONS_PER_PLOT = 35
 
     for var in variables:
         var_df = plot_df[plot_df['Variable'] == var]
@@ -196,7 +200,9 @@ def generate_visualizations(csv_file_path, home_dir, ofs):
                     station_groups.append((prov, st_list, f'_{prov_clean}'))
                 else:
                     # NEW: Provider stations exceed max limit -> sub-chunk into parts
-                    sub_chunks = [st_list[i:i + MAX_STATIONS_PER_PLOT] for i in range(0, len(st_list), MAX_STATIONS_PER_PLOT)]
+                    sub_chunks = [
+                        st_list[i:i + MAX_STATIONS_PER_PLOT]
+                        for i in range(0, len(st_list), MAX_STATIONS_PER_PLOT)]
                     for idx, sub_chunk in enumerate(sub_chunks):
                         display_name = f'{prov} (Part {idx + 1})'
                         group_suffix = f'_{prov_clean}_pt_{idx + 1}'
@@ -210,21 +216,28 @@ def generate_visualizations(csv_file_path, home_dir, ofs):
             fig_height = max(6.5, len(station_chunk) * 0.45)
             fig_width = max(6, ncols * 4.5) + 2
 
-            fig, axes = plt.subplots(nrows=1, ncols=ncols, sharey=True, figsize=(fig_width, fig_height))
+            fig, axes = plt.subplots(
+                nrows=1, ncols=ncols, sharey=True,
+                figsize=(fig_width, fig_height))
             if ncols == 1:
                 axes = [axes]
 
             # Dynamically build a clean legend subtitle from present providers in this chunk
             chunk_df = var_df[var_df['Station_ID'].isin(station_chunk)]
-            unique_provs = sorted([str(p).strip() for p in chunk_df['Provider'].dropna().unique() if str(p).strip()])
+            unique_provs = sorted(
+                {str(p).strip() for p in chunk_df['Provider'].dropna().unique()
+                 if str(p).strip()})
             prov_legend_parts = [f'{get_symbol(p)} = {p}' for p in unique_provs if get_symbol(p)]
             prov_legend_str = f"({', '.join(prov_legend_parts)})" if prov_legend_parts else ''
+
+            # Station -> provider lookup is identical across whichcasts; build once
+            provider_map = var_df.set_index('Station_ID')['Provider'].to_dict()
 
             for i, wc in enumerate(whichcasts):
                 ax = axes[i]
 
-                wc_df = var_df[(var_df['Whichcast'] == wc) & (var_df['Station_ID'].isin(station_chunk))]
-                provider_map = var_df.set_index('Station_ID')['Provider'].to_dict()
+                wc_df = var_df[(var_df['Whichcast'] == wc)
+                               & (var_df['Station_ID'].isin(station_chunk))]
                 wc_df = wc_df.set_index('Station_ID').reindex(station_chunk)[stages]
 
                 # Construct cell marking matrices
@@ -272,9 +285,11 @@ def generate_visualizations(csv_file_path, home_dir, ofs):
 
             # Customize main title text depending on whether it is split or combined
             if len(station_groups) > 1:
-                title_text = f'Pipeline Tracking: {ofs.upper()} | Variable: {var} | Provider: {group_name}\n{prov_legend_str}'
+                title_text = (f'Pipeline Tracking: {ofs.upper()} | Variable: {var} '
+                              f'| Provider: {group_name}\n{prov_legend_str}')
             else:
-                title_text = f'Pipeline Tracking: {ofs.upper()} | Variable: {var}\n{prov_legend_str}'
+                title_text = (f'Pipeline Tracking: {ofs.upper()} | Variable: {var}'
+                              f'\n{prov_legend_str}')
 
             fig.suptitle(title_text, fontsize=16, y=0.99)
             axes[0].set_ylabel('Station ID', fontsize=12)
@@ -297,7 +312,8 @@ def generate_visualizations(csv_file_path, home_dir, ofs):
 def main(args):
     ofs = args.OFS.lower()
     var_selection = args.Var_Selection.lower()
-    conf_path = args.config.lower()
+    # Do not lowercase the config path: filesystem paths are case-sensitive on Linux.
+    conf_path = args.config
 
     raw_wc_str = ' '.join(args.Whichcasts)
     clean_wc_str = raw_wc_str.replace('[', ' ').replace(']', ' ').replace(',', ' ')
@@ -306,14 +322,16 @@ def main(args):
     target_whichcasts = []
     for wc in parsed_whichcasts:
         if wc not in ALLOWED_WHICHCASTS:
-            print(f"Error: Invalid whichcast '{wc}'. Allowed choices are: {', '.join(ALLOWED_WHICHCASTS)}")
-            raise SystemExit
+            print(f"Error: Invalid whichcast '{wc}'. Allowed choices are: "
+                  f"{', '.join(ALLOWED_WHICHCASTS)}")
+            raise SystemExit(1)
         if wc not in target_whichcasts:
             target_whichcasts.append(wc)
 
     if not target_whichcasts:
-        print(f"Error: No valid whichcasts provided. Allowed choices are: {', '.join(ALLOWED_WHICHCASTS)}")
-        raise SystemExit
+        print(f"Error: No valid whichcasts provided. Allowed choices are: "
+              f"{', '.join(ALLOWED_WHICHCASTS)}")
+        raise SystemExit(1)
 
     if var_selection == 'all':
         target_vars = ['cu', 'wl', 'temp', 'salt']
@@ -322,15 +340,23 @@ def main(args):
 
     home_dir = Path(args.Path)
     try:
-        dir_params = utils.Utils(os.path.join(home_dir, conf_path)).read_config_section('directories', None)
-    except FileNotFoundError:
+        dir_params = utils.Utils(
+            os.path.join(home_dir, conf_path)
+        ).read_config_section('directories', None)
+    except FileNotFoundError as exc:
         print('No configuration file found! Please check the path.')
-        raise SystemExit
+        raise SystemExit(1) from exc
 
     dir_ctl = Path(os.path.join(home_dir, dir_params['control_files_dir']))
-    dir_obs = Path(os.path.join(home_dir, dir_params['data_dir'], dir_params['observations_dir'], dir_params['1d_station_dir'], ))
-    dir_prd = Path(os.path.join(home_dir, dir_params['data_dir'], dir_params['model_dir'], dir_params['1d_node_dir'], ))
-    dir_int = Path(os.path.join(home_dir, dir_params['data_dir'], dir_params['skill_dir'], dir_params['1d_pair_dir'], ))
+    dir_obs = Path(os.path.join(
+        home_dir, dir_params['data_dir'], dir_params['observations_dir'],
+        dir_params['1d_station_dir']))
+    dir_prd = Path(os.path.join(
+        home_dir, dir_params['data_dir'], dir_params['model_dir'],
+        dir_params['1d_node_dir']))
+    dir_int = Path(os.path.join(
+        home_dir, dir_params['data_dir'], dir_params['skill_dir'],
+        dir_params['1d_pair_dir']))
     dir_html = Path(os.path.join(home_dir, dir_params['data_dir'], dir_params['visual_dir'], ))
 
     output_csv = Path(os.path.join(home_dir, f'pipeline_summary_{ofs}_{var_selection}.csv'))
@@ -406,6 +432,12 @@ def main(args):
                 with open(mod_ctl_path) as f:
                     mod_ctl_content = f.read().lower()
 
+        # NOTE: stage detection below relies on substring matching (station ID is a
+        # substring of the .ctl content / output filename). This deliberately lets a
+        # base station match its per-bin ADCP files (e.g. 'cb0402' -> 'cb0402_b01...'),
+        # but it is approximate: a station ID that is itself a substring of a longer ID
+        # can register a false positive. The tool is an at-a-glance auditor, not an
+        # exact-match validator.
         for st_id in sorted(stations_tracker.keys()):
             if st_id in obs_ctl_content:
                 stations_tracker[st_id]['obs_ctl'] = True
@@ -419,10 +451,14 @@ def main(args):
                 req_prd_int = [st_id, ofs, var, wc]
                 req_html = [st_id, ofs, html_var_term, wc]
 
-                obs_found = any(all(term in fname for term in req_obs) for fname in obs_files)
-                prd_found = any(all(term in fname for term in req_prd_int) for fname in prd_files)
-                int_found = any(all(term in fname for term in req_prd_int) for fname in int_files)
-                html_found = any(all(term in fname for term in req_html) for fname in html_files)
+                obs_found = any(
+                    all(term in fname for term in req_obs) for fname in obs_files)
+                prd_found = any(
+                    all(term in fname for term in req_prd_int) for fname in prd_files)
+                int_found = any(
+                    all(term in fname for term in req_prd_int) for fname in int_files)
+                html_found = any(
+                    all(term in fname for term in req_html) for fname in html_files)
 
                 # UPDATED: Included 'Provider' key into output rows mapping
                 all_csv_rows.append({
@@ -462,7 +498,8 @@ def main(args):
     try:
         final_csv_path = write_csv(output_csv)
     except PermissionError:
-        output_csv_fallback = Path(os.path.join(home_dir, f'pipeline_summary_{ofs}_{var_selection}_2.csv'))
+        output_csv_fallback = Path(os.path.join(
+            home_dir, f'pipeline_summary_{ofs}_{var_selection}_2.csv'))
         print(f'Permission denied for {output_csv}. Trying {output_csv_fallback}...')
         final_csv_path = write_csv(output_csv_fallback)
 
@@ -470,12 +507,24 @@ def main(args):
     print('Pipeline check complete!')
 
 if __name__ == '__main__':
-    parser = argparse.ArgumentParser(description='Track station processing through the entire 7-stage OFS pipeline.')
-    parser.add_argument('--OFS', '-o', type=str, required=True, help="Name of the Operational Forecast System (e.g., 'necofs').")
-    parser.add_argument('--Var_Selection', '-vs', type=str, required=True, choices=['cu', 'wl', 'temp', 'salt', 'all'], help='Variable type to search for.')
-    parser.add_argument('--Whichcasts', '-ws', type=str, nargs='+', required=True, help='Whichcast type(s) to search for.')
-    parser.add_argument('--Path', '-p', type=str, default='.', help='Path to the home directory.')
-    parser.add_argument('-c', '--config', type=str, default='conf/ofs_dps.conf', help='Path to configuration file.')
+    parser = argparse.ArgumentParser(
+        description='Track station processing through the entire 7-stage OFS pipeline.')
+    parser.add_argument(
+        '--OFS', '-o', type=str, required=True,
+        help="Name of the Operational Forecast System (e.g., 'necofs').")
+    parser.add_argument(
+        '--Var_Selection', '-vs', type=str, required=True,
+        choices=['cu', 'wl', 'temp', 'salt', 'all'],
+        help='Variable type to search for.')
+    parser.add_argument(
+        '--Whichcasts', '-ws', type=str, nargs='+', required=True,
+        help='Whichcast type(s) to search for.')
+    parser.add_argument(
+        '--Path', '-p', type=str, default='.',
+        help='Path to the home directory.')
+    parser.add_argument(
+        '-c', '--config', type=str, default='conf/ofs_dps.conf',
+        help='Path to configuration file.')
 
     parsed_args = parser.parse_args()
     main(parsed_args)

--- a/src/ofs_skill/visualization/plotting_vector.py
+++ b/src/ofs_skill/visualization/plotting_vector.py
@@ -213,6 +213,10 @@ def oned_vector_plot1(
                        + ' ' + name.split('.')[1] if isinstance(name, str) else '' \
                        for name in list(now_fores_paired[i].filename)]
             hovertemplate = f"{seriesname.split(' ')[1]}: %{{y:.2f}}<br><i>Model cycle: %{{text}}<i><extra></extra>"
+        except ValueError:
+            namekey = [name.split('.')[1] if isinstance(name, str) else '' \
+                       for name in list(now_fores_paired[i].filename)]
+            hovertemplate = f"{seriesname.split(' ')[1]}: %{{y:.2f}}<br><i>Model cycle: %{{text}}<i><extra></extra>"
         except AttributeError:
             logger.error('No hoverinfo filenames available!')
             hovertemplate='%{y:.2f}'
@@ -296,6 +300,10 @@ def oned_vector_plot1(
         try:
             namekey = [datetime.strftime(datetime.strptime(name.split('.')[2], '%Y%m%d'), '%m-%d-%Y')\
                        + ' ' + name.split('.')[1] if isinstance(name, str) else '' \
+                       for name in list(now_fores_paired[i].filename)]
+            hovertemplate = f"{seriesname.split(' ')[1]}: %{{y:.2f}}<br><i>Model cycle: %{{text}}<i><extra></extra>"
+        except ValueError:
+            namekey = [name.split('.')[1] if isinstance(name, str) else '' \
                        for name in list(now_fores_paired[i].filename)]
             hovertemplate = f"{seriesname.split(' ')[1]}: %{{y:.2f}}<br><i>Model cycle: %{{text}}<i><extra></extra>"
         except AttributeError:


### PR DESCRIPTION
## Description of Changes

This pull request introduces a utility for tracking stations through the skill assessment processing pipeline. It enables quick visual identification of processing bottlenecks or missing data after a skill assessment run. The new program verifies which stations listed in the OFS inventory file propagate through to the different output stages of a skill assessment run. For each station listed in the inventory file, the program checks if the station is present in the following output stages:

   - Stage 1: In Inventory file
   - Stage 2: In OBS CTL (observation control file)
   - Stage 3: OBS Generated (raw observation file)
   - Stage 4: In Model CTL (numerical model control file)
   - Stage 5: PRD Generated (model prediction file)
   - Stage 6: INT Generated (interpolated paired file)
   - Stage 7: HTML Generated (web-visualization product)
 
After checking each station, a summary CSV and heatmap plots are produced. 

<img width="780" height="1459" alt="pipeline_viz_cbofs_currents_combined" src="https://github.com/user-attachments/assets/b1de3f6d-20ba-4000-b523-3a7735f66890" />


The specific changes include:

1. **New Pipeline Tracking Utility** (`bin/utils/check_pipeline.py`):
   - Creates a new module that audits and tracks station ouput through a linear 7-stage processing pipeline
   - Validates baseline inventory existence against configured control files and directory assets
   - Generates structured CSV summary matrices documenting pipeline completion status for all monitored stations
   - Produces heatmap visualizations showing pipeline progression for all stations grouped by station provider and variable type

The new pipeline tracking utility can be invoked as follows:

`python bin/utils/check_pipeline.py --OFS <ofs_name> --Var_Selection <cu|wl|temp|salt|all> --Whichcasts <nowcast|forecast_b|forecast_a|hindcast> [--Path <home_dir>] [--config <config_path>]`

Required arguments:
- `--OFS` or `-o`: Name of the Operational Forecast System (e.g., 'cbofs', 'dbofs', 'necofs')
- `--Var_Selection` or `-vs`: Variable type to track (cu, wl, temp, salt, or all)
- `--Whichcasts` or `-ws`: One or more forecast cast types (nowcast, forecast_b, forecast_a, hindcast)

Optional arguments:
- `--Path` or `-p`: Path to home directory (default: current directory)
- `--config` or `-c`: Path to configuration file (default: conf/ofs_dps.conf)

Output files:
- CSV summary: `pipeline_summary_{ofs}_{var_selection}.csv`
- Visualizations: `pipeline_viz_{ofs}_{variable}_[combined|provider_name|provider_name_pt_#].png`
`

## Expected Outcome of Changes

- Users can now audit and track station data progression through the entire OFS pipeline in one comprehensive tool
- CSV output provides structured status matrix for all stations across all variables and forecast types
- Enhanced error handling in plotting prevents pipeline failures due to filename parsing issues
- Supports all forecast cast types: `nowcast`, `forecast_b`, `forecast_a`, and `hindcast`

## Developer Questions and Checklist

### Is this a high priority PR? If yes, why and is there a date by which it needs to be merged?

No, low priority.

### Are there any changes needed to how the code should be run on the server? (Commands, flags, job timings, etc.)

No.

### Does this update need to be installed on the server?

Yes.

### Does this update require front end/web app changes? (If yes, provide documentation to Min)

No, this is a backend utility for internal pipeline auditing and monitoring.

### Does this impact code development work on adding SCHISM? (If yes, tag Atieh)

No.

### Does this impact code development work on adding ADCIRC?

_No/Yes + tag Jack if yes_

No.

### Does this impact the expected number of output files for integration tests (i.e., will the integration test fail even though code changes result in desired change in the number of outputs)?

The new module generates additional CSV and PNG files for pipeline visualization, but these are auxiliary outputs. Integration tests should not be impacted if they only track core pipeline output files (.obs, .prd, .int, .html). The bug fix in `plotting_vector.py` improves robustness but does not change output file counts.

### Checklist

- [x] Developer's name is removed throughout the code?
- [x] Did you add relevant labels to the PR?
- [x] Have you run pylint and is the code at an acceptable pylint score? (>8.0)
- [x] Jobs contain the appropriate file checking and handle errors for any missing data?
- [x] Is log free of critical ERRORs or WARNINGs? For errors that are not critical and can remain in code, is there sufficient handling and logging?

## Testing Instructions

1. Run the package for a chosen OFS using all variables, all station providers, and nowcast + forecast_b.

2. Verify the pipeline tracking utility:
`
python bin/utils/check_pipeline.py --OFS necofs --Var_Selection all --Whichcasts nowcast forecast_a forecast_b --Path /path/to.home/dir/
`

3. **Output Validation**:
   - Verify CSV file is generated at expected location with correct headers and data
   - Check that all station IDs from inventory are present in output
   - Validate Yes/No values correctly reflect pipeline stage completion

4. **Visualization Testing**:

🚨Note --> if the number of stations for a given variable is >35, the stations will be grouped by station provider and split into spearate .png files, one plot for each provider. If the number of stations is <35, all station providers will be combined into one plot.

   - Confirm PNG files are generated for each variable/provider combination
   - Verify heatmap colors (green for Yes/completed, red for No/missing)
   - Check provider symbols are correctly annotated (C, N, U)
   - Validate text readability and layout for both small (<35 stations) and large (>35 stations) datasets

6. **Test with Multiple Whichcasts**:
   - Test with each cast type individually: `nowcast`, `forecast_a`, `forecast_b`
   - Test with multiple casts combined: `--Whichcasts nowcast,forecast_b`
   - Test with `all` variable selection to verify all four variables (cu, wl, temp, salt)

7. **Error Handling**:
   - Test with missing configuration file
   - Test with non-existent directory paths
   - Test with invalid whichcast or variable options

## Reminder checklist for PR reviewer:

- [ ] Run PEP8 compliance tests to ensure the code follows best practices
- [ ] Check that documentation in the script is sufficient
- [ ] Validate the output values (if applicable) to make sure the calculations are correct and make scientific/physical sense; include a comment on the pull request including what validation you performed, for replicability.
- [ ] Test code both locally and on the linux server, using several OFS as test cases
- [ ] **Test for all 'cast' options: forecast_a, forecast_b, and nowcast**
- [ ] When approving or commenting on a pull request, add information on the calls you use in case they need to be replicated.