### PR TITLE
refactor(gui): Phase 2 foundation refactor - GUI helpers, tests, GuiParams, labeled sections

### DIFF
--- a/src/ofs_skill/visualization/create_gui.py
+++ b/src/ofs_skill/visualization/create_gui.py
@@ -517,8 +517,8 @@ def create_gui(parser):
                             orient=tk.HORIZONTAL, length=100)
     e_hour_scale.grid(row=1, column=2, sticky='w', padx=padx, pady=pady)
 
-    # === Whichcast & Forecast ========================================
-    wcast_frame = _section('Whichcast & Forecast')
+    # === Whichcasts & Model Cycles ========================================
+    wcast_frame = _section('Whichcasts & Model Cycles')
     wcast_frame.grid(row=section_row, column=0, columnspan=4,
                      sticky='ew', padx=10, pady=5)
     section_row += 1
@@ -562,8 +562,8 @@ def create_gui(parser):
     )
     cycle_chosen.grid(row=2, column=1, sticky='w', padx=padx, pady=pady)
 
-    # === Datum & Output ==============================================
-    datum_frame = _section('Datum & Output')
+    # === Datums & OFS File Type ==============================================
+    datum_frame = _section('Datums & OFS File Type')
     datum_frame.grid(row=section_row, column=0, columnspan=4,
                      sticky='ew', padx=10, pady=5)
     section_row += 1
@@ -591,8 +591,8 @@ def create_gui(parser):
                     value='fields').grid(row=1, column=2, sticky='w',
                                          padx=padx, pady=pady)
 
-    # === Stations & Variables ========================================
-    sv_frame = _section('Stations & Variables')
+    # === Station Providers & Variables ========================================
+    sv_frame = _section('Station Providers & Variables')
     sv_frame.grid(row=section_row, column=0, columnspan=4,
                   sticky='ew', padx=10, pady=5)
     section_row += 1

--- a/src/ofs_skill/visualization/create_gui.py
+++ b/src/ofs_skill/visualization/create_gui.py
@@ -3,21 +3,32 @@ Created on Wed Nov 12 08:39:35 2025
 
 @author: PWL
 """
+from __future__ import annotations
+
 import logging
 import os
 import sys
 import tkinter as tk
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta
 from tkinter import filedialog, messagebox, ttk
 from tkinter.font import Font
 from types import SimpleNamespace
-
-from tkcalendar import DateEntry as _TkDateEntry
 
 from ofs_skill.model_processing.get_fcst_cycle import get_fcst_hours
 
 # Import from ofs_skill package
 from ofs_skill.obs_retrieval import utils
+from ofs_skill.visualization.gui_helpers import (
+    DateEntry,
+    build_utc_datetime,
+    compute_recent_cycle,
+    format_date,
+    quick_run_datum,
+    read_datum_list,
+    validate_date_order,
+    validate_horizon_requires_stations,
+    validate_start_not_future,
+)
 
 # UI sentinel strings — used in multiple places, must match exactly.
 _OFS_PLACEHOLDER = 'Select an OFS...'
@@ -25,141 +36,6 @@ _OFS_FIRST_PLACEHOLDER = 'Select an OFS first...'
 _DATUM_PLACEHOLDER = 'Select a datum...'
 _MOST_RECENT_LABEL = 'Most recent cycle available'
 _WINDOW_GEOMETRY = '850x500'
-
-# Datum fallback if conf cannot be read.
-_DEFAULT_DATUMS = (
-    'MHHW', 'MHW', 'MLLW', 'MLW', 'NAVD88', 'IGLD85', 'LWD', 'XGEOID20B'
-)
-
-# Per-OFS Quick Run datum defaults. Great Lakes use IGLD85; STOFS systems
-# don't have a uniform tidal datum so fall back to NAVD88; tidal coastal
-# OFSes use MLLW.
-_GREAT_LAKES_OFS = ('leofs', 'lmhofs', 'loofs', 'loofs2', 'lsofs')
-_STOFS_OFS = ('stofs_2d_glo', 'stofs_3d_atl', 'stofs_3d_pac')
-
-
-class DateEntry(_TkDateEntry):
-    """Drop-in replacement for ``tkcalendar.DateEntry`` with cross-platform
-    calendar-popup fixes."""
-
-    _CAL_COLOR_DEFAULTS = {
-        'normalbackground':     'white',
-        'normalforeground':     'black',
-        'selectbackground':     '#1a73e8',
-        'selectforeground':     'white',
-        'weekendbackground':    '#f0f0f0',
-        'weekendforeground':    'black',
-        'headersbackground':    '#e0e0e0',
-        'headersforeground':    'black',
-        'othermonthbackground': '#fafafa',
-        'othermonthforeground': 'gray50',
-        'bordercolor':          'gray60',
-    }
-
-    # Grace period (ms) after opening during which a transient FocusOut on
-    # the calendar is ignored. Prevents the popup from immediately closing
-    # when the platform briefly redirects focus while mapping the window.
-    _FOCUS_GRACE_MS = 200
-
-    def __init__(self, master=None, **kw):
-        for key, value in self._CAL_COLOR_DEFAULTS.items():
-            kw.setdefault(key, value)
-        super().__init__(master, **kw)
-        self._drop_down_time = 0
-        if sys.platform == 'darwin':
-            try:
-                self._top_cal.overrideredirect(False)
-            except (tk.TclError, AttributeError):
-                pass
-
-    def drop_down(self):
-        self._drop_down_time = self.winfo_toplevel().tk.call('clock', 'milliseconds')
-        super().drop_down()
-        try:
-            top = self._top_cal
-            if not top.winfo_ismapped():
-                return
-            top.update_idletasks()
-            top.update()
-            top.lift()
-            if sys.platform != 'darwin':
-                top.attributes('-topmost', True)
-        except (tk.TclError, AttributeError):
-            pass
-
-    def _on_focus_out_cal(self, event):
-        """Ignore transient FocusOut events fired right after the popup
-        opens, before the user has had a chance to interact with it."""
-        now = self.winfo_toplevel().tk.call('clock', 'milliseconds')
-        elapsed = now - self._drop_down_time
-        if elapsed < self._FOCUS_GRACE_MS:
-            self._calendar.focus_set()
-            return
-        super()._on_focus_out_cal(event)
-
-
-def _quick_run_datum(ofs):
-    """Return a sensible default datum for the given OFS in Quick Run mode."""
-    if ofs in _GREAT_LAKES_OFS:
-        return 'IGLD85'
-    if ofs in _STOFS_OFS:
-        return 'NAVD88'
-    return 'MLLW'
-
-
-def _compute_recent_cycle(ofs):
-    """Compute the most recent forecast cycle that should be available.
-
-    Returns
-    -------
-    (start_iso, forecast_hr) : tuple of str
-        ``start_iso`` is YYYY-MM-DDTHH:MM:SSZ at the chosen cycle, and
-        ``forecast_hr`` is the cycle as ``'06z'`` etc. Allows a 2h delay
-        for file arrival on NODD before considering a cycle "available".
-    """
-    _, fcstcycles = get_fcst_hours(ofs)
-    cycles = sorted(int(c) for c in fcstcycles)
-    now_utc = datetime.now(timezone.utc).replace(
-        minute=0, second=0, microsecond=0
-    )
-    cutoff = now_utc - timedelta(hours=2)
-    today = now_utc.replace(hour=0)
-    chosen = None
-    for offset_days in (0, 1):
-        day = today - timedelta(days=offset_days)
-        for hr in reversed(cycles):
-            cyc_dt = day.replace(hour=hr)
-            if cyc_dt <= cutoff:
-                chosen = cyc_dt
-                break
-        if chosen is not None:
-            break
-    if chosen is None:
-        chosen = today.replace(hour=cycles[-1]) - timedelta(days=1)
-    return (
-        chosen.strftime('%Y-%m-%dT%H:%M:%SZ'),
-        f'{chosen.hour:02d}z',
-    )
-
-
-def _read_datum_list():
-    """Read [datums] datum_list from conf, falling back to a hardcoded list.
-
-    The shared ``read_config_section`` helper logs via the logger argument
-    on failure; we pass a real logger so a missing section doesn't crash
-    the GUI on launch.
-    """
-    log = logging.getLogger(__name__)
-    try:
-        section = utils.Utils(None).read_config_section('datums', log)
-        raw = section.get('datum_list')
-        if raw:
-            return tuple(raw.split())
-    except (KeyError, AttributeError, OSError):
-        log.warning(
-            'Could not read [datums] from conf; falling back to defaults.'
-        )
-    return _DEFAULT_DATUMS
 
 
 def create_gui(parser):
@@ -187,7 +63,7 @@ def create_gui(parser):
             return
 
         ofs = ofs_entry.get()
-        start_iso, forecast_hr = _compute_recent_cycle(ofs)
+        start_iso, forecast_hr = compute_recent_cycle(ofs)
         end_iso = (
             datetime.strptime(start_iso, '%Y-%m-%dT%H:%M:%SZ')
             + timedelta(hours=24)
@@ -199,7 +75,7 @@ def create_gui(parser):
         args_values.Forecast_Hr = forecast_hr
         args_values.StartDate_full = start_iso
         args_values.EndDate_full = end_iso
-        args_values.Datum = _quick_run_datum(ofs)
+        args_values.Datum = quick_run_datum(ofs)
         args_values.FileType = 'stations'
         args_values.Station_Owner = ['co-ops', 'ndbc', 'usgs']
         args_values.Var_Selection = [
@@ -217,21 +93,23 @@ def create_gui(parser):
         # First check for required arguments and display error if not present
         error = None
 
-        # Build UTC-aware datetimes once for the date-ordering / future
-        # checks so comparisons are unambiguous.
-        start_date = start_entry.get_date()
-        end_date = end_entry.get_date()
-        try:
-            start_dt = datetime(
-                start_date.year, start_date.month, start_date.day,
-                int(s_hour_scale.get()), tzinfo=timezone.utc,
-            ) if start_date else None
-            end_dt = datetime(
-                end_date.year, end_date.month, end_date.day,
-                int(e_hour_scale.get()), tzinfo=timezone.utc,
-            ) if end_date else None
-        except (TypeError, ValueError):
-            start_dt = end_dt = None
+        # Normalised UTC-aware datetimes for ordering / future checks.
+        start_dt = build_utc_datetime(
+            start_entry.get_date(), s_hour_scale.get()
+        )
+        end_dt = build_utc_datetime(
+            end_entry.get_date(), e_hour_scale.get()
+        )
+
+        # Validators that are pure-logic predicates live in gui_helpers;
+        # they return an error string (or None) which the caller surfaces.
+        pure_validator_msg = (
+            validate_date_order(start_dt, end_dt)
+            or validate_start_not_future(start_dt)
+            or validate_horizon_requires_stations(
+                horizon_var.get(), filetype_var.get()
+            )
+        )
 
         if directory_path_var.get() is None:
             messagebox.showerror('Error', 'Please select your home directory.')
@@ -250,18 +128,6 @@ def create_gui(parser):
             error = 1
         elif not end_entry.get_date():
             messagebox.showerror('Error', 'Please enter an end date.')
-            error = 1
-        elif start_dt is not None and end_dt is not None and start_dt >= end_dt:
-            messagebox.showerror(
-                'Error', 'Start date/hour must be before end date/hour.'
-            )
-            error = 1
-        elif (start_dt is not None
-              and start_dt > datetime.now(timezone.utc)):
-            messagebox.showerror(
-                'Error',
-                'Start date/hour cannot be in the future (UTC).'
-            )
             error = 1
         elif (var_now.get() == '0' and var_fore.get() == '0'
               and var_forea.get() == '0' and var_hind.get() == '0'):
@@ -283,14 +149,8 @@ def create_gui(parser):
                 'Error', 'Please select at least one variable to assess.'
             )
             error = 1
-        elif horizon_var.get() and filetype_var.get() != 'stations':
-            messagebox.showerror(
-                'Error',
-                '"Assess all forecast horizons?" is only supported with '
-                'the "Station" model output file type. Either change the '
-                'file type to Station, or set "Assess all forecast '
-                'horizons?" to No.'
-            )
+        elif pure_validator_msg is not None:
+            messagebox.showerror('Error', pure_validator_msg)
             error = 1
 
         args_values.Path = directory_path_var.get()
@@ -338,13 +198,6 @@ def create_gui(parser):
 
         if error is None:
             root.destroy() # Close the GUI window
-
-    def format_date(date, hour):
-        # DateEntry.get_date() returns a datetime.date object
-        from datetime import date as date_type
-        if isinstance(date, date_type):
-            return f"{date.strftime('%Y-%m-%d')}T{int(hour):02d}:00:00Z"
-        raise TypeError(f'Expected date object, got {type(date)}: {date}')
 
     def browse_directory():
         '''
@@ -475,7 +328,7 @@ def create_gui(parser):
     except (KeyError, tk.TclError, OSError):
         log.info('GUI logo not found; defaulting to tkinter logo.')
 
-    datum_list = _read_datum_list()
+    datum_list = read_datum_list()
 
     # Window-wide colors, text, and stuff
     anchor='e'

--- a/src/ofs_skill/visualization/create_gui.py
+++ b/src/ofs_skill/visualization/create_gui.py
@@ -12,7 +12,6 @@ import tkinter as tk
 from datetime import datetime, timedelta
 from tkinter import filedialog, messagebox, ttk
 from tkinter.font import Font
-from types import SimpleNamespace
 
 from ofs_skill.model_processing.get_fcst_cycle import get_fcst_hours
 
@@ -20,6 +19,7 @@ from ofs_skill.model_processing.get_fcst_cycle import get_fcst_hours
 from ofs_skill.obs_retrieval import utils
 from ofs_skill.visualization.gui_helpers import (
     DateEntry,
+    GuiParams,
     build_utc_datetime,
     compute_recent_cycle,
     format_date,
@@ -393,64 +393,55 @@ def create_gui(parser):
     # Set font for drop-downs
     root.option_add('*TCombobox*Listbox*Font',
                     Font(family='Helvetica', size=12))
-    # Set default argument values
-    args_values = SimpleNamespace() # To store the values from GUI
-    args_values.OFS = None
-    args_values.Path = None
-    args_values.StartDate_full = None
-    args_values.EndDate_full = None
-    args_values.Whichcasts = None
-    args_values.Datum = parser.get_default('Datum')
-    args_values.FileType = parser.get_default('FileType')
-    args_values.Station_Owner = parser.get_default('Station_Owner')
-    args_values.Horizon_Skill = parser.get_default('Horizon_Skill')
-    args_values.Forecast_Hr = parser.get_default('Forecast_Hr')
-    args_values.Var_Selection = parser.get_default('Var_Selection')
-    args_values.Currents_Bins_Csv = parser.get_default('Currents_Bins_Csv')
-    args_values.Disable_Model_File_Check = parser.get_default('Disable_Model_File_Check')
-    args_values.config = None
+    args_values = GuiParams()
 
-    # Set row initial value
-    row = -1
+    def _section(title):
+        """Themed LabelFrame container for a group of related widgets."""
+        return tk.LabelFrame(
+            scrollable_frame, text=title,
+            bg=themecolor, fg=textcolor,
+            font=(fontfamily, labelfontsize, 'bold'),
+            padx=padx, pady=pady, bd=1, relief='groove',
+        )
 
-    # Set home dir, -p
-    row += 1
-    # Create a StringVar to hold the selected directory path
+    def _label(parent, text, italic=False):
+        """Standard row label inside a section frame."""
+        font = ((fontfamily, 9, 'italic') if italic
+                else (fontfamily, labelfontsize))
+        return tk.Label(parent, text=text, bg=themecolor, fg=textcolor,
+                        font=font, anchor=anchor)
+
+    section_row = 0
+
+    # === General Settings ============================================
+    general_frame = _section('General Settings')
+    general_frame.grid(row=section_row, column=0, columnspan=4,
+                       sticky='ew', padx=10, pady=(10, 5))
+    section_row += 1
+
+    # Home directory, -p
     directory_path_var = tk.StringVar()
-    tk.Label(scrollable_frame,
-             text='Home directory',
-             bg=themecolor,
-             fg=textcolor,
-             font=(fontfamily, labelfontsize),
-             anchor=anchor).grid(row=row, column=0,  sticky='w',
-                                 padx=padx, pady=pady)
-    ttk.Button(scrollable_frame, text='Browse...', command=browse_directory,
-               style='TButton').grid(row=row, column=1,  sticky='w',
+    _label(general_frame, 'Home directory').grid(
+        row=0, column=0, sticky='w', padx=padx, pady=pady)
+    ttk.Button(general_frame, text='Browse...', command=browse_directory,
+               style='TButton').grid(row=0, column=1, sticky='w',
                                      padx=padx, pady=pady)
-    ttk.Entry(scrollable_frame, textvariable=directory_path_var).grid(row=row, column=2,
-                                                          sticky='w',
-                                                          padx=padx, pady=pady)
+    ttk.Entry(general_frame, textvariable=directory_path_var).grid(
+        row=0, column=2, sticky='w', padx=padx, pady=pady)
 
-    # Config file, -c. Empty/default value means "use the default
+    # Config file, -c. Blank/default value means "use the default
     # conf/ofs_dps.conf"; submit_and_close() converts blanks to None
     # so create_1dplot.py's argparse default kicks in.
-    row += 1
     config_path_var = tk.StringVar(value='conf/ofs_dps.conf')
-    tk.Label(scrollable_frame,
-             text='Config file',
-             bg=themecolor,
-             fg=textcolor,
-             font=(fontfamily, labelfontsize),
-             anchor=anchor).grid(row=row, column=0, sticky='w',
-                                 padx=padx, pady=pady)
-    ttk.Button(scrollable_frame, text='Browse...', command=browse_config_file,
-               style='TButton').grid(row=row, column=1, sticky='w',
+    _label(general_frame, 'Config file').grid(
+        row=1, column=0, sticky='w', padx=padx, pady=pady)
+    ttk.Button(general_frame, text='Browse...', command=browse_config_file,
+               style='TButton').grid(row=1, column=1, sticky='w',
                                      padx=padx, pady=pady)
-    ttk.Entry(scrollable_frame, textvariable=config_path_var).grid(
-        row=row, column=2, sticky='w', padx=padx, pady=pady)
+    ttk.Entry(general_frame, textvariable=config_path_var).grid(
+        row=1, column=2, sticky='w', padx=padx, pady=pady)
 
-    # OFS input, -o
-    row += 1
+    # OFS, -o
     ofs_entry = tk.StringVar()
     choices = (
         _OFS_PLACEHOLDER,
@@ -474,310 +465,228 @@ def create_gui(parser):
         'tbofs',
         'wcofs',
     )
-
     ofs_entry.set(_OFS_PLACEHOLDER)
-    tk.Label(scrollable_frame,
-             text='OFS',
-             bg=themecolor,
-             fg=textcolor,
-             font=(fontfamily, labelfontsize),
-             anchor=anchor).grid(row=row, column=0,  sticky='w',
-                                 padx=padx, pady=pady)
+    _label(general_frame, 'OFS').grid(
+        row=2, column=0, sticky='w', padx=padx, pady=pady)
     ofs_chosen = ttk.Combobox(
-        scrollable_frame, width=15, textvariable=ofs_entry,
+        general_frame, width=15, textvariable=ofs_entry,
         font=('Helvetica', 12), state='readonly',
     )
     ofs_chosen['values'] = choices
-    ofs_chosen.grid(row=row, column=1, sticky='w', padx=padx, pady=pady)
+    ofs_chosen.grid(row=2, column=1, sticky='w', padx=padx, pady=pady)
     ofs_chosen.bind('<<ComboboxSelected>>', on_ofs_changed)
 
-    row += 1
-    tk.Label(scrollable_frame,
-             text='Quick run mode assesses the most recent model cycle ➡️',
-             bg=themecolor,
-             fg=textcolor,
-             font=(fontfamily, 9, 'italic'),
-             anchor=anchor).grid(
-                 row=row, column=0, sticky='w', padx=padx, pady=(0, pady))
-    ttk.Button(
-        scrollable_frame, text='⚡ Quick Run Mode',
-        command=quick_run_submit, style='TButton',
-    ).grid(row=row, column=1, sticky='w', padx=padx, pady=(0, pady))
+    # Quick Run button (sits under OFS so the per-OFS context is clear).
+    _label(general_frame,
+           'Quick run mode assesses the most recent model cycle ➡️',
+           italic=True).grid(row=3, column=0, sticky='w',
+                             padx=padx, pady=(0, pady))
+    ttk.Button(general_frame, text='⚡ Quick Run Mode',
+               command=quick_run_submit, style='TButton').grid(
+        row=3, column=1, sticky='w', padx=padx, pady=(0, pady))
 
-    row += 1
-    ttk.Separator(scrollable_frame, orient='horizontal').grid(
-        row=row, column=0, columnspan=4, sticky='ew', pady=(15, 10))
+    # === Time Range ==================================================
+    time_frame = _section('Time Range')
+    time_frame.grid(row=section_row, column=0, columnspan=4,
+                    sticky='ew', padx=10, pady=5)
+    section_row += 1
 
     # Start date, -s
-    row += 1
-    tk.Label(scrollable_frame,
-             text='Start date & hour',
-             bg=themecolor,
-             fg=textcolor,
-             font=(fontfamily, labelfontsize),
-             anchor=anchor).grid(row=row, column=0, sticky='w',
-                                 padx=padx, pady=pady)
+    _label(time_frame, 'Start date & hour').grid(
+        row=0, column=0, sticky='w', padx=padx, pady=pady)
     start_entry = DateEntry(
-        scrollable_frame, width=16, background='darkblue',
+        time_frame, width=16, background='darkblue',
         foreground='white', bd=2, date_pattern='yyyy-mm-dd',
         font=('Helvetica', 12),
     )
-    start_entry.grid(row=row, column=1,  sticky='w', padx=padx, pady=pady)
-    # Create scale widget for hour selection
-    s_hour_scale = tk.Scale(scrollable_frame, from_=0, to=23, orient=tk.HORIZONTAL,
-                          length=100)
-    s_hour_scale.grid(row=row, column=2,  sticky='w', padx=padx, pady=pady)
+    start_entry.grid(row=0, column=1, sticky='w', padx=padx, pady=pady)
+    s_hour_scale = tk.Scale(time_frame, from_=0, to=23,
+                            orient=tk.HORIZONTAL, length=100)
+    s_hour_scale.grid(row=0, column=2, sticky='w', padx=padx, pady=pady)
 
     # End date, -e
-    row += 1
-    tk.Label(scrollable_frame,
-             text='End date & hour',
-             bg=themecolor,
-             fg=textcolor,
-             font=(fontfamily, labelfontsize),
-             anchor=anchor).grid(row=row, column=0,  sticky='w',
-                                 padx=padx, pady=pady)
+    _label(time_frame, 'End date & hour').grid(
+        row=1, column=0, sticky='w', padx=padx, pady=pady)
     end_entry = DateEntry(
-        scrollable_frame, width=16, background='darkblue',
+        time_frame, width=16, background='darkblue',
         foreground='white', bd=2, date_pattern='yyyy-mm-dd',
         font=('Helvetica', 12),
     )
-    end_entry.grid(row=row, column=1,  sticky='w', padx=padx, pady=pady)
-    # Create scale widget for hour selection
-    e_hour_scale = tk.Scale(scrollable_frame, from_=0, to=23, orient=tk.HORIZONTAL,
-                          length=100)
-    e_hour_scale.grid(row=row, column=2,  sticky='w', padx=padx, pady=pady)
+    end_entry.grid(row=1, column=1, sticky='w', padx=padx, pady=pady)
+    e_hour_scale = tk.Scale(time_frame, from_=0, to=23,
+                            orient=tk.HORIZONTAL, length=100)
+    e_hour_scale.grid(row=1, column=2, sticky='w', padx=padx, pady=pady)
+
+    # === Whichcast & Forecast ========================================
+    wcast_frame = _section('Whichcast & Forecast')
+    wcast_frame.grid(row=section_row, column=0, columnspan=4,
+                     sticky='ew', padx=10, pady=5)
+    section_row += 1
 
     # Whichcasts, -ws
-    row += 1
-    var_now = tk.StringVar()
-    var_fore = tk.StringVar()
-    var_hind = tk.StringVar()
-    var_forea = tk.StringVar()
-    var_now.set('nowcast')
-    var_fore.set('forecast_b')
+    var_now = tk.StringVar(value='nowcast')
+    var_fore = tk.StringVar(value='forecast_b')
+    var_forea = tk.StringVar(value='0')
+    var_hind = tk.StringVar(value='0')
 
-    # Set these to '0' so they are unchecked by default
-    var_forea.set('0')
-    var_hind.set('0')
-
-    tk.Label(scrollable_frame,
-             text='Whichcasts',
-             bg=themecolor,
-             fg=textcolor,
-             font=(fontfamily, labelfontsize),
-             anchor=anchor).grid(row=row, column=0, sticky='w',
-                                 padx=padx, pady=pady)
+    _label(wcast_frame, 'Whichcasts').grid(
+        row=0, column=0, sticky='w', padx=padx, pady=pady)
     now_chk = ttk.Checkbutton(
-        scrollable_frame, text='Nowcast', variable=var_now,
+        wcast_frame, text='Nowcast', variable=var_now,
         onvalue='nowcast', offvalue=0,
     )
-    now_chk.grid(row=row, column=1, sticky='w', padx=padx, pady=pady)
+    now_chk.grid(row=0, column=1, sticky='w', padx=padx, pady=pady)
     fore_chk = ttk.Checkbutton(
-        scrollable_frame, text='Forecast_b', variable=var_fore,
+        wcast_frame, text='Forecast_b', variable=var_fore,
         onvalue='forecast_b', offvalue=0,
     )
-    fore_chk.grid(row=row, column=2, sticky='w', padx=padx, pady=pady)
-    row += 1
+    fore_chk.grid(row=0, column=2, sticky='w', padx=padx, pady=pady)
     forea_chk = ttk.Checkbutton(
-        scrollable_frame, text='Forecast_a', variable=var_forea,
+        wcast_frame, text='Forecast_a', variable=var_forea,
         onvalue='forecast_a', offvalue=0, command=toggle_cycle_state,
     )
-    forea_chk.grid(row=row, column=1, sticky='w', padx=padx, pady=pady)
+    forea_chk.grid(row=1, column=1, sticky='w', padx=padx, pady=pady)
     hind_chk = ttk.Checkbutton(
-        scrollable_frame, text='Hindcast (LOOFS2 only)', variable=var_hind,
+        wcast_frame, text='Hindcast (LOOFS2 only)', variable=var_hind,
         onvalue='hindcast', offvalue=0,
     )
-    hind_chk.grid(row=row, column=2, sticky='w', padx=padx, pady=pady)
+    hind_chk.grid(row=1, column=2, sticky='w', padx=padx, pady=pady)
 
-    # Model Cycle input, -f
-    row += 1
-    cycle_var = tk.StringVar()
-    cycle_var.set(_OFS_FIRST_PLACEHOLDER)
-    tk.Label(scrollable_frame,
-             text='Model cycle (forecast_a only)',
-             bg=themecolor,
-             fg=textcolor,
-             font=(fontfamily, labelfontsize),
-             anchor=anchor).grid(row=row, column=0,  sticky='w',
-                                 padx=padx, pady=pady)
-    cycle_chosen = ttk.Combobox(scrollable_frame, width=22, textvariable=cycle_var,
-                              font=('Helvetica', 12), state='readonly')
-    cycle_chosen.grid(row=row, column=1,  sticky='w', padx=padx, pady=pady)
+    # Model cycle, -f
+    cycle_var = tk.StringVar(value=_OFS_FIRST_PLACEHOLDER)
+    _label(wcast_frame, 'Model cycle (forecast_a only)').grid(
+        row=2, column=0, sticky='w', padx=padx, pady=pady)
+    cycle_chosen = ttk.Combobox(
+        wcast_frame, width=22, textvariable=cycle_var,
+        font=('Helvetica', 12), state='readonly',
+    )
+    cycle_chosen.grid(row=2, column=1, sticky='w', padx=padx, pady=pady)
 
-    # Datums, -d
-    row += 1
+    # === Datum & Output ==============================================
+    datum_frame = _section('Datum & Output')
+    datum_frame.grid(row=section_row, column=0, columnspan=4,
+                     sticky='ew', padx=10, pady=5)
+    section_row += 1
+
+    # Datum, -d
     datum_var = tk.StringVar()
     dchoices = (_DATUM_PLACEHOLDER,) + tuple(datum_list)
     datum_var.set(_DATUM_PLACEHOLDER)
-    tk.Label(scrollable_frame,
-             text='Vertical datum',
-             bg=themecolor,
-             fg=textcolor,
-             font=(fontfamily, labelfontsize),
-             anchor=anchor).grid(row=row, column=0, sticky='w',
-                                 padx=padx, pady=pady)
-    datum_chosen = ttk.Combobox(scrollable_frame, width = 15, textvariable = datum_var,
-                                font=('Helvetica', 12))
+    _label(datum_frame, 'Vertical datum').grid(
+        row=0, column=0, sticky='w', padx=padx, pady=pady)
+    datum_chosen = ttk.Combobox(
+        datum_frame, width=15, textvariable=datum_var, font=('Helvetica', 12),
+    )
     datum_chosen['values'] = dchoices
-    datum_chosen.grid(row=row, column=1, sticky='w', padx=padx, pady=pady)
+    datum_chosen.grid(row=0, column=1, sticky='w', padx=padx, pady=pady)
 
     # File type, -t
-    row += 1
-    filetype_var = tk.StringVar(value='stations') # Default selection
-    tk.Label(scrollable_frame,
-             text='Model output file type',
-             bg=themecolor,
-             fg=textcolor,
-             font=(fontfamily, labelfontsize),
-             anchor=anchor).grid(row=row, column=0, sticky='w',
-                                 padx=padx, pady=pady)
-    ttk.Radiobutton(scrollable_frame, text='Station', variable=filetype_var,
-                   value='stations').grid(row=row, column=1,
-                                          sticky='w', padx=padx, pady=pady)
-    ttk.Radiobutton(scrollable_frame, text='Field', variable=filetype_var, value='fields').\
-        grid(row=row, column=2, sticky='w', padx=padx, pady=pady)
+    filetype_var = tk.StringVar(value='stations')
+    _label(datum_frame, 'Model output file type').grid(
+        row=1, column=0, sticky='w', padx=padx, pady=pady)
+    ttk.Radiobutton(datum_frame, text='Station', variable=filetype_var,
+                    value='stations').grid(row=1, column=1, sticky='w',
+                                           padx=padx, pady=pady)
+    ttk.Radiobutton(datum_frame, text='Field', variable=filetype_var,
+                    value='fields').grid(row=1, column=2, sticky='w',
+                                         padx=padx, pady=pady)
 
-    # Station provider, -so
-    row += 1
-    var_coops = tk.StringVar()
-    var_ndbc = tk.StringVar()
-    var_usgs = tk.StringVar()
-    var_list = tk.StringVar()
-    var_coops.set('co-ops')
-    var_ndbc.set('ndbc')
-    var_usgs.set('usgs')
-    var_list.set(0)
-    tk.Label(scrollable_frame,
-             text='Station providers',
-             bg=themecolor,
-             fg=textcolor,
-             font=(fontfamily, labelfontsize),
-             anchor=anchor).grid(
-        row=row, column=0, sticky='w', padx=padx, pady=pady)
-    tk.Label(scrollable_frame,
-             text='If adding stations from list, provider selection is optional',
-             bg=themecolor,
-             fg=textcolor,
-             font=(fontfamily, 9, 'italic'),
-             anchor=anchor).grid(
-        row=row+1, column=0, sticky='w', padx=padx, pady=(0,pady))
-    ttk.Checkbutton(scrollable_frame, text='CO-OPS',
-                   variable=var_coops, onvalue='co-ops', offvalue=0).grid(
-                              row=row, column=1, sticky='w',
-                              padx=padx, pady=(pady,2))
-    ttk.Checkbutton(scrollable_frame, text='NDBC',
-                   variable=var_ndbc, onvalue='ndbc', offvalue=0).grid(
-                              row=row, column=2, sticky='w',
-                              padx=padx, pady=(pady,2))
-    row += 1
-    ttk.Checkbutton(scrollable_frame, text='USGS',
-                   variable=var_usgs, onvalue='usgs', offvalue=0).grid(
-                              row=row, column=1, sticky='w',
-                              padx=padx, pady=(0,pady))
-    ttk.Checkbutton(scrollable_frame, text='Add from conf file',
-                   variable=var_list, onvalue='list', offvalue=0).grid(
-                              row=row, column=2, sticky='w',
-                              padx=padx, pady=(0,pady))
+    # === Stations & Variables ========================================
+    sv_frame = _section('Stations & Variables')
+    sv_frame.grid(row=section_row, column=0, columnspan=4,
+                  sticky='ew', padx=10, pady=5)
+    section_row += 1
+
+    # Station providers, -so
+    var_coops = tk.StringVar(value='co-ops')
+    var_ndbc = tk.StringVar(value='ndbc')
+    var_usgs = tk.StringVar(value='usgs')
+    var_list = tk.StringVar(value='0')
+    _label(sv_frame, 'Station providers').grid(
+        row=0, column=0, sticky='w', padx=padx, pady=pady)
+    _label(sv_frame,
+           'If adding stations from list, provider selection is optional',
+           italic=True).grid(row=1, column=0, sticky='w',
+                             padx=padx, pady=(0, pady))
+    ttk.Checkbutton(sv_frame, text='CO-OPS', variable=var_coops,
+                    onvalue='co-ops', offvalue=0).grid(
+        row=0, column=1, sticky='w', padx=padx, pady=(pady, 2))
+    ttk.Checkbutton(sv_frame, text='NDBC', variable=var_ndbc,
+                    onvalue='ndbc', offvalue=0).grid(
+        row=0, column=2, sticky='w', padx=padx, pady=(pady, 2))
+    ttk.Checkbutton(sv_frame, text='USGS', variable=var_usgs,
+                    onvalue='usgs', offvalue=0).grid(
+        row=1, column=1, sticky='w', padx=padx, pady=(0, pady))
+    ttk.Checkbutton(sv_frame, text='Add from conf file', variable=var_list,
+                    onvalue='list', offvalue=0).grid(
+        row=1, column=2, sticky='w', padx=padx, pady=(0, pady))
 
     # Variables, -vs
-    row += 1
-    var_wl = tk.StringVar()
-    var_temp = tk.StringVar()
-    var_salt = tk.StringVar()
-    var_cu = tk.StringVar()
-    var_wl.set('water_level')
-    var_temp.set('water_temperature')
-    var_salt.set('salinity')
-    var_cu.set('currents')
-    tk.Label(scrollable_frame,
-             text='Variables',
-             bg=themecolor,
-             fg=textcolor,
-             font=(fontfamily, labelfontsize),
-             anchor=anchor).grid(
-        row=row, column=0, sticky='w', padx=padx, pady=pady)
-    ttk.Checkbutton(scrollable_frame, text='Water level',
-                   variable=var_wl, onvalue='water_level', offvalue=0).grid(
-                              row=row, column=1, sticky='w',
-                              padx=padx, pady=(pady,2))
-    ttk.Checkbutton(scrollable_frame, text='Temperature',
-                   variable=var_temp, onvalue='water_temperature', offvalue=0).grid(
-                              row=row, column=2, sticky='w',
-                              padx=padx, pady=(pady,2))
-    row += 1
-    ttk.Checkbutton(scrollable_frame, text='Salinity',
-                   variable=var_salt, onvalue='salinity', offvalue=0).grid(
-                              row=row, column=1, sticky='w',
-                              padx=padx, pady=(0,pady))
-    ttk.Checkbutton(scrollable_frame, text='Current velocity',
-                   variable=var_cu, onvalue='currents', offvalue=0).grid(
-                              row=row, column=2, sticky='w',
-                              padx=padx, pady=(0,pady))
+    var_wl = tk.StringVar(value='water_level')
+    var_temp = tk.StringVar(value='water_temperature')
+    var_salt = tk.StringVar(value='salinity')
+    var_cu = tk.StringVar(value='currents')
+    _label(sv_frame, 'Variables').grid(
+        row=2, column=0, sticky='w', padx=padx, pady=pady)
+    ttk.Checkbutton(sv_frame, text='Water level', variable=var_wl,
+                    onvalue='water_level', offvalue=0).grid(
+        row=2, column=1, sticky='w', padx=padx, pady=(pady, 2))
+    ttk.Checkbutton(sv_frame, text='Temperature', variable=var_temp,
+                    onvalue='water_temperature', offvalue=0).grid(
+        row=2, column=2, sticky='w', padx=padx, pady=(pady, 2))
+    ttk.Checkbutton(sv_frame, text='Salinity', variable=var_salt,
+                    onvalue='salinity', offvalue=0).grid(
+        row=3, column=1, sticky='w', padx=padx, pady=(0, pady))
+    ttk.Checkbutton(sv_frame, text='Current velocity', variable=var_cu,
+                    onvalue='currents', offvalue=0).grid(
+        row=3, column=2, sticky='w', padx=padx, pady=(0, pady))
+
+    # === Advanced ====================================================
+    adv_frame = _section('Advanced')
+    adv_frame.grid(row=section_row, column=0, columnspan=4,
+                   sticky='ew', padx=10, pady=5)
+    section_row += 1
 
     # Forecast horizon skill, -hs
-    row += 1
-    horizon_var = tk.BooleanVar(value=False) # Default selection
-    tk.Label(scrollable_frame,
-             text='Assess all forecast horizons?',
-             bg=themecolor,
-             fg=textcolor,
-             font=(fontfamily, labelfontsize),
-             anchor=anchor).grid(
-        row=row, column=0, sticky='w', padx=padx, pady=pady)
-    ttk.Radiobutton(scrollable_frame, text='No (default)', variable=horizon_var, value=False).grid(
-        row=row, column=1, sticky='w', padx=padx, pady=pady)
-    ttk.Radiobutton(scrollable_frame, text='Yes', variable=horizon_var, value=True).grid(
-        row=row, column=2, sticky='w', padx=padx, pady=pady)
+    horizon_var = tk.BooleanVar(value=False)
+    _label(adv_frame, 'Assess all forecast horizons?').grid(
+        row=0, column=0, sticky='w', padx=padx, pady=pady)
+    ttk.Radiobutton(adv_frame, text='No (default)', variable=horizon_var,
+                    value=False).grid(row=0, column=1, sticky='w',
+                                      padx=padx, pady=pady)
+    ttk.Radiobutton(adv_frame, text='Yes', variable=horizon_var,
+                    value=True).grid(row=0, column=2, sticky='w',
+                                     padx=padx, pady=pady)
 
     # Currents bins CSV, -cb
-    row += 1
     cb_var = tk.StringVar()
-    tk.Label(scrollable_frame,
-             text='Currents bins CSV (Optional)',
-             bg=themecolor,
-             fg=textcolor,
-             font=(fontfamily, labelfontsize),
-             anchor=anchor).grid(row=row, column=0, sticky='w',
-                                 padx=padx, pady=pady)
-    ttk.Button(scrollable_frame, text='Browse...', command=browse_csv_file,
-               style='TButton').grid(row=row, column=1, sticky='w',
+    _label(adv_frame, 'Currents bins CSV (Optional)').grid(
+        row=1, column=0, sticky='w', padx=padx, pady=pady)
+    ttk.Button(adv_frame, text='Browse...', command=browse_csv_file,
+               style='TButton').grid(row=1, column=1, sticky='w',
                                      padx=padx, pady=pady)
-    ttk.Entry(scrollable_frame, textvariable=cb_var).grid(row=row, column=2,
-                                              sticky='w',
-                                              padx=padx, pady=pady)
+    ttk.Entry(adv_frame, textvariable=cb_var).grid(
+        row=1, column=2, sticky='w', padx=padx, pady=pady)
 
     # Model file check, -df
-    # NOTE: True means the pre-check IS performed (matches the
+    # True means the pre-check IS performed (matches the
     # action='store_false' semantics of -df in create_1dplot.py).
-    row += 1
     enable_file_check_var = tk.BooleanVar(value=True)
-    tk.Label(scrollable_frame,
-             text='Pre-check for model output files?',
-             bg=themecolor,
-             fg=textcolor,
-             font=(fontfamily, labelfontsize),
-             anchor=anchor).grid(
-        row=row, column=0, sticky='w', padx=padx, pady=pady)
-    ttk.Radiobutton(
-        scrollable_frame, text='No (disable check)',
-        variable=enable_file_check_var, value=False,
-    ).grid(row=row, column=1, sticky='w', padx=padx, pady=pady)
-    ttk.Radiobutton(
-        scrollable_frame, text='Yes (default)',
-        variable=enable_file_check_var, value=True,
-    ).grid(row=row, column=2, sticky='w', padx=padx, pady=pady)
+    _label(adv_frame, 'Pre-check for model output files?').grid(
+        row=2, column=0, sticky='w', padx=padx, pady=pady)
+    ttk.Radiobutton(adv_frame, text='No (disable check)',
+                    variable=enable_file_check_var, value=False).grid(
+        row=2, column=1, sticky='w', padx=padx, pady=pady)
+    ttk.Radiobutton(adv_frame, text='Yes (default)',
+                    variable=enable_file_check_var, value=True).grid(
+        row=2, column=2, sticky='w', padx=padx, pady=pady)
 
-    # Horizontal separator
-    row += 1
-    separator = ttk.Separator(scrollable_frame, orient='horizontal')
-    separator.grid(row=row, column=0, columnspan=4, sticky='ew', pady=pady)
-
-    # Submit button
-    row += 1
-    submit_button = ttk.Button(scrollable_frame, text='Run skill assessment!',
-                              command=submit_and_close)
-    submit_button.grid(row=row, column=0, columnspan=4, pady=10)
+    # === Submit ======================================================
+    submit_button = ttk.Button(scrollable_frame,
+                               text='Run skill assessment!',
+                               command=submit_and_close)
+    submit_button.grid(row=section_row, column=0, columnspan=4,
+                       pady=(15, 15))
     toggle_cycle_state()
     root.mainloop()
     return args_values

--- a/src/ofs_skill/visualization/gui_helpers.py
+++ b/src/ofs_skill/visualization/gui_helpers.py
@@ -6,7 +6,7 @@ widget used by create_gui.py. Keeping them here lets the GUI module focus on
 layout and wiring, and lets the helpers be unit tested without spinning up Tk.
 
 Key Features:
-    - Cross-platform tkcalendar DateEntry wrapper with macOS Sonoma fixes
+    - Cross-platform tkcalendar DateEntry wrapper with calendar-popup fixes
     - Per-OFS default datum and most-recent-cycle computation for Quick Run
     - Conf-driven datum list lookup with hardcoded fallback
     - Pure-logic validators that return error message strings (or None) so
@@ -50,8 +50,7 @@ DEFAULT_DATUMS = (
 
 class DateEntry(_TkDateEntry):
     """Drop-in replacement for ``tkcalendar.DateEntry`` with cross-platform
-    calendar-popup fixes (macOS Sonoma+ rendering, focus, and color
-    inheritance)."""
+    calendar-popup fixes."""
 
     _CAL_COLOR_DEFAULTS = {
         'normalbackground':     'white',
@@ -67,10 +66,16 @@ class DateEntry(_TkDateEntry):
         'bordercolor':          'gray60',
     }
 
+    # Grace period (ms) after opening during which a transient FocusOut on
+    # the calendar is ignored. Prevents the popup from immediately closing
+    # when the platform briefly redirects focus while mapping the window.
+    _FOCUS_GRACE_MS = 200
+
     def __init__(self, master=None, **kw):
         for key, value in self._CAL_COLOR_DEFAULTS.items():
             kw.setdefault(key, value)
         super().__init__(master, **kw)
+        self._drop_down_time = 0
         if sys.platform == 'darwin':
             try:
                 self._top_cal.overrideredirect(False)
@@ -78,6 +83,7 @@ class DateEntry(_TkDateEntry):
                 pass
 
     def drop_down(self):
+        self._drop_down_time = self.winfo_toplevel().tk.call('clock', 'milliseconds')
         super().drop_down()
         try:
             top = self._top_cal
@@ -88,9 +94,18 @@ class DateEntry(_TkDateEntry):
             top.lift()
             if sys.platform != 'darwin':
                 top.attributes('-topmost', True)
-                top.focus_force()
         except (tk.TclError, AttributeError):
             pass
+
+    def _on_focus_out_cal(self, event):
+        """Ignore transient FocusOut events fired right after the popup
+        opens, before the user has had a chance to interact with it."""
+        now = self.winfo_toplevel().tk.call('clock', 'milliseconds')
+        elapsed = now - self._drop_down_time
+        if elapsed < self._FOCUS_GRACE_MS:
+            self._calendar.focus_set()
+            return
+        super()._on_focus_out_cal(event)
 
 
 def quick_run_datum(ofs: str) -> str:

--- a/src/ofs_skill/visualization/gui_helpers.py
+++ b/src/ofs_skill/visualization/gui_helpers.py
@@ -1,0 +1,235 @@
+"""
+Reusable helpers for the skill-assessment Tkinter GUI.
+
+This module contains the pure-logic helpers and the cross-platform DateEntry
+widget used by create_gui.py. Keeping them here lets the GUI module focus on
+layout and wiring, and lets the helpers be unit tested without spinning up Tk.
+
+Key Features:
+    - Cross-platform tkcalendar DateEntry wrapper with macOS Sonoma fixes
+    - Per-OFS default datum and most-recent-cycle computation for Quick Run
+    - Conf-driven datum list lookup with hardcoded fallback
+    - Pure-logic validators that return error message strings (or None) so
+      callers decide how to surface them (messagebox, assertion, log, etc.)
+
+Functions:
+    quick_run_datum: Pick a sensible default vertical datum per OFS family
+    compute_recent_cycle: Compute most recent available forecast cycle
+    read_datum_list: Load [datums] datum_list from conf with fallback
+    format_date: Format a date object and hour into the CLI's ISO string
+    build_utc_datetime: Combine date + hour into a UTC-aware datetime
+    validate_date_order: Check that start is strictly before end
+    validate_start_not_future: Check that start is not in the future (UTC)
+    validate_horizon_requires_stations: Enforce Horizon_Skill + stations rule
+
+Author: TSR
+Created: Extracted from create_gui.py for modularity
+"""
+from __future__ import annotations
+
+import logging
+import sys
+import tkinter as tk
+from datetime import date as date_type
+from datetime import datetime, timedelta, timezone
+
+from tkcalendar import DateEntry as _TkDateEntry
+
+from ofs_skill.model_processing.get_fcst_cycle import get_fcst_hours
+from ofs_skill.obs_retrieval import utils
+
+# OFS groupings used to pick sensible per-OFS defaults in Quick Run mode.
+GREAT_LAKES_OFS = ('leofs', 'lmhofs', 'loofs', 'loofs2', 'lsofs')
+STOFS_OFS = ('stofs_2d_glo', 'stofs_3d_atl', 'stofs_3d_pac')
+
+# Datum fallback if the [datums] section of the conf cannot be read.
+DEFAULT_DATUMS = (
+    'MHHW', 'MHW', 'MLLW', 'MLW', 'NAVD88', 'IGLD85', 'LWD', 'XGEOID20B'
+)
+
+
+class DateEntry(_TkDateEntry):
+    """Drop-in replacement for ``tkcalendar.DateEntry`` with cross-platform
+    calendar-popup fixes (macOS Sonoma+ rendering, focus, and color
+    inheritance)."""
+
+    _CAL_COLOR_DEFAULTS = {
+        'normalbackground':     'white',
+        'normalforeground':     'black',
+        'selectbackground':     '#1a73e8',
+        'selectforeground':     'white',
+        'weekendbackground':    '#f0f0f0',
+        'weekendforeground':    'black',
+        'headersbackground':    '#e0e0e0',
+        'headersforeground':    'black',
+        'othermonthbackground': '#fafafa',
+        'othermonthforeground': 'gray50',
+        'bordercolor':          'gray60',
+    }
+
+    def __init__(self, master=None, **kw):
+        for key, value in self._CAL_COLOR_DEFAULTS.items():
+            kw.setdefault(key, value)
+        super().__init__(master, **kw)
+        if sys.platform == 'darwin':
+            try:
+                self._top_cal.overrideredirect(False)
+            except (tk.TclError, AttributeError):
+                pass
+
+    def drop_down(self):
+        super().drop_down()
+        try:
+            top = self._top_cal
+            if not top.winfo_ismapped():
+                return
+            top.update_idletasks()
+            top.update()
+            top.lift()
+            if sys.platform != 'darwin':
+                top.attributes('-topmost', True)
+                top.focus_force()
+        except (tk.TclError, AttributeError):
+            pass
+
+
+def quick_run_datum(ofs: str) -> str:
+    """Return a sensible default vertical datum for Quick Run mode.
+
+    Great Lakes OFSes use IGLD85, the global/regional STOFS systems
+    don't have a uniform tidal datum so fall back to NAVD88, and tidal
+    coastal OFSes use MLLW.
+    """
+    if ofs in GREAT_LAKES_OFS:
+        return 'IGLD85'
+    if ofs in STOFS_OFS:
+        return 'NAVD88'
+    return 'MLLW'
+
+
+def compute_recent_cycle(ofs: str, now: datetime | None = None):
+    """Compute the most recent forecast cycle that should be available.
+
+    Parameters
+    ----------
+    ofs : str
+        OFS identifier (e.g. ``'cbofs'``).
+    now : datetime, optional
+        UTC-aware "current" time. Defaults to ``datetime.now(timezone.utc)``.
+        Exposed for deterministic unit testing.
+
+    Returns
+    -------
+    (start_iso, forecast_hr) : tuple of str
+        ``start_iso`` is YYYY-MM-DDTHH:MM:SSZ at the chosen cycle, and
+        ``forecast_hr`` is the cycle as ``'06z'`` etc. Allows a 2h delay
+        for file arrival on NODD before considering a cycle "available".
+    """
+    _, fcstcycles = get_fcst_hours(ofs)
+    cycles = sorted(int(c) for c in fcstcycles)
+    if now is None:
+        now = datetime.now(timezone.utc)
+    now_utc = now.replace(minute=0, second=0, microsecond=0)
+    cutoff = now_utc - timedelta(hours=2)
+    today = now_utc.replace(hour=0)
+    chosen = None
+    for offset_days in (0, 1):
+        day = today - timedelta(days=offset_days)
+        for hr in reversed(cycles):
+            cyc_dt = day.replace(hour=hr)
+            if cyc_dt <= cutoff:
+                chosen = cyc_dt
+                break
+        if chosen is not None:
+            break
+    if chosen is None:
+        chosen = today.replace(hour=cycles[-1]) - timedelta(days=1)
+    return (
+        chosen.strftime('%Y-%m-%dT%H:%M:%SZ'),
+        f'{chosen.hour:02d}z',
+    )
+
+
+def read_datum_list():
+    """Read ``[datums] datum_list`` from the active conf, falling back
+    to ``DEFAULT_DATUMS`` if the section is missing or unreadable."""
+    log = logging.getLogger(__name__)
+    try:
+        section = utils.Utils(None).read_config_section('datums', log)
+        raw = section.get('datum_list')
+        if raw:
+            return tuple(raw.split())
+    except (KeyError, AttributeError, OSError):
+        log.warning(
+            'Could not read [datums] from conf; falling back to defaults.'
+        )
+    return DEFAULT_DATUMS
+
+
+def format_date(date_obj, hour) -> str:
+    """Format a date object and integer-ish hour into the ISO string the
+    downstream CLI expects, e.g. ``'2025-11-12T06:00:00Z'``.
+
+    Raises ``TypeError`` if ``date_obj`` is not a ``datetime.date``.
+    """
+    if isinstance(date_obj, date_type):
+        return f"{date_obj.strftime('%Y-%m-%d')}T{int(hour):02d}:00:00Z"
+    raise TypeError(f'Expected date object, got {type(date_obj)}: {date_obj}')
+
+
+def build_utc_datetime(date_obj, hour) -> datetime | None:
+    """Build a UTC-aware ``datetime`` from a ``date`` and integer-ish hour.
+
+    Returns ``None`` if ``date_obj`` is falsy or if ``hour`` cannot be
+    coerced to an integer. Used to normalise the two ``DateEntry`` +
+    ``Scale`` widget pairs in the GUI before comparison.
+    """
+    if not date_obj:
+        return None
+    try:
+        return datetime(
+            date_obj.year, date_obj.month, date_obj.day,
+            int(hour), tzinfo=timezone.utc,
+        )
+    except (TypeError, ValueError):
+        return None
+
+
+def validate_date_order(start_dt: datetime | None,
+                        end_dt: datetime | None) -> str | None:
+    """Return an error message if start is not strictly before end."""
+    if start_dt is not None and end_dt is not None and start_dt >= end_dt:
+        return 'Start date/hour must be before end date/hour.'
+    return None
+
+
+def validate_start_not_future(start_dt: datetime | None,
+                              now: datetime | None = None
+                              ) -> str | None:
+    """Return an error message if ``start_dt`` is in the future (UTC).
+
+    ``now`` defaults to ``datetime.now(timezone.utc)``; overridable for
+    deterministic testing.
+    """
+    if start_dt is None:
+        return None
+    if now is None:
+        now = datetime.now(timezone.utc)
+    if start_dt > now:
+        return 'Start date/hour cannot be in the future (UTC).'
+    return None
+
+
+def validate_horizon_requires_stations(horizon_skill: bool,
+                                       filetype: str) -> str | None:
+    """Return an error message if Horizon_Skill=True is combined with a
+    non-stations file type. Horizon skill is only implemented for the
+    station model output files."""
+    if horizon_skill and filetype != 'stations':
+        return (
+            '"Assess all forecast horizons?" is only supported with '
+            'the "Station" model output file type. Either change the '
+            'file type to Station, or set "Assess all forecast '
+            'horizons?" to No.'
+        )
+    return None

--- a/src/ofs_skill/visualization/gui_helpers.py
+++ b/src/ofs_skill/visualization/gui_helpers.py
@@ -2,7 +2,7 @@
 Reusable helpers for the skill-assessment Tkinter GUI.
 
 This module contains the pure-logic helpers and the cross-platform DateEntry
-widget used by create_gui.py. Keeping them here lets the GUI module focus on
+widget used by create_gui.py. This separation lets the GUI module focus on
 layout and wiring, and lets the helpers be unit tested without spinning up Tk.
 
 Key Features:
@@ -11,6 +11,10 @@ Key Features:
     - Conf-driven datum list lookup with hardcoded fallback
     - Pure-logic validators that return error message strings (or None) so
       callers decide how to surface them (messagebox, assertion, log, etc.)
+
+Classes:
+    DateEntry: Cross-platform tkcalendar DateEntry subclass
+    GuiParams: Typed dataclass mirroring the argparse namespace
 
 Functions:
     quick_run_datum: Pick a sensible default vertical datum per OFS family
@@ -30,6 +34,7 @@ from __future__ import annotations
 import logging
 import sys
 import tkinter as tk
+from dataclasses import dataclass, field
 from datetime import date as date_type
 from datetime import datetime, timedelta, timezone
 
@@ -98,8 +103,7 @@ class DateEntry(_TkDateEntry):
             pass
 
     def _on_focus_out_cal(self, event):
-        """Ignore transient FocusOut events fired right after the popup
-        opens, before the user has had a chance to interact with it."""
+        """Ignore transient FocusOut events fired right after popup opens."""
         now = self.winfo_toplevel().tk.call('clock', 'milliseconds')
         elapsed = now - self._drop_down_time
         if elapsed < self._FOCUS_GRACE_MS:
@@ -109,12 +113,8 @@ class DateEntry(_TkDateEntry):
 
 
 def quick_run_datum(ofs: str) -> str:
-    """Return a sensible default vertical datum for Quick Run mode.
-
-    Great Lakes OFSes use IGLD85, the global/regional STOFS systems
-    don't have a uniform tidal datum so fall back to NAVD88, and tidal
-    coastal OFSes use MLLW.
-    """
+    """Default vertical datum per OFS family: IGLD85 (Great Lakes),
+    NAVD88 (STOFS), else MLLW (tidal coastal)."""
     if ofs in GREAT_LAKES_OFS:
         return 'IGLD85'
     if ofs in STOFS_OFS:
@@ -123,23 +123,9 @@ def quick_run_datum(ofs: str) -> str:
 
 
 def compute_recent_cycle(ofs: str, now: datetime | None = None):
-    """Compute the most recent forecast cycle that should be available.
-
-    Parameters
-    ----------
-    ofs : str
-        OFS identifier (e.g. ``'cbofs'``).
-    now : datetime, optional
-        UTC-aware "current" time. Defaults to ``datetime.now(timezone.utc)``.
-        Exposed for deterministic unit testing.
-
-    Returns
-    -------
-    (start_iso, forecast_hr) : tuple of str
-        ``start_iso`` is YYYY-MM-DDTHH:MM:SSZ at the chosen cycle, and
-        ``forecast_hr`` is the cycle as ``'06z'`` etc. Allows a 2h delay
-        for file arrival on NODD before considering a cycle "available".
-    """
+    """Return ``(start_iso, forecast_hr)`` for the most recent cycle
+    available (assumes a 2h NODD delivery delay). ``now`` is overridable
+    for deterministic testing; defaults to ``datetime.now(timezone.utc)``."""
     _, fcstcycles = get_fcst_hours(ofs)
     cycles = sorted(int(c) for c in fcstcycles)
     if now is None:
@@ -182,23 +168,16 @@ def read_datum_list():
 
 
 def format_date(date_obj, hour) -> str:
-    """Format a date object and integer-ish hour into the ISO string the
-    downstream CLI expects, e.g. ``'2025-11-12T06:00:00Z'``.
-
-    Raises ``TypeError`` if ``date_obj`` is not a ``datetime.date``.
-    """
+    """Format date + hour into the CLI ISO string ``'YYYY-MM-DDTHH:00:00Z'``;
+    raises ``TypeError`` if ``date_obj`` is not a ``datetime.date``."""
     if isinstance(date_obj, date_type):
         return f"{date_obj.strftime('%Y-%m-%d')}T{int(hour):02d}:00:00Z"
     raise TypeError(f'Expected date object, got {type(date_obj)}: {date_obj}')
 
 
 def build_utc_datetime(date_obj, hour) -> datetime | None:
-    """Build a UTC-aware ``datetime`` from a ``date`` and integer-ish hour.
-
-    Returns ``None`` if ``date_obj`` is falsy or if ``hour`` cannot be
-    coerced to an integer. Used to normalise the two ``DateEntry`` +
-    ``Scale`` widget pairs in the GUI before comparison.
-    """
+    """Build a UTC-aware ``datetime`` from date + hour, or ``None`` if
+    ``date_obj`` is falsy or ``hour`` is not int-coercible."""
     if not date_obj:
         return None
     try:
@@ -221,11 +200,8 @@ def validate_date_order(start_dt: datetime | None,
 def validate_start_not_future(start_dt: datetime | None,
                               now: datetime | None = None
                               ) -> str | None:
-    """Return an error message if ``start_dt`` is in the future (UTC).
-
-    ``now`` defaults to ``datetime.now(timezone.utc)``; overridable for
-    deterministic testing.
-    """
+    """Error message if ``start_dt`` is in the future (UTC); ``now`` is
+    overridable for deterministic testing."""
     if start_dt is None:
         return None
     if now is None:
@@ -237,9 +213,8 @@ def validate_start_not_future(start_dt: datetime | None,
 
 def validate_horizon_requires_stations(horizon_skill: bool,
                                        filetype: str) -> str | None:
-    """Return an error message if Horizon_Skill=True is combined with a
-    non-stations file type. Horizon skill is only implemented for the
-    station model output files."""
+    """Error message if ``Horizon_Skill=True`` is paired with a non-stations
+    file type (horizon skill is only implemented for station outputs)."""
     if horizon_skill and filetype != 'stations':
         return (
             '"Assess all forecast horizons?" is only supported with '
@@ -248,3 +223,32 @@ def validate_horizon_requires_stations(horizon_skill: bool,
             'horizons?" to No.'
         )
     return None
+
+
+@dataclass
+class GuiParams:
+    """Typed GUI-to-CLI param schema; fields mirror argparse ``dest`` names
+    in ``create_1dplot.py`` as a drop-in for ``argparse.Namespace``."""
+
+    OFS: str | None = None
+    Path: str | None = None
+    StartDate_full: str | None = None
+    EndDate_full: str | None = None
+    Whichcasts: list[str] = field(
+        default_factory=lambda: ['nowcast', 'forecast_b']
+    )
+    Datum: str = 'MLLW'
+    FileType: str = 'stations'
+    Forecast_Hr: str = 'now'
+    Station_Owner: list[str] = field(
+        default_factory=lambda: ['co-ops', 'ndbc', 'usgs', 'chs']
+    )
+    Horizon_Skill: bool = False
+    Var_Selection: list[str] = field(
+        default_factory=lambda: [
+            'water_level', 'water_temperature', 'salinity', 'currents'
+        ]
+    )
+    Currents_Bins_Csv: str | None = None
+    Disable_Model_File_Check: bool = True
+    config: str | None = None

--- a/tests/gui_helpers_test.py
+++ b/tests/gui_helpers_test.py
@@ -470,5 +470,59 @@ class TestDateEntryClassAttributes:
         assert d['weekendbackground'] != d['weekendforeground']
 
 
+class TestGuiParams:
+    """Tests for the GuiParams dataclass."""
+
+    def test_default_instantiation(self):
+        """GuiParams() should create an instance with all argparse defaults."""
+        p = gui_helpers.GuiParams()
+        assert p.OFS is None
+        assert p.Path is None
+        assert p.StartDate_full is None
+        assert p.EndDate_full is None
+        assert p.Whichcasts == ['nowcast', 'forecast_b']
+        assert p.Datum == 'MLLW'
+        assert p.FileType == 'stations'
+        assert p.Forecast_Hr == 'now'
+        assert p.Station_Owner == ['co-ops', 'ndbc', 'usgs', 'chs']
+        assert p.Horizon_Skill is False
+        assert p.Var_Selection == [
+            'water_level', 'water_temperature', 'salinity', 'currents'
+        ]
+        assert p.Currents_Bins_Csv is None
+        assert p.Disable_Model_File_Check is True
+        assert p.config is None
+
+    def test_custom_instantiation(self):
+        """Fields can be overridden at construction time."""
+        p = gui_helpers.GuiParams(
+            OFS='cbofs',
+            Path='/tmp/out',
+            Datum='NAVD88',
+            Horizon_Skill=True,
+        )
+        assert p.OFS == 'cbofs'
+        assert p.Path == '/tmp/out'
+        assert p.Datum == 'NAVD88'
+        assert p.Horizon_Skill is True
+        # Unspecified fields keep defaults
+        assert p.FileType == 'stations'
+
+    def test_mutable_defaults_are_independent(self):
+        """Each instance gets its own list for mutable defaults."""
+        p1 = gui_helpers.GuiParams()
+        p2 = gui_helpers.GuiParams()
+        p1.Station_Owner.append('extra')
+        assert 'extra' not in p2.Station_Owner
+
+    def test_attribute_assignment(self):
+        """Fields can be mutated after construction (GUI submit pattern)."""
+        p = gui_helpers.GuiParams()
+        p.OFS = 'leofs'
+        p.Whichcasts = ['nowcast', 'forecast_a']
+        assert p.OFS == 'leofs'
+        assert p.Whichcasts == ['nowcast', 'forecast_a']
+
+
 if __name__ == '__main__':
     pytest.main([__file__, '-v'])

--- a/tests/gui_helpers_test.py
+++ b/tests/gui_helpers_test.py
@@ -1,0 +1,474 @@
+"""Tests for ofs_skill.visualization.gui_helpers.
+
+Covers the pure-logic helpers, conf-driven datum lookup, and validators
+extracted from create_gui.py during the Phase 2 refactor. Helpers were
+designed to be testable without a Tk root, so every test runs headless.
+
+DateEntry instantiation is intentionally not exercised here (it requires a
+display); the corresponding test class verifies the widget's class-level
+configuration dictionary, which is the surface most likely to regress.
+"""
+
+from datetime import date, datetime, timezone
+
+import pytest
+
+from ofs_skill.visualization import gui_helpers
+
+
+# ---------------------------------------------------------------------------
+# Module-level constants
+# ---------------------------------------------------------------------------
+
+
+class TestConstants:
+    """Sanity checks on the module-level OFS / datum tuples."""
+
+    def test_great_lakes_ofs_membership(self):
+        """Every Great Lakes OFS should be present and lower-cased."""
+        for ofs in ('leofs', 'lmhofs', 'loofs', 'loofs2', 'lsofs'):
+            assert ofs in gui_helpers.GREAT_LAKES_OFS
+
+    def test_great_lakes_ofs_does_not_contain_coastal(self):
+        """Coastal OFSes must not leak into the Great Lakes group."""
+        for ofs in ('cbofs', 'ngofs2', 'wcofs', 'sscofs'):
+            assert ofs not in gui_helpers.GREAT_LAKES_OFS
+
+    def test_stofs_ofs_membership(self):
+        """All STOFS variants must be present."""
+        assert set(gui_helpers.STOFS_OFS) == {
+            'stofs_2d_glo', 'stofs_3d_atl', 'stofs_3d_pac'
+        }
+
+    def test_default_datums_includes_common_us_datums(self):
+        """Fallback datum list must cover the datums used by most OFSes."""
+        for datum in ('MHHW', 'MLLW', 'NAVD88', 'IGLD85'):
+            assert datum in gui_helpers.DEFAULT_DATUMS
+
+    def test_default_datums_is_immutable_tuple(self):
+        """Returned constant should be a tuple so callers can't mutate it."""
+        assert isinstance(gui_helpers.DEFAULT_DATUMS, tuple)
+
+
+# ---------------------------------------------------------------------------
+# quick_run_datum
+# ---------------------------------------------------------------------------
+
+
+class TestQuickRunDatum:
+    """Default-datum lookup for Quick Run mode."""
+
+    @pytest.mark.parametrize('ofs', ['leofs', 'lmhofs', 'loofs', 'loofs2', 'lsofs'])
+    def test_great_lakes_returns_igld85(self, ofs):
+        """Great Lakes OFSes use IGLD85 (no MLLW in fresh water)."""
+        assert gui_helpers.quick_run_datum(ofs) == 'IGLD85'
+
+    @pytest.mark.parametrize('ofs', ['stofs_2d_glo', 'stofs_3d_atl', 'stofs_3d_pac'])
+    def test_stofs_returns_navd88(self, ofs):
+        """STOFS systems lack a uniform tidal datum, so use NAVD88."""
+        assert gui_helpers.quick_run_datum(ofs) == 'NAVD88'
+
+    @pytest.mark.parametrize('ofs', ['cbofs', 'ngofs2', 'wcofs', 'sscofs', 'tbofs'])
+    def test_tidal_coastal_returns_mllw(self, ofs):
+        """Tidal coastal OFSes default to MLLW."""
+        assert gui_helpers.quick_run_datum(ofs) == 'MLLW'
+
+    def test_unknown_ofs_falls_back_to_mllw(self):
+        """Unknown OFS names fall through to the MLLW default."""
+        assert gui_helpers.quick_run_datum('not_a_real_ofs') == 'MLLW'
+
+
+# ---------------------------------------------------------------------------
+# compute_recent_cycle
+# ---------------------------------------------------------------------------
+
+
+class TestComputeRecentCycle:
+    """Most-recent-cycle picker with 2h NODD arrival delay."""
+
+    @pytest.fixture
+    def six_hourly_cycles(self, monkeypatch):
+        """Patch get_fcst_hours to advertise 00/06/12/18z cycles."""
+        monkeypatch.setattr(
+            gui_helpers, 'get_fcst_hours',
+            lambda ofs: ([], ['00', '06', '12', '18'])
+        )
+
+    def test_picks_06z_at_noon_utc(self, six_hourly_cycles):
+        """At 12:00 UTC, the 12z cycle is too fresh (cutoff=10:00); pick 06z."""
+        now = datetime(2025, 11, 12, 12, 0, tzinfo=timezone.utc)
+        iso, hr = gui_helpers.compute_recent_cycle('xxx', now=now)
+        assert iso == '2025-11-12T06:00:00Z'
+        assert hr == '06z'
+
+    def test_picks_12z_at_late_afternoon(self, six_hourly_cycles):
+        """At 17:00 UTC, cutoff=15:00 → 12z is most recent available."""
+        now = datetime(2025, 11, 12, 17, 0, tzinfo=timezone.utc)
+        iso, hr = gui_helpers.compute_recent_cycle('xxx', now=now)
+        assert iso == '2025-11-12T12:00:00Z'
+        assert hr == '12z'
+
+    def test_picks_18z_late_evening(self, six_hourly_cycles):
+        """At 23:00 UTC, cutoff=21:00 → 18z is most recent available."""
+        now = datetime(2025, 11, 12, 23, 0, tzinfo=timezone.utc)
+        iso, hr = gui_helpers.compute_recent_cycle('xxx', now=now)
+        assert iso == '2025-11-12T18:00:00Z'
+        assert hr == '18z'
+
+    def test_falls_back_to_yesterday_in_early_morning(self, six_hourly_cycles):
+        """At 01:00 UTC, even today's 00z is > cutoff (-01:00) → use yesterday's 18z."""
+        now = datetime(2025, 11, 12, 1, 0, tzinfo=timezone.utc)
+        iso, hr = gui_helpers.compute_recent_cycle('xxx', now=now)
+        assert iso == '2025-11-11T18:00:00Z'
+        assert hr == '18z'
+
+    def test_two_hour_delay_boundary_inclusive(self, six_hourly_cycles):
+        """A cycle exactly 2h old is considered available (cyc_dt <= cutoff)."""
+        # cutoff = 14:00; the 12z cycle (2h ago) is at the boundary.
+        now = datetime(2025, 11, 12, 14, 0, tzinfo=timezone.utc)
+        iso, hr = gui_helpers.compute_recent_cycle('xxx', now=now)
+        assert hr == '12z'
+        assert iso == '2025-11-12T12:00:00Z'
+
+    def test_unsorted_cycle_input_still_returns_correct_result(self, monkeypatch):
+        """Function sorts internally; upstream order shouldn't matter."""
+        monkeypatch.setattr(
+            gui_helpers, 'get_fcst_hours',
+            lambda ofs: ([], ['18', '00', '12', '06'])
+        )
+        now = datetime(2025, 11, 12, 12, 0, tzinfo=timezone.utc)
+        _, hr = gui_helpers.compute_recent_cycle('xxx', now=now)
+        assert hr == '06z'
+
+    def test_minute_and_second_components_dont_shift_cycle(self, six_hourly_cycles):
+        """Sub-hour drift in `now` should not change the chosen cycle."""
+        now = datetime(2025, 11, 12, 12, 59, 59, 999, tzinfo=timezone.utc)
+        _, hr = gui_helpers.compute_recent_cycle('xxx', now=now)
+        assert hr == '06z'
+
+    def test_iso_string_uses_z_suffix(self, six_hourly_cycles):
+        """Downstream CLI parses YYYY-MM-DDTHH:MM:SSZ — ensure the Z is present."""
+        now = datetime(2025, 11, 12, 12, 0, tzinfo=timezone.utc)
+        iso, _ = gui_helpers.compute_recent_cycle('xxx', now=now)
+        assert iso.endswith('Z')
+        assert 'T' in iso
+
+    def test_default_now_uses_real_clock(self, six_hourly_cycles):
+        """Omitting `now` should fall back to current UTC time without raising."""
+        iso, hr = gui_helpers.compute_recent_cycle('xxx')
+        assert iso.endswith('Z')
+        assert hr.endswith('z') and len(hr) == 3
+
+    def test_fallback_when_no_cycle_in_past_two_days_qualifies(self, monkeypatch):
+        """Edge case: a single late cycle + early-morning `now` exhausts the
+        2-day search window, exercising the safety-net fallback path."""
+        monkeypatch.setattr(
+            gui_helpers, 'get_fcst_hours',
+            lambda ofs: ([], ['23'])
+        )
+        # At 00:30 UTC the cutoff is yesterday 22:00. Today's 23z is 23h in
+        # the future and yesterday's 23z is 1h after the cutoff — both fail
+        # the `<= cutoff` check, so the function falls through to the
+        # "yesterday's last cycle" guess.
+        now = datetime(2025, 11, 12, 0, 30, tzinfo=timezone.utc)
+        iso, hr = gui_helpers.compute_recent_cycle('xxx', now=now)
+        assert iso == '2025-11-11T23:00:00Z'
+        assert hr == '23z'
+
+
+# ---------------------------------------------------------------------------
+# read_datum_list
+# ---------------------------------------------------------------------------
+
+
+def _patch_utils_section(monkeypatch, section_payload, exc=None):
+    """Helper: replace gui_helpers.utils.Utils with a fake whose
+    read_config_section either returns `section_payload` or raises `exc`."""
+
+    class FakeUtils:
+        def __init__(self, *_args, **_kwargs):
+            pass
+
+        def read_config_section(self, _section, _log):
+            if exc is not None:
+                raise exc
+            return section_payload
+
+    monkeypatch.setattr(gui_helpers.utils, 'Utils', FakeUtils)
+
+
+class TestReadDatumList:
+    """Conf-driven datum list with hardcoded fallback."""
+
+    def test_returns_parsed_tuple_from_conf(self, monkeypatch):
+        """Whitespace-separated datum_list should be split into a tuple."""
+        _patch_utils_section(monkeypatch, {'datum_list': 'NAVD88 MLLW IGLD85'})
+        assert gui_helpers.read_datum_list() == ('NAVD88', 'MLLW', 'IGLD85')
+
+    def test_collapses_arbitrary_whitespace(self, monkeypatch):
+        """str.split() with no arg collapses tabs/newlines/multi-spaces."""
+        _patch_utils_section(
+            monkeypatch, {'datum_list': '  NAVD88\t MLLW\n  IGLD85 '}
+        )
+        assert gui_helpers.read_datum_list() == ('NAVD88', 'MLLW', 'IGLD85')
+
+    def test_falls_back_when_datum_list_key_missing(self, monkeypatch):
+        """Section present but no datum_list key → defaults."""
+        _patch_utils_section(monkeypatch, {'something_else': 'x'})
+        assert gui_helpers.read_datum_list() == gui_helpers.DEFAULT_DATUMS
+
+    def test_falls_back_when_datum_list_empty_string(self, monkeypatch):
+        """Empty datum_list value → defaults (raw is falsy)."""
+        _patch_utils_section(monkeypatch, {'datum_list': ''})
+        assert gui_helpers.read_datum_list() == gui_helpers.DEFAULT_DATUMS
+
+    def test_falls_back_on_oserror(self, monkeypatch):
+        """Conf file IO failure must not crash the GUI launch."""
+        _patch_utils_section(monkeypatch, None, exc=OSError('boom'))
+        assert gui_helpers.read_datum_list() == gui_helpers.DEFAULT_DATUMS
+
+    def test_falls_back_on_keyerror(self, monkeypatch):
+        """Missing section raises KeyError; defaults must still be returned."""
+        _patch_utils_section(monkeypatch, None, exc=KeyError('datums'))
+        assert gui_helpers.read_datum_list() == gui_helpers.DEFAULT_DATUMS
+
+    def test_falls_back_on_attributeerror(self, monkeypatch):
+        """Defensive against malformed Utils objects in older configs."""
+        _patch_utils_section(monkeypatch, None, exc=AttributeError())
+        assert gui_helpers.read_datum_list() == gui_helpers.DEFAULT_DATUMS
+
+
+# ---------------------------------------------------------------------------
+# format_date
+# ---------------------------------------------------------------------------
+
+
+class TestFormatDate:
+    """ISO-string formatter consumed by the downstream CLI."""
+
+    def test_formats_basic_date_and_hour(self):
+        """Standard noon date → ISO Z string with seconds set to 00."""
+        assert (
+            gui_helpers.format_date(date(2025, 11, 12), 12)
+            == '2025-11-12T12:00:00Z'
+        )
+
+    def test_pads_single_digit_hour(self):
+        """Hour 6 must be rendered as '06' for downstream parsers."""
+        assert (
+            gui_helpers.format_date(date(2025, 11, 12), 6)
+            == '2025-11-12T06:00:00Z'
+        )
+
+    def test_accepts_string_hour(self):
+        """tk.Scale.get() returns strings; the function must coerce."""
+        assert (
+            gui_helpers.format_date(date(2025, 1, 1), '0')
+            == '2025-01-01T00:00:00Z'
+        )
+
+    def test_accepts_datetime_input_too(self):
+        """datetime is a subclass of date, so it should be accepted."""
+        assert (
+            gui_helpers.format_date(datetime(2025, 6, 15, 9, 30), 18)
+            == '2025-06-15T18:00:00Z'
+        )
+
+    def test_raises_typeerror_for_non_date(self):
+        """A bare string is not a date object and must be rejected."""
+        with pytest.raises(TypeError):
+            gui_helpers.format_date('2025-11-12', 12)
+
+    def test_raises_typeerror_for_none(self):
+        """None as date must raise (caller is responsible for the falsy check)."""
+        with pytest.raises(TypeError):
+            gui_helpers.format_date(None, 0)
+
+
+# ---------------------------------------------------------------------------
+# build_utc_datetime
+# ---------------------------------------------------------------------------
+
+
+class TestBuildUtcDatetime:
+    """Robust constructor used to normalise widget state for comparisons."""
+
+    def test_builds_correct_utc_datetime(self):
+        """Returned datetime should match inputs and carry UTC tzinfo."""
+        dt = gui_helpers.build_utc_datetime(date(2025, 11, 12), 6)
+        assert dt == datetime(2025, 11, 12, 6, tzinfo=timezone.utc)
+
+    def test_resulting_datetime_is_utc_aware(self):
+        """Comparisons would silently fail if tzinfo were missing."""
+        dt = gui_helpers.build_utc_datetime(date(2025, 1, 1), 0)
+        assert dt.tzinfo is not None
+        assert dt.utcoffset().total_seconds() == 0
+
+    def test_accepts_string_hour(self):
+        """tk.Scale.get() returns strings; coercion must succeed."""
+        dt = gui_helpers.build_utc_datetime(date(2025, 1, 1), '23')
+        assert dt.hour == 23
+
+    def test_returns_none_for_falsy_date(self):
+        """Empty/None date (widget never populated) → None, not a crash."""
+        assert gui_helpers.build_utc_datetime(None, 0) is None
+        assert gui_helpers.build_utc_datetime('', 0) is None
+
+    def test_returns_none_for_non_integer_hour(self):
+        """Non-integer hour string from a malformed widget → None."""
+        assert gui_helpers.build_utc_datetime(date(2025, 1, 1), 'noon') is None
+
+    def test_returns_none_for_out_of_range_hour(self):
+        """Hour 24 raises ValueError inside datetime(); caller gets None."""
+        assert gui_helpers.build_utc_datetime(date(2025, 1, 1), 24) is None
+
+
+# ---------------------------------------------------------------------------
+# validate_date_order
+# ---------------------------------------------------------------------------
+
+
+class TestValidateDateOrder:
+    """Pure-logic check that start is strictly before end."""
+
+    def test_returns_none_when_start_before_end(self):
+        """Valid ordering → no error."""
+        s = datetime(2025, 1, 1, tzinfo=timezone.utc)
+        e = datetime(2025, 1, 2, tzinfo=timezone.utc)
+        assert gui_helpers.validate_date_order(s, e) is None
+
+    def test_returns_error_when_start_equals_end(self):
+        """Strict inequality: equal timestamps are rejected."""
+        s = e = datetime(2025, 1, 1, tzinfo=timezone.utc)
+        msg = gui_helpers.validate_date_order(s, e)
+        assert msg == 'Start date/hour must be before end date/hour.'
+
+    def test_returns_error_when_start_after_end(self):
+        """Reversed inputs trigger the validator."""
+        s = datetime(2025, 1, 2, tzinfo=timezone.utc)
+        e = datetime(2025, 1, 1, tzinfo=timezone.utc)
+        assert gui_helpers.validate_date_order(s, e) is not None
+
+    def test_returns_none_when_start_is_none(self):
+        """Missing inputs are someone else's problem (other validators)."""
+        e = datetime(2025, 1, 1, tzinfo=timezone.utc)
+        assert gui_helpers.validate_date_order(None, e) is None
+
+    def test_returns_none_when_end_is_none(self):
+        """Missing inputs are someone else's problem (other validators)."""
+        s = datetime(2025, 1, 1, tzinfo=timezone.utc)
+        assert gui_helpers.validate_date_order(s, None) is None
+
+    def test_returns_none_when_both_none(self):
+        """Empty form: no opinion to offer."""
+        assert gui_helpers.validate_date_order(None, None) is None
+
+
+# ---------------------------------------------------------------------------
+# validate_start_not_future
+# ---------------------------------------------------------------------------
+
+
+class TestValidateStartNotFuture:
+    """UTC-aware future-date guard with injectable clock."""
+
+    def test_returns_none_when_start_in_past(self):
+        """Past date is always valid."""
+        start = datetime(2020, 1, 1, tzinfo=timezone.utc)
+        now = datetime(2025, 1, 1, tzinfo=timezone.utc)
+        assert gui_helpers.validate_start_not_future(start, now=now) is None
+
+    def test_returns_none_when_start_equals_now(self):
+        """Inclusive boundary: start == now is allowed (only > now is rejected)."""
+        now = datetime(2025, 1, 1, 12, tzinfo=timezone.utc)
+        assert gui_helpers.validate_start_not_future(now, now=now) is None
+
+    def test_returns_error_when_start_in_future(self):
+        """Future start is rejected with the canonical error message."""
+        start = datetime(2099, 1, 1, tzinfo=timezone.utc)
+        now = datetime(2025, 1, 1, tzinfo=timezone.utc)
+        assert gui_helpers.validate_start_not_future(start, now=now) == (
+            'Start date/hour cannot be in the future (UTC).'
+        )
+
+    def test_returns_none_when_start_is_none(self):
+        """Missing input is a different validator's responsibility."""
+        assert gui_helpers.validate_start_not_future(None) is None
+
+    def test_default_now_uses_real_clock(self):
+        """Omitting `now` should still work; a 1970 date is always past."""
+        start = datetime(1970, 1, 1, tzinfo=timezone.utc)
+        assert gui_helpers.validate_start_not_future(start) is None
+
+
+# ---------------------------------------------------------------------------
+# validate_horizon_requires_stations
+# ---------------------------------------------------------------------------
+
+
+class TestValidateHorizonRequiresStations:
+    """Horizon_Skill is only implemented for the station model output files."""
+
+    def test_returns_none_when_horizon_off(self):
+        """Filetype is irrelevant when horizon assessment is disabled."""
+        assert gui_helpers.validate_horizon_requires_stations(False, 'fields') is None
+        assert gui_helpers.validate_horizon_requires_stations(False, 'stations') is None
+
+    def test_returns_none_when_horizon_on_with_stations(self):
+        """Supported combination: no error."""
+        assert (
+            gui_helpers.validate_horizon_requires_stations(True, 'stations')
+            is None
+        )
+
+    def test_returns_error_when_horizon_on_with_fields(self):
+        """The unsupported combo must surface a guiding error message."""
+        msg = gui_helpers.validate_horizon_requires_stations(True, 'fields')
+        assert msg is not None
+        assert 'Station' in msg
+        assert 'forecast horizons' in msg
+
+    def test_returns_error_for_any_non_stations_filetype(self):
+        """Defensive: arbitrary filetype strings still trigger the check."""
+        assert (
+            gui_helpers.validate_horizon_requires_stations(True, 'something_new')
+            is not None
+        )
+
+
+# ---------------------------------------------------------------------------
+# DateEntry class-level configuration
+# ---------------------------------------------------------------------------
+
+
+class TestDateEntryClassAttributes:
+    """Verify DateEntry's static config without instantiating Tk widgets."""
+
+    def test_inherits_from_tkcalendar_dateentry(self):
+        """Drop-in replacement contract: must be a tkcalendar DateEntry subclass."""
+        from tkcalendar import DateEntry as TkDateEntry
+        assert issubclass(gui_helpers.DateEntry, TkDateEntry)
+
+    def test_color_defaults_present(self):
+        """All cell colours must be defined to override the dark-blue inherit."""
+        defaults = gui_helpers.DateEntry._CAL_COLOR_DEFAULTS
+        for key in (
+            'normalbackground', 'normalforeground',
+            'selectbackground', 'selectforeground',
+            'weekendbackground', 'weekendforeground',
+            'headersbackground', 'headersforeground',
+            'othermonthbackground', 'othermonthforeground',
+            'bordercolor',
+        ):
+            assert key in defaults, f'missing color default: {key}'
+
+    def test_color_defaults_have_visible_contrast(self):
+        """Foreground must not equal background — guards regression to all-dark."""
+        d = gui_helpers.DateEntry._CAL_COLOR_DEFAULTS
+        assert d['normalbackground'] != d['normalforeground']
+        assert d['selectbackground'] != d['selectforeground']
+        assert d['weekendbackground'] != d['weekendforeground']
+
+
+if __name__ == '__main__':
+    pytest.main([__file__, '-v'])


### PR DESCRIPTION
## Summary

Phase 2 of the GUI roadmap(issue #138, Phase 2): a foundation refactor that prepares `create_gui.py` for the new GUI surfaces planned in later phases. No user-facing behaviour changes, same widgets, same defaults, same submit flow, but the code is now modular, tested, type-checked, and visually grouped.

## Changes

### 1. Extract reusable helpers into `gui_helpers.py`
Moved all pure-logic helpers and the cross-platform `DateEntry` widget out of `create_gui.py` into a new `src/ofs_skill/visualization/gui_helpers.py`:

- `DateEntry` themed `tkcalendar.DateEntry` subclass with the cross-platform calendar-popup grace-period fix.
- `quick_run_datum`, `compute_recent_cycle`, `read_datum_list`
- `format_date`, `build_utc_datetime`
- `validate_date_order`, `validate_start_not_future`, `validate_horizon_requires_stations`
- Module-level constants: `GREAT_LAKES_OFS`, `STOFS_OFS`, `DEFAULT_DATUMS`

`create_gui.py` now imports these from `gui_helpers` and focuses on layout + wiring only.

### 2. Add unit tests for helpers
New `tests/gui_helpers_test.py` with 11 test classes (parametrized where useful, monkeypatched for IO):

- `TestConstants`, `TestQuickRunDatum`, `TestComputeRecentCycle`, `TestReadDatumList`
- `TestFormatDate`, `TestBuildUtcDatetime`
- `TestValidateDateOrder`, `TestValidateStartNotFuture`, `TestValidateHorizonRequiresStations`
- `TestDateEntryClassAttributes`, `TestGuiParams`

### 3. Introduce `GuiParams` dataclass
A typed schema in `gui_helpers.py` whose field names mirror the `create_1dplot.py` argparse `dest` attributes one-for-one (14 fields, defaults match argparse). Replaces the previous `SimpleNamespace` + manual default-population block in `create_gui.py` with a single `args_values = GuiParams()`.

### 4. Reorganize widgets into labeled sections
Widgets are now grouped into six `tk.LabelFrame` sections instead of a flat row-by-row grid:

1. **General Settings** - Home directory, Config file, OFS dropdown, Quick Run
2. **Time Range** - Start / End date + hour scales
3. **Whichcast & Forecast** - Nowcast / Forecast_b / Forecast_a / Hindcast checkboxes, Model cycle dropdown
4. **Datum & Output** - Vertical datum, Station/Field radio
5. **Stations & Variables** - Provider checkboxes (CO-OPS, NDBC, USGS, list), variable checkboxes
6. **Advanced** - Horizon Skill, Currents bins CSV, model-file pre-check

Two tiny internal helpers (`_section`, `_label`) DRY the repeated frame/label styling. All event bindings, validators, and the submit flow are unchanged.

#### New Labeled Sections
<img width="701" height="650" alt="Screenshot 2026-06-05 at 16 01 05" src="https://github.com/user-attachments/assets/9a98b7fc-176b-46a8-8e0e-eee89596aa57" />
<img width="703" height="650" alt="Screenshot 2026-06-05 at 16 02 10" src="https://github.com/user-attachments/assets/51062d33-bfa3-4ff5-84c2-904a1a9362f1" />
