### PR TITLE
Add Custom Model File Input and Enhanced CO-OPS Current Data Retrieval

### DIFF
--- a/bin/visualization/create_1dplot.py
+++ b/bin/visualization/create_1dplot.py
@@ -70,6 +70,7 @@ import logging
 import logging.config
 import os
 import sys
+import time
 import warnings
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import UTC, datetime
@@ -576,7 +577,13 @@ def create_1dplot(prop, logger):
                        ['datum_list']).split(' ')
     conf_settings = utils.Utils(_conf).read_config_section('settings', logger)
     prop.static_plots = conf_settings['static_plots']
-
+    use_custom_files = conf_settings.get('use_custom_filenames', 'False').lower() in ('true', '1', 'yes')
+    if use_custom_files:
+        logger.warning('HEADS UP: You are using custom model input file names! '
+                       'If you want to disable this option, update your conf '
+                       'file and restart. Pausing 5 seconds...')
+        time.sleep(5)
+        logger.info('Continuing with custom file names...')
 
     # Parse incoming arguments stored in prop from string to a list
     prop.whichcasts = parse_arguments_to_list(prop.whichcasts, logger)

--- a/bin/visualization/create_1dplot.py
+++ b/bin/visualization/create_1dplot.py
@@ -741,10 +741,10 @@ def create_1dplot(prop, logger):
 
     # Hindcast validation -- LOOFS2 only! Also, LOOFS2 cannot use nowcast or
     # forecast yet.
-    if prop.ofs == 'loofs2':
+    if prop.ofs in ['loofs2']:
         prop.whichcasts = ['hindcast']
-    if 'hindcast' in prop.whichcasts and prop.ofs != 'loofs2':
-        logger.warning('Hindcast can only be used with loofs2! Switching to '
+    if 'hindcast' in prop.whichcasts and prop.ofs not in ['loofs2','necofs']:
+        logger.warning('Hindcast can only be used with loofs2 or necofs! Switching to '
                        'nowcast + forecast_b...')
         prop.whichcasts = ['nowcast', 'forecast_b']
 

--- a/bin/visualization/create_1dplot.py
+++ b/bin/visualization/create_1dplot.py
@@ -582,7 +582,7 @@ def create_1dplot(prop, logger):
         logger.warning('HEADS UP: You are using custom model input file names! '
                        'If you want to disable this option, update your conf '
                        'file and restart. Pausing 5 seconds...')
-        time.sleep(5)
+        time.sleep(10)
         logger.info('Continuing with custom file names...')
 
     # Parse incoming arguments stored in prop from string to a list

--- a/bin/visualization/create_1dplot.py
+++ b/bin/visualization/create_1dplot.py
@@ -579,10 +579,11 @@ def create_1dplot(prop, logger):
     prop.static_plots = conf_settings['static_plots']
     use_custom_files = conf_settings.get('use_custom_filenames', 'False').lower() in ('true', '1', 'yes')
     if use_custom_files:
+        pause_seconds = 5
         logger.warning('HEADS UP: You are using custom model input file names! '
                        'If you want to disable this option, update your conf '
-                       'file and restart. Pausing 5 seconds...')
-        time.sleep(10)
+                       'file and restart. Pausing %d seconds...', pause_seconds)
+        time.sleep(pause_seconds)
         logger.info('Continuing with custom file names...')
 
     # Parse incoming arguments stored in prop from string to a list

--- a/conf/ofs_dps.conf.example
+++ b/conf/ofs_dps.conf.example
@@ -196,5 +196,5 @@ use_s3_fallback=True
 # True = load filenames from user-provided text file
 # False = default; SA will fetch file names either from the S3 bucket, or locally
 # If True, set 'filename_path' to the path to your text file, including the filename.
-use_custom_filenames=True
+use_custom_filenames=False
 filename_path=path/to/filename.txt

--- a/conf/ofs_dps.conf.example
+++ b/conf/ofs_dps.conf.example
@@ -89,7 +89,7 @@ nssr_sport=https://nssrgeo.ndc.nasa.gov/SPoRT/enhanced_sst/ghrsst_netcdf
 [datums]
 # List of vertical datums that the program can convert between. If a new datum
 # is added to the package, include it here!
-datum_list = MHHW MHW MLLW MLW NAVD88 IGLD85 LWD XGEOID20B
+datum_list=MHHW MHW MLLW MLW NAVD88 IGLD85 LWD XGEOID20B
 
 
 [station_IDs]
@@ -101,7 +101,7 @@ datum_list = MHHW MHW MLLW MLW NAVD88 IGLD85 LWD XGEOID20B
 # `--Station_Owner list`
 # If using `-so list` and the list below is blank, the skill
 # assessment will include all stations found in an OFS.
-station_ID_list = 8551910 8571421
+station_ID_list=8551910 8571421
 
 
 [user_xy_inputs]
@@ -116,7 +116,7 @@ station_ID_list = 8551910 8571421
 # For example:
 #    myloc1 39.582 -75.589 0
 #    myloc2 37.996 -76.464 2
-user_xy_path = path/to/filename.txt
+user_xy_path=path/to/filename.txt
 
 
 [parallelization]
@@ -191,3 +191,10 @@ static_plots=False
 # True = automatically read from NODD S3 bucket if local files are missing
 # False = exit with error if local files are missing (original behavior)
 use_s3_fallback=True
+
+# Use a custom list of model files?
+# True = load filenames from user-provided text file
+# False = default; SA will fetch file names either from the S3 bucket, or locally
+# If True, set 'filename_path' to the path to your text file, including the filename.
+use_custom_filenames=True
+filename_path=path/to/filename.txt

--- a/src/ofs_skill/model_processing/check_model_files.py
+++ b/src/ofs_skill/model_processing/check_model_files.py
@@ -9,6 +9,7 @@ those missing files from the NODD bucket.
 Functions
 ---------
 check_model_files : Main validation function that checks for required model files
+check_custom_file_list : Verifies files from a provided text file (Local, S3, or HTTP/HTTPS)
 
 Notes
 -----
@@ -25,14 +26,97 @@ Created: Fri Aug 8 08:59:28 2025
 """
 
 import os
+import urllib.parse
+import urllib.request
 from datetime import datetime
 from logging import Logger
 from pathlib import Path
 from typing import Any
+from urllib.error import HTTPError, URLError
 
 from bin.utils import get_model_data
 from ofs_skill.model_processing.list_of_files import list_of_dir, list_of_files
 from ofs_skill.obs_retrieval import utils
+
+
+def check_custom_file_list(file_list_path: str, logger: Logger) -> None:
+    """
+    Reads a text file containing a list of paths (local, S3 URIs, or HTTPS URLs) and
+    verifies that they exist.
+
+    Parameters
+    ----------
+    file_list_path : str
+        Path to the text file containing a list of model file locations.
+    logger : Logger
+        Logger instance for logging messages.
+    """
+    if not os.path.exists(file_list_path):
+        logger.error(f'Custom file list text file not found: {file_list_path}')
+        raise SystemExit(1)
+
+    with open(file_list_path) as f:
+        files_to_check = [line.strip() for line in f if line.strip()]
+
+    if not files_to_check:
+        logger.error('The custom file list is empty.')
+        raise SystemExit(1)
+
+    s3_client = None
+    missing_files = []
+
+    for filepath in files_to_check:
+        # Check native S3 paths
+        if filepath.startswith('s3://'):
+            if s3_client is None:
+                try:
+                    import boto3
+                    # If dealing with public NODD buckets, you may need to configure
+                    # unsigned requests: boto3.client('s3', config=Config(signature_version=UNSIGNED))
+                    s3_client = boto3.client('s3')
+                except ImportError:
+                    logger.error('boto3 library is required to verify s3:// paths. Please install it.')
+                    raise SystemExit(1)
+
+            parsed = urllib.parse.urlparse(filepath)
+            bucket = parsed.netloc
+            key = parsed.path.lstrip('/')
+
+            try:
+                s3_client.head_object(Bucket=bucket, Key=key)
+            except Exception:
+                # Catching general exception; typically botocore.exceptions.ClientError for 404/403
+                missing_files.append(filepath)
+
+        # Check HTTP/HTTPS paths pointing to S3 (or any web server)
+        elif filepath.startswith(('http://', 'https://')):
+            try:
+                # Use a HEAD request to check for file existence without downloading the payload
+                req = urllib.request.Request(
+                    filepath,
+                    headers={'User-Agent': 'Mozilla/5.0'},
+                    method='HEAD'
+                )
+                with urllib.request.urlopen(req, timeout=10) as response:
+                    if response.status >= 400:
+                        missing_files.append(filepath)
+            except (HTTPError, URLError):
+                # HTTPError handles 403 Forbidden, 404 Not Found, etc. URLError handles connection failures.
+                missing_files.append(filepath)
+            except Exception:
+                missing_files.append(filepath)
+
+        # Check local paths
+        else:
+            if not os.path.exists(filepath):
+                missing_files.append(filepath)
+
+    if missing_files:
+        logger.error('The following custom files are missing:\n{}'.format('\n'.join(missing_files)))
+        raise SystemExit(1)
+    else:
+        logger.info('All custom files from the provided list were verified successfully.')
+
 
 
 def check_model_files(prop: Any, logger: Logger) -> None:
@@ -69,20 +153,29 @@ def check_model_files(prop: Any, logger: Logger) -> None:
     ------
     SystemExit
         If model files are missing or if there are errors in date formatting
-
-    Notes
-    -----
-    - Handles both ISO format dates (with 'T' and 'Z') and simple format dates
-    - Creates a wish list of files that should exist based on configuration
-    - Creates an actual list of files that do exist in the directories
-    - Cross-checks and reports any discrepancies
-    - Resets date formats to original values before returning
-
-    Examples
-    --------
-    >>> check_model_files(prop, logger)
-    INFO:root:Located all necessary model files for nowcast!
     """
+
+    # Check if custom filename input is enabled
+    _conf = getattr(prop, 'config_file', None)
+    try:
+        conf_settings = utils.Utils(_conf).read_config_section('settings', logger)
+        use_custom_files = conf_settings.get('use_custom_filenames', 'False').lower() in ('true', '1', 'yes')
+        # Retrieve the path to the text file list from config (adjust key as needed)
+        custom_file_list_path = conf_settings.get('filename_path', '')
+    except Exception:
+        use_custom_files = False
+        custom_file_list_path = ''
+
+    if use_custom_files:
+        logger.info('Custom model file input is enabled! Checking to see if '
+                    'files are available...')
+        if custom_file_list_path:
+            check_custom_file_list(custom_file_list_path, logger)
+        else:
+            logger.warning('use_custom_filenames is enabled, but no path '
+                           'was found in the configuration!')
+        return
+
     # This first chunk handles the main skill assessment
     for cast in prop.whichcasts:
         prop.whichcast = cast

--- a/src/ofs_skill/model_processing/check_model_files.py
+++ b/src/ofs_skill/model_processing/check_model_files.py
@@ -39,6 +39,18 @@ from ofs_skill.model_processing.list_of_files import list_of_dir, list_of_files
 from ofs_skill.obs_retrieval import utils
 
 
+class _NoRedirect(urllib.request.HTTPRedirectHandler):
+    """urllib handler that refuses to follow redirects on the HEAD probe.
+
+    Following redirects on an arbitrary custom URL could bounce the request to
+    an unexpected internal host (SSRF). A 3xx is treated as a verification
+    failure instead.
+    """
+
+    def redirect_request(self, *_args, **_kwargs):  # noqa: D102
+        return None
+
+
 def check_custom_file_list(file_list_path: str, logger: Logger) -> None:
     """
     Reads a text file containing a list of paths (local, S3 URIs, or HTTPS URLs) and
@@ -63,6 +75,11 @@ def check_custom_file_list(file_list_path: str, logger: Logger) -> None:
         raise SystemExit(1)
 
     s3_client = None
+    # Exception types are bound alongside the client on first use; default to
+    # empty tuples so the except clauses are always defined (and match nothing
+    # until boto3 is actually imported).
+    s3_client_error: Any = ()
+    s3_other_errors: Any = ()
     missing_files = []
 
     for filepath in files_to_check:
@@ -71,9 +88,19 @@ def check_custom_file_list(file_list_path: str, logger: Logger) -> None:
             if s3_client is None:
                 try:
                     import boto3
-                    # If dealing with public NODD buckets, you may need to configure
-                    # unsigned requests: boto3.client('s3', config=Config(signature_version=UNSIGNED))
-                    s3_client = boto3.client('s3')
+                    from botocore import UNSIGNED
+                    from botocore.client import Config
+                    from botocore.exceptions import (
+                        BotoCoreError,
+                        ClientError,
+                        NoCredentialsError,
+                    )
+                    # NODD buckets are public; sign-less requests avoid the 403
+                    # that a default (signed) client returns without creds.
+                    s3_client = boto3.client(
+                        's3', config=Config(signature_version=UNSIGNED))
+                    s3_client_error = ClientError
+                    s3_other_errors = (BotoCoreError, NoCredentialsError)
                 except ImportError:
                     logger.error('boto3 library is required to verify s3:// paths. Please install it.')
                     raise SystemExit(1)
@@ -84,27 +111,46 @@ def check_custom_file_list(file_list_path: str, logger: Logger) -> None:
 
             try:
                 s3_client.head_object(Bucket=bucket, Key=key)
-            except Exception:
-                # Catching general exception; typically botocore.exceptions.ClientError for 404/403
+            except s3_client_error as exc:
+                code = exc.response.get('Error', {}).get('Code', '')
+                if code in ('404', 'NoSuchKey', 'NoSuchBucket'):
+                    missing_files.append(filepath)
+                else:
+                    # 403/permission/transient: log distinctly rather than
+                    # implying the object simply does not exist.
+                    logger.error(
+                        'Could not verify s3 path %s (error %s); treating as '
+                        'unverified.', filepath, code)
+                    missing_files.append(filepath)
+            except s3_other_errors as exc:
+                logger.error('S3 client error verifying %s: %s', filepath, exc)
                 missing_files.append(filepath)
 
-        # Check HTTP/HTTPS paths pointing to S3 (or any web server)
-        elif filepath.startswith(('http://', 'https://')):
+        # Check HTTPS paths pointing to S3 (or any web server). Plain http://
+        # is rejected: cleartext + redirect-following is an SSRF foot-gun.
+        elif filepath.startswith('https://'):
             try:
-                # Use a HEAD request to check for file existence without downloading the payload
+                # HEAD request: check existence without downloading the payload.
+                # Use an opener with redirects disabled so a crafted entry cannot
+                # bounce the probe to an unexpected internal host.
                 req = urllib.request.Request(
                     filepath,
                     headers={'User-Agent': 'Mozilla/5.0'},
                     method='HEAD'
                 )
-                with urllib.request.urlopen(req, timeout=10) as response:
+                opener = urllib.request.build_opener(_NoRedirect)
+                with opener.open(req, timeout=10) as response:
                     if response.status >= 400:
                         missing_files.append(filepath)
-            except (HTTPError, URLError):
-                # HTTPError handles 403 Forbidden, 404 Not Found, etc. URLError handles connection failures.
+            except (HTTPError, URLError) as exc:
+                # HTTPError covers 403/404; URLError covers connection failures.
+                logger.error('Could not verify URL %s: %s', filepath, exc)
                 missing_files.append(filepath)
-            except Exception:
-                missing_files.append(filepath)
+        elif filepath.startswith('http://'):
+            logger.error(
+                'Refusing to verify insecure http:// custom file entry %s; '
+                'use https:// or s3:// instead.', filepath)
+            missing_files.append(filepath)
 
         # Check local paths
         else:
@@ -160,9 +206,11 @@ def check_model_files(prop: Any, logger: Logger) -> None:
     try:
         conf_settings = utils.Utils(_conf).read_config_section('settings', logger)
         use_custom_files = conf_settings.get('use_custom_filenames', 'False').lower() in ('true', '1', 'yes')
-        # Retrieve the path to the text file list from config (adjust key as needed)
+        # Retrieve the path to the text file list from config
         custom_file_list_path = conf_settings.get('filename_path', '')
-    except Exception:
+    except (KeyError, AttributeError, ValueError, OSError) as exc:
+        logger.warning('Could not read [settings] for custom-file check (%s); '
+                       'proceeding with default model file discovery.', exc)
         use_custom_files = False
         custom_file_list_path = ''
 

--- a/src/ofs_skill/model_processing/get_node_ofs.py
+++ b/src/ofs_skill/model_processing/get_node_ofs.py
@@ -904,6 +904,12 @@ def parameter_validation(prop, dir_params, logger):
             prop.var_list = ['water_level']
             # I think we can alter its state here, but maybe there's a reason not to?
 
+def read_custom_filenames(filepath):
+    with open(filepath) as file:
+        # Reads the whole file and splits it into a list, removing '\n'
+        lines = file.read().splitlines()
+    return lines
+
 
 def get_node_ofs(prop, logger, model_dataset=None):
     """
@@ -946,6 +952,14 @@ def get_node_ofs(prop, logger, model_dataset=None):
     dir_params = utils.Utils(_conf).read_config_section('directories', logger)
     prop.datum_list = (utils.Utils(_conf).read_config_section('datums', logger)\
                        ['datum_list']).split(' ')
+
+    # Check if custom filename input is enabled
+    try:
+        conf_settings = utils.Utils(_conf).read_config_section('settings', logger)
+        use_custom_files = conf_settings.get('use_custom_filenames', 'False').lower() in ('true', '1', 'yes')
+    except Exception:
+        use_custom_files = False
+
     # Parse variable selection input to list
     prop.var_list = parse_arguments_to_list(prop.var_list, logger)
     # Parameter validation
@@ -995,8 +1009,23 @@ def get_node_ofs(prop, logger, model_dataset=None):
         model = model_dataset
         logger.info('Using pre-loaded model dataset (skipping intake_model)')
     else:
-        dir_list = list_of_dir(prop, logger)
-        list_files = list_of_files_func(prop, dir_list, logger)
+        if not use_custom_files:
+            dir_list = list_of_dir(prop, logger)
+            list_files = list_of_files_func(prop, dir_list, logger)
+        else:
+            filepath = (utils.Utils(_conf).read_config_section('settings', logger)\
+                               ['filename_path'])
+            try:
+                list_files = read_custom_filenames(filepath)
+            except FileNotFoundError:
+                logger.error('No custom model filename file found in get_node_ofs! '
+                             'Please check the file path and try again.')
+                raise SystemExit(1)
+            except Exception as e:
+                logger.error('Error when loading custom filenames from file in '
+                             'get_node_ofs! Error: %s', e)
+                raise SystemExit(1)
+
         logging.info('About to start intake_scisa from get_node ...')
         model = intake_model(list_files, prop, logger)
         logging.info('Lazily loaded dataset complete for %s!', prop.whichcast)

--- a/src/ofs_skill/model_processing/get_node_ofs.py
+++ b/src/ofs_skill/model_processing/get_node_ofs.py
@@ -492,6 +492,11 @@ def format_temp_salt(prop, model, ofs_ctlfile, model_var, i, precomputed=None):
 
     formatted_series = \
         scalar(data_model, start_date, end_date)
+
+    if not formatted_series:
+        logger.error('Formatted series is empty in format_temp_salt! If using '
+                     'custom model file names, make sure input date range and '
+                     'the date range of your files overlap.')
     return formatted_series
 
 
@@ -673,6 +678,11 @@ def format_currents(prop, model, ofs_ctlfile, i, precomputed=None):
     formatted_series = \
         vector(mfp.data_model, start_date, end_date)
 
+    if not formatted_series:
+        logger.error('Formatted series is empty in format_currents! If using '
+                     'custom model file names, make sure input date range and '
+                     'the date range of your files overlap.')
+
     return formatted_series
 
 
@@ -779,6 +789,11 @@ def format_waterlevel(prop, model, ofs_ctlfile, model_var,
 
     formatted_series = \
         scalar(data_model, start_date, end_date)
+
+    if not formatted_series:
+        logger.error('Formatted series is empty in format_waterlevel! If using '
+                     'custom model file names, make sure input date range and '
+                     'the date range of your files overlap.')
 
     return formatted_series, datum_offset
 
@@ -1318,7 +1333,8 @@ def get_node_ofs(prop, logger, model_dataset=None):
             for variable in prop.var_list:
                 prop_local = copy.deepcopy(prop)
                 prop_local.var_list = [variable]
-                futures.append(executor.submit(_extract_variable, variable, prop_local))
+                futures.append(executor.submit(
+                    _extract_variable, variable, prop_local))
             for f in futures:
                 f.result()  # Raise any exceptions
     else:

--- a/src/ofs_skill/model_processing/get_node_ofs.py
+++ b/src/ofs_skill/model_processing/get_node_ofs.py
@@ -20,6 +20,7 @@ from pathlib import Path
 
 import numpy as np
 import pandas as pd
+import xarray as xr
 
 from ofs_skill.model_processing import do_horizon_skill_utils
 
@@ -797,6 +798,53 @@ def format_waterlevel(prop, model, ofs_ctlfile, model_var,
 
     return formatted_series, datum_offset
 
+def find_time_variable_name(ds: xr.Dataset) -> str:
+    """Scans an xarray Dataset to find the coordinate name representing time
+
+    based on its datetime64 data type.
+    """
+    # First, check the coordinates (most common place for the time dimension)
+    for coord_name in ds.coords:
+        if np.issubdtype(ds[coord_name].dtype, np.datetime64):
+            return str(coord_name)
+
+    # Fallback: check data variables if it wasn't explicitly marked as a coordinate
+    for var_name in ds.data_vars:
+        if np.issubdtype(ds[var_name].dtype, np.datetime64):
+            return str(var_name)
+
+    raise ValueError(
+        'Could not automatically detect a datetime variable in this dataset.'
+    )
+
+
+def has_date_overlap(
+    start_date: datetime,
+    end_date: datetime,
+    ds: xr.Dataset,
+    ) -> bool:
+    """Checks for a date overlap by auto-detecting the time variable in an
+
+    xarray Dataset.
+    """
+    # 1. Auto-detect the time coordinate name
+    time_var_name = find_time_variable_name(ds)
+
+    # 2. Extract the lazy-loaded time array using the detected name
+    time_array = ds[time_var_name]
+
+    # 3. Convert input Python datetimes to numpy.datetime64
+    np_start = np.datetime64(start_date)
+    np_end = np.datetime64(end_date)
+
+    # 4. Extract min and max boundaries lazily
+    xr_min = time_array.min().values
+    xr_max = time_array.max().values
+
+    # 5. Check for overlap
+    overlap = (np_start <= xr_max) and (xr_min <= np_end)
+
+    return bool(overlap)
 
 def parameter_validation(prop, dir_params, logger):
     """Parameter validation"""
@@ -1044,6 +1092,28 @@ def get_node_ofs(prop, logger, model_dataset=None):
         logging.info('About to start intake_scisa from get_node ...')
         model = intake_model(list_files, prop, logger)
         logging.info('Lazily loaded dataset complete for %s!', prop.whichcast)
+
+        if use_custom_files:
+            # Check if dates of loaded model data overlap with user-input dates
+            try:
+                date_overlap = has_date_overlap(datetime.strptime(
+                    start_date_internal.split('-')[0], '%Y%m%d'),
+                    datetime.strptime(end_date_internal.split('-')[0], '%Y%m%d'),
+                    model)
+                if not date_overlap:
+                    logger.error('The date range of the loaded model files '
+                                 'does not overlap with the start and end '
+                                 'dates of the skill assessment run. Please '
+                                 'either disable custom file name loading '
+                                 'in the conf file, or check that the provided '
+                                 'filenames are correct. Exiting...')
+                    raise SystemExit(1)
+            except Exception as e:
+                logger.error('Cannot verify if the dates in user-supplied '
+                             'custom model files overlap with the start and '
+                             'end dates of the skill assessment run. Program '
+                             'may crash further down the pipeline! Error: %s',
+                             e)
 
     if not model:
         logger.error('No model files or URLs to load in intake! Exiting...')

--- a/src/ofs_skill/model_processing/get_node_ofs.py
+++ b/src/ofs_skill/model_processing/get_node_ofs.py
@@ -1301,8 +1301,19 @@ def parameter_validation(prop, dir_params, logger):
             # I think we can alter its state here, but maybe there's a reason not to?
 
 def read_custom_filenames(filepath):
+    """Read a custom model-file list, one path/URL per line.
+
+    Parameters
+    ----------
+    filepath : str
+        Path to the text file enumerating model file locations.
+
+    Returns
+    -------
+    list[str]
+        One entry per line with trailing newlines stripped.
+    """
     with open(filepath) as file:
-        # Reads the whole file and splits it into a list, removing '\n'
         lines = file.read().splitlines()
     return lines
 
@@ -1420,7 +1431,9 @@ def get_node_ofs(prop, logger, model_dataset=None):
     try:
         conf_settings = utils.Utils(_conf).read_config_section('settings', logger)
         use_custom_files = conf_settings.get('use_custom_filenames', 'False').lower() in ('true', '1', 'yes')
-    except Exception:
+    except (KeyError, AttributeError, ValueError, OSError) as exc:
+        logger.warning('Could not read [settings] for custom-file mode (%s); '
+                       'proceeding with default model file discovery.', exc)
         use_custom_files = False
 
     # Parse variable selection input to list

--- a/src/ofs_skill/model_processing/intake_scisa.py
+++ b/src/ofs_skill/model_processing/intake_scisa.py
@@ -221,8 +221,8 @@ def intake_model(file_list: list[str], prop: Any, logger: Logger) -> xr.Dataset:
         ]
         time_name = 'time'
 
-    if prop.ofs in ['necofs', 'loofs2','secofs']:
-        engine = 'netcdf4'
+    if prop.ofs in ['necofs', 'loofs2', 'secofs']:
+        engine = 'scipy'
     elif prop.ofs in ['stofs_2d_glo']:
         engine = 'scipy'
     else:

--- a/src/ofs_skill/model_processing/intake_scisa.py
+++ b/src/ofs_skill/model_processing/intake_scisa.py
@@ -221,10 +221,11 @@ def intake_model(file_list: list[str], prop: Any, logger: Logger) -> xr.Dataset:
         ]
         time_name = 'time'
 
-    if prop.ofs in ['necofs', 'loofs2', 'secofs']:
+    if prop.ofs in ['stofs_2d_glo'] or \
+        any('2017_free_run_station' in file for file in file_list):
         engine = 'scipy'
-    elif prop.ofs in ['stofs_2d_glo']:
-        engine = 'scipy'
+    elif prop.ofs in ['necofs', 'loofs2', 'secofs']:
+        engine = 'netcdf4'
     else:
         engine = 'h5netcdf'
 

--- a/src/ofs_skill/model_processing/intake_scisa.py
+++ b/src/ofs_skill/model_processing/intake_scisa.py
@@ -442,7 +442,13 @@ def intake_model(file_list: list[str], prop: Any, logger: Logger) -> xr.Dataset:
         ds = fix_adcirc_dataset(prop, ds, urlpaths, logger)
 
     # Round all times to nearest minute
-    ds[time_name] = ds[time_name].dt.round('1min')
+    try:
+        ds[time_name] = ds[time_name].dt.round('1min')
+    except AttributeError:
+        logger.error('Incompatible netcdf engine selected! Please make sure '
+                     'use_custom_filenames is set correctly in ofs_dps.conf, '
+                     'or confirm which engine your custom filenames require.')
+        raise SystemExit
     if prop.ofsfiletype == 'stations' and prop.whichcast != 'forecast_a':
         ds = ds.drop_duplicates(dim=time_name, keep='last')
     elif prop.ofsfiletype == 'stations' and prop.whichcast == 'forecast_a':

--- a/src/ofs_skill/model_processing/intake_scisa.py
+++ b/src/ofs_skill/model_processing/intake_scisa.py
@@ -228,8 +228,15 @@ def intake_model(file_list: list[str], prop: Any, logger: Logger) -> xr.Dataset:
         ]
         time_name = 'time'
 
-    if prop.ofs in ['stofs_2d_glo'] or \
-        any('2017_free_run_station' in file for file in file_list):
+    # Custom NECOFS free-run station files are NetCDF3 and need the scipy
+    # engine. They are identified by this filename marker; if other NetCDF3
+    # custom files are added, extend this list. The intake_model call below
+    # also falls back with a clear error if the wrong engine is selected.
+    _netcdf3_filename_markers = ('2017_free_run_station',)
+    if prop.ofs in ['stofs_2d_glo'] or any(
+            marker in f
+            for f in file_list
+            for marker in _netcdf3_filename_markers):
         engine = 'scipy'
     elif prop.ofs in ['necofs', 'loofs2', 'secofs']:
         engine = 'netcdf4'

--- a/src/ofs_skill/obs_retrieval/get_station_observations.py
+++ b/src/ofs_skill/obs_retrieval/get_station_observations.py
@@ -418,6 +418,7 @@ def _fetch_and_format_station(
                     # available bin so the pipeline keeps producing data.
                     if bin_num is not None and bin_num in timeseries:
                         timeseries = timeseries[bin_num]
+                        logger.info('Picked currents bin successfully!')
                     elif timeseries:
                         fallback_key = sorted(timeseries.keys())[0]
                         logger.warning(

--- a/src/ofs_skill/obs_retrieval/get_station_observations.py
+++ b/src/ofs_skill/obs_retrieval/get_station_observations.py
@@ -210,7 +210,7 @@ def _split_virtual_currents_id(sid: str) -> tuple[str, Optional[int]]:
 
 def _apply_datum_shift(
     timeseries, variable, station_id, source, ofs, datum, datum_list,
-    datum_shift, retrieve_input, logger, config_file=None,
+    datum_shift, retrieve_input, logger, control_files_path, config_file=None,
 ):
     """Apply datum shift to water_level timeseries, with CO-OPS multi-datum fallback.
 
@@ -264,7 +264,7 @@ def _apply_datum_shift(
                     retrieve_input.variable = variable
                     retrieve_input.datum = all_datums[dat]
                     timeseries = retrieve_t_and_c_station(
-                        retrieve_input, logger,
+                        retrieve_input, logger, control_files_path,
                         config_file=config_file,
                     )
                     if (timeseries is not None and
@@ -345,7 +345,7 @@ def _format_timeseries(timeseries, variable, start_date_full, end_date_full):
 def _fetch_and_format_station(
     station_info, station_metadata, variable, name_var, datum, datum_list,
     start_date, end_date, start_date_full, end_date_full, ofs,
-    data_observations_1d_station_path, logger, config_file=None,
+    data_observations_1d_station_path, logger, control_files_path, config_file=None,
 ):
     """Fetch observation data for a single station, format it, and write .obs file.
 
@@ -410,7 +410,9 @@ def _fetch_and_format_station(
 
                 timeseries = retrieve_t_and_c_station(
                     retrieve_input, logger,
-                    config_file=config_file)
+                    control_files_path,
+                    config_file=config_file,
+                    )
 
                 if variable == 'currents' and isinstance(timeseries, dict):
                     # Pick out the requested bin. When no bin suffix was
@@ -445,7 +447,7 @@ def _fetch_and_format_station(
                     timeseries = _apply_datum_shift(
                         timeseries, variable, station_id, source,
                         ofs, datum, datum_list, datum_shift,
-                        retrieve_input, logger, config_file=config_file,
+                        retrieve_input, logger, control_files_path, config_file=config_file,
                     )
 
                 formatted_series = _format_timeseries(
@@ -474,7 +476,7 @@ def _fetch_and_format_station(
                     timeseries = _apply_datum_shift(
                         timeseries, variable, station_id, source,
                         ofs, datum, datum_list, datum_shift,
-                        retrieve_input, logger, config_file=config_file,
+                        retrieve_input, logger, control_files_path, config_file=config_file,
                     )
 
                 formatted_series = _format_timeseries(
@@ -503,7 +505,7 @@ def _fetch_and_format_station(
                     timeseries = _apply_datum_shift(
                         timeseries, variable, station_id, source,
                         ofs, datum, datum_list, datum_shift,
-                        retrieve_input, logger, config_file=config_file,
+                        retrieve_input, logger, control_files_path, config_file=config_file,
                     )
 
                 formatted_series = _format_timeseries(
@@ -532,7 +534,7 @@ def _fetch_and_format_station(
                     timeseries = _apply_datum_shift(
                         timeseries, variable, station_id, source,
                         ofs, datum, datum_list, datum_shift,
-                        retrieve_input, logger, config_file=config_file,
+                        retrieve_input, logger, control_files_path, config_file=config_file,
                     )
 
                 formatted_series = _format_timeseries(
@@ -802,6 +804,7 @@ def _process_variable_obs(
                             ofs,
                             data_observations_1d_station_path,
                             logger,
+                            control_files_path,
                             config_file,
                         )
                         futures[future] = station_info[0]

--- a/src/ofs_skill/obs_retrieval/inventory_t_c_station.py
+++ b/src/ofs_skill/obs_retrieval/inventory_t_c_station.py
@@ -116,6 +116,7 @@ def inventory_t_c_station(
         ('water_temperature', 'watertemp', 'has_temp'),
         ('salinity', 'physocean', 'has_salt'),
         ('currents', 'currents', 'has_cu'),
+        ('currents', 'historiccurrents', 'has_cu')
     ]
 
     for variable, station_type, var_col in variable_config:

--- a/src/ofs_skill/obs_retrieval/retrieve_t_and_c_station.py
+++ b/src/ofs_skill/obs_retrieval/retrieve_t_and_c_station.py
@@ -1368,19 +1368,21 @@ def _fetch_currents_chunked(
 
     # 1-hour tolerance for expected sampling intervals
     if max_dt < end_dt_0 - timedelta(hours=1):
-        logger.info(
-            'Incomplete date range retrieved. '
-            'Searching backwards from %s to bridge gap...', end_dt_0
-        )
         retry_cur = end_dt_0
 
         # Iterate backward day-by-day until overlapping with previously retrieved data
+        search_chunk = '3'
         while retry_cur > max_dt and retry_cur >= start_dt_0:
             date_str = retry_cur.strftime('%Y%m%d')
+            logger.info(
+                'Incomplete date range retrieved for station %s, bin %s. '
+                'Searching backwards from %s to bridge gap...', station_id,
+                bin_num, date_str
+            )
             bin_qs = f'&bin={bin_num}' if bin_num is not None else ''
 
             url = (
-                f'{api_url}/datagetter?end_date={date_str}&range=24'
+                f'{api_url}/datagetter?end_date={date_str}&range={search_chunk}'
                 f'&station={station_id}&product=currents{bin_qs}'
                 f'&time_zone=gmt&units=metric&format=json'
             )
@@ -1398,7 +1400,7 @@ def _fetch_currents_chunked(
                 earlier_date_str = earlier_dt.strftime('%Y%m%d')
 
                 url_fwd = (
-                    f'{api_url}/datagetter?begin_date={earlier_date_str}&range=24'
+                    f'{api_url}/datagetter?begin_date={earlier_date_str}&range={search_chunk}'
                     f'&station={station_id}&product=currents{bin_qs}'
                     f'&time_zone=gmt&units=metric&format=json'
                 )

--- a/src/ofs_skill/obs_retrieval/retrieve_t_and_c_station.py
+++ b/src/ofs_skill/obs_retrieval/retrieve_t_and_c_station.py
@@ -1289,7 +1289,6 @@ def _legacy_fallback_bin(
                 return rtb
     return 1
 
-
 def _fetch_currents_chunked(
     station_id: str,
     bin_num: Optional[int],
@@ -1301,6 +1300,9 @@ def _fetch_currents_chunked(
     """Pull currents data for a station (optionally a specific bin) in
     30-day chunks and return a DataFrame with DateTime/DIR/OBS columns.
 
+    If the full range isn't retrieved (but some data exists), retries by
+    searching backwards from end_dt_0 day-by-day.
+
     Returns ``None`` when no rows fall inside ``[start_dt_0, end_dt_0]``.
     """
     delta = timedelta(days=30)
@@ -1309,27 +1311,9 @@ def _fetch_currents_chunked(
     speeds: list[float] = []
     dirs: list[float] = []
 
-    while cur <= end_dt_0:
-        date_i = cur.strftime('%Y%m%d')
-        date_f = (cur + delta).strftime('%Y%m%d')
-        bin_qs = f'&bin={bin_num}' if bin_num is not None else ''
-        url = (
-            f'{api_url}/datagetter?begin_date={date_i}&end_date={date_f}'
-            f'&station={station_id}&product=currents{bin_qs}'
-            f'&time_zone=gmt&units=metric&format=json'
-        )
-        context = (f'currents bin={bin_num}' if bin_num is not None
-                   else 'currents')
-        obs = _get_with_retry(url, station_id, context, logger)
-        if obs is None:
-            cur += delta
-            continue
-
-        for row in obs.get('data', []) or []:
-            # Defend against upstream API regressions: if the server
-            # echoes a bin number that doesn't match what we requested,
-            # skip the row rather than silently mis-pair it with the
-            # wrong bin's depth.
+    def _process_obs(obs_data: dict) -> None:
+        """Helper to extract and append rows from the API response."""
+        for row in obs_data.get('data', []) or []:
             if bin_num is not None:
                 row_bin_raw = row.get('b')
                 if row_bin_raw is not None:
@@ -1351,25 +1335,79 @@ def _fetch_currents_chunked(
                 direction = float(row['d'])
             except (TypeError, ValueError, KeyError):
                 direction = float('nan')
+
             dates.append(row['t'])
             speeds.append(speed_m)
             dirs.append(direction)
 
+    # forward chunking
+    while cur <= end_dt_0:
+        date_i = cur.strftime('%Y%m%d')
+        date_f = (cur + delta).strftime('%Y%m%d')
+        bin_qs = f'&bin={bin_num}' if bin_num is not None else ''
+        url = (
+            f'{api_url}/datagetter?begin_date={date_i}&end_date={date_f}'
+            f'&station={station_id}&product=currents{bin_qs}'
+            f'&time_zone=gmt&units=metric&format=json'
+        )
+        context = f'currents bin={bin_num}' if bin_num is not None else 'currents'
+        obs = _get_with_retry(url, station_id, context, logger)
+
+        if obs is not None:
+            _process_obs(obs)
+
         cur += delta
 
+    # bail if there is no data
     if not dates:
         return None
 
+    # check if the full date range was retrieved
+    max_dt = pd.to_datetime(max(dates))
+
+    # 1-hour tolerance for expected sampling intervals
+    if max_dt < end_dt_0 - timedelta(hours=1):
+        logger.info(
+            'Incomplete date range retrieved. '
+            'Searching backwards from %s to bridge gap...', end_dt_0
+        )
+        retry_cur = end_dt_0
+
+        # Iterate backward day-by-day until overlapping with previously retrieved data
+        while retry_cur > max_dt and retry_cur >= start_dt_0:
+            date_str = retry_cur.strftime('%Y%m%d')
+            bin_qs = f'&bin={bin_num}' if bin_num is not None else ''
+
+            url = (
+                f'{api_url}/datagetter?end_date={date_str}&range=24'
+                f'&station={station_id}&product=currents{bin_qs}'
+                f'&time_zone=gmt&units=metric&format=json'
+            )
+            context = (f'currents bin={bin_num} (retry)' if bin_num is not None
+                       else 'currents (retry)')
+
+            obs = _get_with_retry(url, station_id, context, logger)
+
+            if obs is not None:
+                _process_obs(obs)
+
+            # Step backwards by 24 hours
+            retry_cur -= timedelta(days=1)
+
+    # assemble and filter
     df = pd.DataFrame({
         'DateTime': pd.to_datetime(dates),
         'DEP01': pd.to_numeric(0.0),
         'DIR': pd.to_numeric(dirs),
         'OBS': pd.to_numeric(speeds),
     })
+
     mask = (df['DateTime'] >= start_dt_0) & (df['DateTime'] <= end_dt_0)
     df = df.loc[mask]
+
     if df.empty:
         return None
+
     df = df.sort_values(by='DateTime').drop_duplicates()
     return df
 

--- a/src/ofs_skill/obs_retrieval/retrieve_t_and_c_station.py
+++ b/src/ofs_skill/obs_retrieval/retrieve_t_and_c_station.py
@@ -999,6 +999,7 @@ def _retrieve_currents_all_bins(
             api_url=api_url,
             station_info=station_info,
             bins_payload=bins_payload,
+            deployment_info=deployment_info,  # <-- ADDED
             hfb=hfb,
             orientation_label=orientation_label,
             mounting_type=mounting_type,
@@ -1031,6 +1032,7 @@ def _retrieve_currents_all_bins(
             end_dt_0=end_dt_0,
             api_url=api_url,
             logger=logger,
+            deployment_info=deployment_info,  # <-- ADDED
         )
         if df is None:
             continue
@@ -1166,6 +1168,7 @@ def _retrieve_side_looking_currents(
             end_dt_0=end_dt_0,
             api_url=api_url,
             logger=logger,
+            deployment_info=deployment_info,  # <-- ADDED
         )
         if df is None:
             logger.info(
@@ -1207,6 +1210,7 @@ def _retrieve_currents_legacy_fallback(
     api_url: str,
     station_info: Optional[dict],
     bins_payload: Optional[dict],
+    deployment_info: Optional[dict],  # <-- ADDED
     hfb: Optional[float],
     orientation_label: str,
     mounting_type: str,
@@ -1236,6 +1240,7 @@ def _retrieve_currents_legacy_fallback(
         end_dt_0=end_dt_0,
         api_url=api_url,
         logger=logger,
+        deployment_info=deployment_info,  # <-- ADDED
     )
     if legacy is None:
         return None
@@ -1251,7 +1256,6 @@ def _retrieve_currents_legacy_fallback(
         '(legacy fallback, bin=%s, depth UNKNOWN, mounting=%s).',
         station_id, fallback_bin, mounting_type)
     return {fallback_bin: legacy}
-
 
 def _legacy_fallback_bin(
     station_info: Optional[dict],
@@ -1296,13 +1300,14 @@ def _fetch_currents_chunked(
     end_dt_0: datetime,
     api_url: str,
     logger: Logger,
+    deployment_info: Optional[dict] = None,
 ) -> Optional[pd.DataFrame]:
     """Pull currents data for a station (optionally a specific bin) in
     30-day chunks and return a DataFrame with DateTime/DIR/OBS columns.
 
-    If the full range isn't retrieved (but some data exists), retries by
-    searching backwards from end_dt_0 day-by-day. If a backward 24h chunk
-    fails, it falls back to a forward 24h search for that specific day.
+    If the full range isn't retrieved, checks if a deployment change
+    occurred within the requested window. If so, retries by searching
+    backwards using expanding windows.
 
     Returns ``None`` when no rows fall inside ``[start_dt_0, end_dt_0]``.
     """
@@ -1368,58 +1373,75 @@ def _fetch_currents_chunked(
 
     # 1-hour tolerance for expected sampling intervals
     if max_dt < end_dt_0 - timedelta(hours=1):
-        retry_cur = end_dt_0
 
-        # Iterate backward day-by-day until overlapping with previously retrieved data
-        search_chunk = '3'
-        while retry_cur > max_dt and retry_cur >= start_dt_0:
-            date_str = retry_cur.strftime('%Y%m%d')
+        # only backward chunk if a deployment change occurred in the window
+        has_deployment_change = False
+        if deployment_info and deployment_info.get('deployments'):
+            for dep in deployment_info['deployments']:
+                for date_key in ('deployed', 'retrieved'):
+                    val = dep.get(date_key)
+                    if val:
+                        try:
+                            # NOAA returns dates as YYYY-MM-DD.
+                            # Slice first 10 chars to defend against potential time components
+                            dt_val = datetime.strptime(val[:10], '%Y-%m-%d')
+                            if start_dt_0 <= dt_val <= end_dt_0:
+                                has_deployment_change = True
+                                break
+                        except ValueError:
+                            continue
+                if has_deployment_change:
+                    break
+
+        if has_deployment_change:
             logger.info(
-                'Incomplete date range retrieved for station %s, bin %s. '
-                'Searching backwards from %s to bridge gap...', station_id,
-                bin_num, date_str
+                'Incomplete date range and deployment change detected. '
+                'Searching backwards from %s using expanding windows to bridge gap...', end_dt_0
             )
-            bin_qs = f'&bin={bin_num}' if bin_num is not None else ''
+            retry_cur = end_dt_0
+            gap_bridged = False
 
-            url = (
-                f'{api_url}/datagetter?end_date={date_str}&range={search_chunk}'
-                f'&station={station_id}&product=currents{bin_qs}'
-                f'&time_zone=gmt&units=metric&format=json'
+            # Use .date() for the loop condition to avoid the midnight cutoff bug,
+            # ensuring we query the API for the day even if max_dt has a PM timestamp.
+            while retry_cur.date() >= max_dt.date() and retry_cur.date() >= start_dt_0.date():
+                date_str = retry_cur.strftime('%Y%m%d')
+                bin_qs = f'&bin={bin_num}' if bin_num is not None else ''
+
+                # Search backward using expanding 3-hour windows up to 24 hours
+                for range_hrs in range(3, 27, 3):
+                    url = (
+                        f'{api_url}/datagetter?end_date={date_str}&range={range_hrs}'
+                        f'&station={station_id}&product=currents{bin_qs}'
+                        f'&time_zone=gmt&units=metric&format=json'
+                    )
+                    context = (f'currents bin={bin_num} (retry {range_hrs}h)' if bin_num is not None
+                               else f'currents (retry {range_hrs}h)')
+
+                    obs = _get_with_retry(url, station_id, context, logger)
+
+                    if obs is not None and obs.get('data'):
+                        _process_obs(obs)
+
+                        # Early exit optimization: stop hammering the API if we just bridged the gap
+                        earliest_str = obs['data'][0]['t']
+                        earliest_dt = datetime.strptime(earliest_str, '%Y-%m-%d %H:%M')
+
+                        # We still use full datetime here to know exactly when the chronological gap is bridged
+                        if earliest_dt <= max_dt or earliest_dt <= start_dt_0:
+                            logger.info('Gap bridged at %s. Halting backward search.', earliest_str)
+                            gap_bridged = True
+                            break
+
+                if gap_bridged:
+                    break
+
+                retry_cur -= timedelta(days=1)
+        else:
+            logger.info(
+                'Incomplete date range retrieved, but no deployment change '
+                'detected in the %s to %s window. Skipping backward search.',
+                start_dt_0.strftime('%Y-%m-%d'), end_dt_0.strftime('%Y-%m-%d')
             )
-            context = (f'currents bin={bin_num} (retry)' if bin_num is not None
-                       else 'currents (retry)')
-
-            obs = _get_with_retry(url, station_id, context, logger)
-
-            if obs is not None and obs.get('data'):
-                _process_obs(obs)
-            else:
-                # 24-hour chunk not found backwards. Go to the earlier date of
-                # the 24-hour chunk and search forward.
-                earlier_dt = retry_cur - timedelta(days=1)
-                earlier_date_str = earlier_dt.strftime('%Y%m%d')
-
-                url_fwd = (
-                    f'{api_url}/datagetter?begin_date={earlier_date_str}&range={search_chunk}'
-                    f'&station={station_id}&product=currents{bin_qs}'
-                    f'&time_zone=gmt&units=metric&format=json'
-                )
-                context_fwd = (f'currents bin={bin_num} (forward retry)' if bin_num is not None
-                               else 'currents (forward retry)')
-
-                logger.info(
-                    'Backward chunk end_date=%s yielded no data. '
-                    'Retrying forward from begin_date=%s...',
-                    date_str, earlier_date_str
-                )
-
-                obs_fwd = _get_with_retry(url_fwd, station_id, context_fwd, logger)
-
-                if obs_fwd is not None:
-                    _process_obs(obs_fwd)
-
-            # Step backwards by 24 hours to resume backward search
-            retry_cur -= timedelta(days=1)
 
     # 4. Assemble and filter
     df = pd.DataFrame({
@@ -1435,7 +1457,18 @@ def _fetch_currents_chunked(
     if df.empty:
         return None
 
+    # Handles overlapping duplicates generated by the expanding 3-hour windows
     df = df.sort_values(by='DateTime').drop_duplicates()
+
+    # 5. Final completion check logging
+    final_max_dt = df['DateTime'].max()
+    if final_max_dt < end_dt_0 - timedelta(hours=1):
+        logger.warning(
+            'After all retrievals, data for CO-OPS station %s (bin=%s) is still incomplete. '
+            'Latest timestamp is %s (expected %s). Retaining retrieved data.',
+            station_id, bin_num, final_max_dt, end_dt_0
+        )
+
     return df
 
 

--- a/src/ofs_skill/obs_retrieval/retrieve_t_and_c_station.py
+++ b/src/ofs_skill/obs_retrieval/retrieve_t_and_c_station.py
@@ -1301,7 +1301,8 @@ def _fetch_currents_chunked(
     30-day chunks and return a DataFrame with DateTime/DIR/OBS columns.
 
     If the full range isn't retrieved (but some data exists), retries by
-    searching backwards from end_dt_0 day-by-day.
+    searching backwards from end_dt_0 day-by-day. If a backward 24h chunk
+    fails, it falls back to a forward 24h search for that specific day.
 
     Returns ``None`` when no rows fall inside ``[start_dt_0, end_dt_0]``.
     """
@@ -1340,7 +1341,7 @@ def _fetch_currents_chunked(
             speeds.append(speed_m)
             dirs.append(direction)
 
-    # forward chunking
+    # 1. Forward chunking
     while cur <= end_dt_0:
         date_i = cur.strftime('%Y%m%d')
         date_f = (cur + delta).strftime('%Y%m%d')
@@ -1358,11 +1359,11 @@ def _fetch_currents_chunked(
 
         cur += delta
 
-    # bail if there is no data
+    # 2. Bail if there is no data at all
     if not dates:
         return None
 
-    # check if the full date range was retrieved
+    # 3. Check if the full date range was retrieved
     max_dt = pd.to_datetime(max(dates))
 
     # 1-hour tolerance for expected sampling intervals
@@ -1388,13 +1389,37 @@ def _fetch_currents_chunked(
 
             obs = _get_with_retry(url, station_id, context, logger)
 
-            if obs is not None:
+            if obs is not None and obs.get('data'):
                 _process_obs(obs)
+            else:
+                # 24-hour chunk not found backwards. Go to the earlier date of
+                # the 24-hour chunk and search forward.
+                earlier_dt = retry_cur - timedelta(days=1)
+                earlier_date_str = earlier_dt.strftime('%Y%m%d')
 
-            # Step backwards by 24 hours
+                url_fwd = (
+                    f'{api_url}/datagetter?begin_date={earlier_date_str}&range=24'
+                    f'&station={station_id}&product=currents{bin_qs}'
+                    f'&time_zone=gmt&units=metric&format=json'
+                )
+                context_fwd = (f'currents bin={bin_num} (forward retry)' if bin_num is not None
+                               else 'currents (forward retry)')
+
+                logger.info(
+                    'Backward chunk end_date=%s yielded no data. '
+                    'Retrying forward from begin_date=%s...',
+                    date_str, earlier_date_str
+                )
+
+                obs_fwd = _get_with_retry(url_fwd, station_id, context_fwd, logger)
+
+                if obs_fwd is not None:
+                    _process_obs(obs_fwd)
+
+            # Step backwards by 24 hours to resume backward search
             retry_cur -= timedelta(days=1)
 
-    # assemble and filter
+    # 4. Assemble and filter
     df = pd.DataFrame({
         'DateTime': pd.to_datetime(dates),
         'DEP01': pd.to_numeric(0.0),

--- a/src/ofs_skill/obs_retrieval/retrieve_t_and_c_station.py
+++ b/src/ofs_skill/obs_retrieval/retrieve_t_and_c_station.py
@@ -21,6 +21,7 @@ number — see :func:`_retrieve_currents_all_bins` and the wiki page
 
 import json
 import math
+import os
 import random
 import threading
 import time
@@ -74,6 +75,8 @@ _COOPS_CONCURRENCY_LIMIT = 2
 _COOPS_MIN_REQUEST_GAP_SEC = 0.5
 _coops_request_semaphore = threading.Semaphore(_COOPS_CONCURRENCY_LIMIT)
 _coops_pacing_lock = threading.Lock()
+# Lock to prevent concurrent threads from corrupting the deployment summary CSV
+_csv_export_lock = threading.Lock()
 _coops_last_request_time = 0.0  # pylint: disable=invalid-name
 
 
@@ -489,6 +492,221 @@ def get_station_deployment(
     _station_deployment_cache[station_id] = payload
     return payload
 
+def check_bin_depth_changes(
+    station_id: str,
+    mdapi_url: str,
+    logger: Logger,
+) -> bool:
+    """
+    Check if an ADCP station's bin depths have shifted across different deployments.
+
+    Queries the MDAPI with expand=deployments,bins to get the full historical
+    bin profiles, groups them by deployment ID, and compares the configurations.
+    """
+    url = f'{mdapi_url}/webapi/stations/{station_id}.json?expand=deployments,bins&units=metric'
+
+    payload = _get_with_retry(url, station_id, 'bin-depth-audit', logger)
+
+    # Safely validate top-level structure
+    if not payload or not isinstance(payload, dict):
+        return False
+
+    stations = payload.get('stations')
+    if not stations or not isinstance(stations, list) or not isinstance(stations[0], dict):
+        logger.warning('CO-OPS bin depth audit failed: No station data returned for %s', station_id)
+        return False
+
+    station_data = stations[0]
+    bins_node = station_data.get('bins')
+
+    # Safely extract the list depending on how the MDAPI nested it
+    bins_list = []
+    if isinstance(bins_node, dict):
+        bins_list = bins_node.get('bins', [])
+    elif isinstance(bins_node, list):
+        bins_list = bins_node
+
+    if not bins_list:
+        return False
+
+    # Group bins by their specific deployment ID
+    deployment_profiles = {}
+    for b in bins_list:
+        # Protect against anomalous non-dict items in the list
+        if not isinstance(b, dict):
+            continue
+
+        dep_id = b.get('deploymentId')
+        bin_num = _coerce_int(b.get('num') or b.get('bin'))
+        distance = b.get('distance')
+
+        if dep_id is None or bin_num is None or distance is None:
+            continue
+
+        if dep_id not in deployment_profiles:
+            deployment_profiles[dep_id] = {}
+
+        try:
+            deployment_profiles[dep_id][bin_num] = float(distance)
+        except (TypeError, ValueError):
+            continue
+
+    if len(deployment_profiles) <= 1:
+        return False
+
+    profiles = list(deployment_profiles.values())
+    baseline_profile = profiles[0]
+
+    for i, profile in enumerate(profiles[1:], start=1):
+        if profile != baseline_profile:
+            logger.warning(
+                'CO-OPS station %s has shifting bin depths across deployments! '
+                'Mismatch detected between deployment profiles.',
+                station_id
+            )
+            return True
+
+    logger.info('CO-OPS station %s bin depths are consistent across all deployments.', station_id)
+    return False
+
+def log_and_export_deployment_info(
+    station_id: str,
+    mdapi_url: str,
+    control_files_path: str,
+    logger: Logger,
+    start_date: Optional[str] = None,
+    end_date: Optional[str] = None,
+) -> None:
+    """
+    Retrieves deployment info for a station, logs the configuration,
+    and appends a summary to a CSV in the control files directory.
+
+    Thread-safe implementation allowing multiple concurrent station
+    workers to append to the same file safely.
+    """
+    # 1. Fetch relevant metadata
+    deployment_info = get_station_deployment(station_id, mdapi_url, logger)
+    has_depth_shifts = check_bin_depth_changes(station_id, mdapi_url, logger)
+    mounting_type = resolve_mounting_type(deployment_info)
+
+    deployments = deployment_info.get('deployments', []) if deployment_info else []
+    num_deployments = len(deployments)
+
+    # 2. Check if a physical deployment change or gap occurred within the requested date window
+    window_change = False
+    gaps_str = 'N/A'
+    total_gap_days = 0
+
+    if start_date and end_date:
+        try:
+            s_dt = datetime.strptime(start_date, '%Y%m%d')
+            e_dt = datetime.strptime(end_date, '%Y%m%d')
+
+            # --- WINDOW CHANGE CHECK ---
+            for dep in deployments:
+                if not isinstance(dep, dict):
+                    continue
+                for d_key in ('deployed', 'retrieved'):
+                    val = dep.get(d_key)
+                    if val:
+                        dt_val = datetime.strptime(val, '%Y-%m-%d %H:%M:%S')
+                        if s_dt <= dt_val <= e_dt:
+                            window_change = True
+                            break
+                if window_change:
+                    break
+
+            # --- TRUE DEPLOYMENT GAP CALCULATION ---
+            if num_deployments > 0:
+                dep_intervals = []
+                for dep in deployments:
+                    if not isinstance(dep, dict):
+                        continue
+                    d_val = dep.get('deployed')
+                    r_val = dep.get('retrieved')
+                    if d_val:
+                        d_dt = datetime.strptime(d_val, '%Y-%m-%d %H:%M:%S')
+                        # Active deployments lack a retrieved date; cap at current time
+                        r_dt = datetime.strptime(r_val, '%Y-%m-%d %H:%M:%S') if r_val else datetime.utcnow()
+                        dep_intervals.append((d_dt, r_dt))
+
+                # Sort intervals chronologically by start date
+                dep_intervals.sort(key=lambda x: x[0])
+
+                # Merge overlapping deployments to define solid coverage blocks
+                merged_coverage = []
+                for current in dep_intervals:
+                    if not merged_coverage:
+                        merged_coverage.append(current)
+                    else:
+                        last_start, last_end = merged_coverage[-1]
+                        curr_start, curr_end = current
+
+                        if curr_start <= last_end:
+                            # Deployments overlap; extend the coverage end date if needed
+                            merged_coverage[-1] = (last_start, max(last_end, curr_end))
+                        else:
+                            # No overlap; this is a new distinct coverage block
+                            merged_coverage.append(current)
+
+                gap_details = []
+
+                # Find gaps specifically between the merged coverage blocks
+                for i in range(len(merged_coverage) - 1):
+                    # Gap starts precisely when the previous coverage block ends
+                    gap_start = merged_coverage[i][1]
+                    # Gap ends precisely when the subsequent coverage block begins
+                    gap_end = merged_coverage[i+1][0]
+
+                    # Assess how much of this gap falls within the requested [s_dt, e_dt] window
+                    overlap_start = max(gap_start, s_dt)
+                    overlap_end = min(gap_end, e_dt)
+
+                    if overlap_start < overlap_end:
+                        window_gap_days = (overlap_end - overlap_start).seconds/60/24
+                        total_gap_days += window_gap_days
+                        gap_details.append(
+                            f"{overlap_start.strftime('%Y-%m-%d')} to {overlap_end.strftime('%Y-%m-%d')} ({window_gap_days}d)"
+                        )
+
+                gaps_str = '; '.join(gap_details) if gap_details else 'None'
+
+        except Exception as ex:
+            logger.debug('Failed to parse dates for window checks on %s: %s', station_id, ex)
+
+    # 3. Emit the Log
+    logger.info(
+        'Station %s deployment summary: %d total deployments, '
+        'has_historical_shifts=%s, change_in_requested_window=%s, '
+        'gap_days_in_window=%d, mounting=%s',
+        station_id, num_deployments, has_depth_shifts,
+        window_change, total_gap_days, mounting_type
+    )
+
+    # 4. Append to CSV safely
+    if not control_files_path:
+        return
+
+    csv_path = os.path.join(control_files_path, f'coops_deployment_summary_{start_date}_{end_date}.csv')
+
+    row_dict = {
+        'Station ID': station_id,
+        'Total Deployments': num_deployments,
+        'Multiple Deployments in Window': window_change if (start_date and end_date) else 'N/A',
+        'Gap Details': gaps_str,
+        'Has Bin Depth Shifts': has_depth_shifts,
+        'Current Mounting Type': mounting_type,
+    }
+
+    df = pd.DataFrame([row_dict])
+
+    with _csv_export_lock:
+        try:
+            write_header = not os.path.exists(csv_path)
+            df.to_csv(csv_path, mode='a', index=False, header=write_header)
+        except Exception as e:
+            logger.error('Failed to write deployment summary to CSV for station %s: %s', station_id, e)
+
 
 def resolve_mounting_type(
     deployment_info: Optional[dict],
@@ -616,6 +834,7 @@ _get_station_deployment = get_station_deployment
 def retrieve_t_and_c_station(
     retrieve_input: Any,
     logger: Logger,
+    control_files_path: Any,
     only_bins: Optional[set[int]] = None,
     config_file=None,
 ) -> Optional[Union[pd.DataFrame, dict[int, pd.DataFrame]]]:
@@ -682,6 +901,7 @@ def retrieve_t_and_c_station(
             mdapi_url=t_c.mdapi_url,
             logger=logger,
             only_bins=only_bins,
+            control_files_path=control_files_path,
         )
 
     t_c.start_dt = datetime.strptime(retrieve_input.start_date, '%Y%m%d')
@@ -891,6 +1111,7 @@ def _retrieve_currents_all_bins(
     mdapi_url: str,
     logger: Logger,
     only_bins: Optional[set[int]] = None,
+    control_files_path: Optional[str] = None,
 ) -> Optional[dict[int, pd.DataFrame]]:
     """Retrieve CO-OPS currents data for every bin of an ADCP station.
 
@@ -927,6 +1148,28 @@ def _retrieve_currents_all_bins(
     """
     start_dt_0 = datetime.strptime(start_date, '%Y%m%d')
     end_dt_0 = datetime.strptime(end_date, '%Y%m%d')
+
+    # ---> NEW: Run our bin depth audit <---
+    has_depth_shifts = check_bin_depth_changes(station_id, mdapi_url, logger)
+    if has_depth_shifts:
+        logger.warning(
+            'CO-OPS station %s has historical deployment depth shifts. '
+            'If your requested date range (%s to %s) crosses a deployment '
+            'boundary, you may be mixing different physical depths within '
+            'the same bin number.',
+            station_id, start_date, end_date
+        )
+    # --------------------------------------
+
+    # ---> Trigger the CSV export <---
+    log_and_export_deployment_info(
+        station_id=station_id,
+        mdapi_url=mdapi_url,
+        control_files_path=control_files_path,
+        logger=logger,
+        start_date=start_date,
+        end_date=end_date
+    )
 
     bins_payload = get_station_depth(station_id, mdapi_url, logger)
     bin_records = _extract_bin_records(bins_payload)
@@ -984,6 +1227,7 @@ def _retrieve_currents_all_bins(
             hfb=hfb,
             orientation_label=orientation_label,
             only_bins=only_bins,
+            has_depth_shifts=has_depth_shifts,
             logger=logger,
         )
 
@@ -1003,6 +1247,7 @@ def _retrieve_currents_all_bins(
             hfb=hfb,
             orientation_label=orientation_label,
             mounting_type=mounting_type,
+            has_depth_shifts=has_depth_shifts,
             logger=logger,
         )
 
@@ -1043,6 +1288,7 @@ def _retrieve_currents_all_bins(
         df.attrs['orientation'] = orientation_label
         df.attrs['mounting_type'] = mounting_type
         df.attrs['height_from_bottom'] = hfb
+        df.attrs['has_historical_depth_shifts'] = has_depth_shifts
         result[bin_num] = df
 
     if missing_depth:
@@ -1105,6 +1351,7 @@ def _retrieve_side_looking_currents(
     hfb: Optional[float],
     orientation_label: str,
     only_bins: Optional[set[int]],
+    has_depth_shifts: bool,
     logger: Logger,
 ) -> Optional[dict[int, pd.DataFrame]]:
     """Side-looking ADCP currents retrieval (issue #140).
@@ -1182,6 +1429,7 @@ def _retrieve_side_looking_currents(
         df.attrs['orientation'] = orientation_label or 'side'
         df.attrs['mounting_type'] = 'side'
         df.attrs['height_from_bottom'] = hfb
+        df.attrs['has_historical_depth_shifts'] = has_depth_shifts
         result[chosen_bin] = df
 
     if not result:
@@ -1214,6 +1462,7 @@ def _retrieve_currents_legacy_fallback(
     hfb: Optional[float],
     orientation_label: str,
     mounting_type: str,
+    has_depth_shifts: bool,
     logger: Logger,
 ) -> Optional[dict[int, pd.DataFrame]]:
     """No bin records on MDAPI: fall back to one unfiltered datagetter call.
@@ -1250,6 +1499,7 @@ def _retrieve_currents_legacy_fallback(
     legacy.attrs['orientation'] = orientation_label
     legacy.attrs['mounting_type'] = mounting_type
     legacy.attrs['height_from_bottom'] = hfb
+    legacy.attrs['has_historical_depth_shifts'] = has_depth_shifts
     _record_mounting(mounting_type)
     logger.warning(
         'CO-OPS currents retrieval for station %s returned 1 bin '
@@ -1368,79 +1618,164 @@ def _fetch_currents_chunked(
     if not dates:
         return None
 
-    # 3. Check if the full date range was retrieved
-    max_dt = pd.to_datetime(max(dates))
+    # 3. Assess data completeness and patch gaps using deployment metadata
+    max_dt = pd.to_datetime(max(dates)) if dates else start_dt_0 - timedelta(days=1)
 
-    # 1-hour tolerance for expected sampling intervals
-    if max_dt < end_dt_0 - timedelta(hours=1):
+    if deployment_info and deployment_info.get('deployments'):
+        # Compile a list of active deployment periods within the requested window
+        active_periods = []
+        for dep in deployment_info['deployments']:
+            dep_str = dep.get('deployed')
+            ret_str = dep.get('retrieved')
 
-        # only backward chunk if a deployment change occurred in the window
-        has_deployment_change = False
-        if deployment_info and deployment_info.get('deployments'):
-            for dep in deployment_info['deployments']:
-                for date_key in ('deployed', 'retrieved'):
-                    val = dep.get(date_key)
-                    if val:
-                        try:
-                            # NOAA returns dates as YYYY-MM-DD.
-                            # Slice first 10 chars to defend against potential time components
-                            dt_val = datetime.strptime(val[:10], '%Y-%m-%d')
-                            if start_dt_0 <= dt_val <= end_dt_0:
-                                has_deployment_change = True
-                                break
-                        except ValueError:
-                            continue
-                if has_deployment_change:
-                    break
+            if not dep_str:
+                continue
 
-        if has_deployment_change:
+            try:
+                dep_dt = datetime.strptime(dep_str, '%Y-%m-%d %H:%M:%S')
+                if ret_str:
+                    ret_dt = datetime.strptime(ret_str, '%Y-%m-%d %H:%M:%S')
+                else:
+                    ret_dt = datetime.max
+
+                # Intersect this deployment with the requested date window
+                if dep_dt <= end_dt_0 and ret_dt >= start_dt_0:
+                    p_start = max(start_dt_0, dep_dt)
+                    p_end = min(end_dt_0, ret_dt)
+                    if p_start <= p_end:
+                        active_periods.append((p_start, p_end))
+            except ValueError as e:
+                logger.debug('Failed to parse deployment dates for %s: %s', station_id, e)
+                continue
+
+        active_periods.sort()
+
+        if not active_periods:
             logger.info(
-                'Incomplete date range and deployment change detected. '
-                'Searching backwards from %s using expanding windows to bridge gap...', end_dt_0
+                'No active deployments found for %s in the requested window. '
+                'Skipping patching logic.', station_id
             )
-            retry_cur = end_dt_0
-            gap_bridged = False
+            absolute_expected_end = end_dt_0
+        else:
+            # Determine the maximum expected date based ONLY on physical retrievals
+            absolute_expected_end = max([p[1] for p in active_periods])
 
-            # Use .date() for the loop condition to avoid the midnight cutoff bug,
-            # ensuring we query the API for the day even if max_dt has a PM timestamp.
-            while retry_cur.date() >= max_dt.date() and retry_cur.date() >= start_dt_0.date():
-                date_str = retry_cur.strftime('%Y%m%d')
-                bin_qs = f'&bin={bin_num}' if bin_num is not None else ''
+            logger.info(
+                'Detected %d active deployment period(s) for %s. Validating data coverage...',
+                len(active_periods), station_id
+            )
 
-                # Search backward using expanding 3-hour windows up to 24 hours
-                for range_hrs in range(3, 27, 3):
-                    url = (
-                        f'{api_url}/datagetter?end_date={date_str}&range={range_hrs}'
-                        f'&station={station_id}&product=currents{bin_qs}'
-                        f'&time_zone=gmt&units=metric&format=json'
+            for p_start, p_end in active_periods:
+                period_dates = [d for d in dates if p_start <= pd.to_datetime(d) <= p_end]
+                period_max_dt = pd.to_datetime(max(period_dates)) if period_dates else p_start - timedelta(days=1)
+
+                # Only check for gaps up to the end of THIS specific physical deployment
+                if period_max_dt < p_end - timedelta(hours=1):
+                    logger.info(
+                        'Gap detected in deployment period (%s to %s). '
+                        'Searching backwards from calendar day after deployment...',
+                        p_start.strftime('%Y-%m-%d'), p_end.strftime('%Y-%m-%d')
                     )
-                    context = (f'currents bin={bin_num} (retry {range_hrs}h)' if bin_num is not None
-                               else f'currents (retry {range_hrs}h)')
 
-                    obs = _get_with_retry(url, station_id, context, logger)
+                    # Set retry_cur to max 1 calendar day after the deployment
+                    day_after_dep = p_start + timedelta(days=1)
+                    retry_cur = min(day_after_dep, p_end)
+                    gap_bridged = False
+                    bin_qs = f'&bin={bin_num}' if bin_num is not None else ''
 
-                    if obs is not None and obs.get('data'):
-                        _process_obs(obs)
+                    # 1. Backward expanding search (ONLY down to the deployment start)
+                    while retry_cur.date() >= p_start.date() and not gap_bridged:
+                        date_str = retry_cur.strftime('%Y%m%d')
 
-                        # Early exit optimization: stop hammering the API if we just bridged the gap
-                        earliest_str = obs['data'][0]['t']
-                        earliest_dt = datetime.strptime(earliest_str, '%Y-%m-%d %H:%M')
+                        for range_hrs in range(3, 27, 3):
+                            url = (
+                                f'{api_url}/datagetter?end_date={date_str}&range={range_hrs}'
+                                f'&station={station_id}&product=currents{bin_qs}'
+                                f'&time_zone=gmt&units=metric&format=json'
+                            )
+                            context = (f'currents bin={bin_num} (backward {range_hrs}h)' if bin_num is not None
+                                       else f'currents (backward {range_hrs}h)')
 
-                        # We still use full datetime here to know exactly when the chronological gap is bridged
-                        if earliest_dt <= max_dt or earliest_dt <= start_dt_0:
-                            logger.info('Gap bridged at %s. Halting backward search.', earliest_str)
-                            gap_bridged = True
+                            obs = _get_with_retry(url, station_id, context, logger)
+
+                            if obs is not None and obs.get('data'):
+                                _process_obs(obs)
+
+                                earliest_str = obs['data'][0]['t']
+                                earliest_dt = datetime.strptime(earliest_str, '%Y-%m-%d %H:%M')
+
+                                # Halt if we found the deployment start
+                                if earliest_dt <= p_start + timedelta(hours=1):
+                                    logger.info('Deployment start found at %s.', earliest_str)
+                                    gap_bridged = True
+                                    break
+
+                        if gap_bridged:
                             break
 
-                if gap_bridged:
-                    break
+                        retry_cur -= timedelta(days=1)
 
-                retry_cur -= timedelta(days=1)
-        else:
+                    # 2. Re-evaluate data coverage for this period after boundary patching
+                    period_dates = [d for d in dates if p_start <= pd.to_datetime(d) <= p_end]
+                    new_max_dt = pd.to_datetime(max(period_dates)) if period_dates else p_start
+
+                    # 3. Resume standard forward search to bulk-fill the remainder of THIS period
+                    if new_max_dt < p_end - timedelta(hours=1):
+                        logger.info(
+                            'Resuming standard forward search from %s to %s...',
+                            new_max_dt.strftime('%Y-%m-%d %H:%M'), p_end.strftime('%Y-%m-%d %H:%M')
+                        )
+
+                        forward_cur = new_max_dt
+                        delta = timedelta(days=30)
+
+                        while forward_cur <= p_end:
+                            f_date_i = forward_cur.strftime('%Y%m%d')
+                            f_date_f = min(forward_cur + delta, p_end).strftime('%Y%m%d')
+
+                            url = (
+                                f'{api_url}/datagetter?begin_date={f_date_i}&end_date={f_date_f}'
+                                f'&station={station_id}&product=currents{bin_qs}'
+                                f'&time_zone=gmt&units=metric&format=json'
+                            )
+                            context = (f'currents bin={bin_num} (forward patch)' if bin_num is not None
+                                       else 'currents (forward patch)')
+
+                            obs = _get_with_retry(url, station_id, context, logger)
+                            if obs is not None and obs.get('data'):
+                                _process_obs(obs)
+
+                            forward_cur += delta
+                else:
+                    logger.info('Data complete for period %s to %s.',
+                                p_start.strftime('%Y-%m-%d'), p_end.strftime('%Y-%m-%d'))
+
+        # Final check against the absolute expected end (the final physical retrieval date)
+        final_max_dt = pd.to_datetime(max(dates)) if dates else start_dt_0 - timedelta(days=1)
+        if final_max_dt < absolute_expected_end - timedelta(hours=1):
+            logger.warning(
+                'After all retrievals, data for CO-OPS station %s (bin=%s) is still incomplete. '
+                'Latest timestamp is %s (expected %s). Retaining retrieved data.',
+                station_id, bin_num, final_max_dt, absolute_expected_end
+            )
+
+    else:
+        # Fallback when no deployment info is available
+        absolute_expected_end = end_dt_0
+        if max_dt < end_dt_0 - timedelta(hours=1):
             logger.info(
-                'Incomplete date range retrieved, but no deployment change '
-                'detected in the %s to %s window. Skipping backward search.',
-                start_dt_0.strftime('%Y-%m-%d'), end_dt_0.strftime('%Y-%m-%d')
+                'Incomplete date range retrieved (latest: %s, expected: %s), '
+                'but no deployment info is available for %s to determine gaps. '
+                'Skipping patching logic.',
+                max_dt, end_dt_0, station_id
+            )
+
+        final_max_dt = max_dt
+        if final_max_dt < end_dt_0 - timedelta(hours=1):
+            logger.warning(
+                'After all retrievals, data for CO-OPS station %s (bin=%s) is still incomplete. '
+                'Latest timestamp is %s (expected %s). Retaining retrieved data.',
+                station_id, bin_num, final_max_dt, end_dt_0
             )
 
     # 4. Assemble and filter

--- a/src/ofs_skill/obs_retrieval/retrieve_t_and_c_station.py
+++ b/src/ofs_skill/obs_retrieval/retrieve_t_and_c_station.py
@@ -77,6 +77,7 @@ _coops_request_semaphore = threading.Semaphore(_COOPS_CONCURRENCY_LIMIT)
 _coops_pacing_lock = threading.Lock()
 # Lock to prevent concurrent threads from corrupting the deployment summary CSV
 _csv_export_lock = threading.Lock()
+_exported_stations: set[str] = set()  # Tracks stations written to CSV in the current run
 _coops_last_request_time = 0.0  # pylint: disable=invalid-name
 
 
@@ -144,6 +145,9 @@ def reset_run_counters() -> None:
     with _adcp_mounting_counter_lock:
         for key in _adcp_mounting_counter:
             _adcp_mounting_counter[key] = 0
+
+    with _csv_export_lock:
+        _exported_stations.clear()
 
 
 def canonicalize_mounting_symbol(value: Any) -> str:
@@ -576,6 +580,7 @@ def log_and_export_deployment_info(
     logger: Logger,
     start_date: Optional[str] = None,
     end_date: Optional[str] = None,
+    actual_gap_str: str = 'N/A',
 ) -> None:
     """
     Retrieves deployment info for a station, logs the configuration,
@@ -595,7 +600,7 @@ def log_and_export_deployment_info(
     # 2. Check if a physical deployment change or gap occurred within the requested date window
     window_change = False
     gaps_str = 'N/A'
-    total_gap_days = 0
+    total_gap_days = 0.0
 
     if start_date and end_date:
         try:
@@ -666,7 +671,7 @@ def log_and_export_deployment_info(
                         window_gap_days = (overlap_end - overlap_start).seconds/60/24
                         total_gap_days += window_gap_days
                         gap_details.append(
-                            f"{overlap_start.strftime('%Y-%m-%d')} to {overlap_end.strftime('%Y-%m-%d')} ({window_gap_days}d)"
+                            f"{ overlap_start.strftime('%Y-%m-%d')} to {overlap_end.strftime('%Y-%m-%d')} ({window_gap_days:.2f} days)"
                         )
 
                 gaps_str = '; '.join(gap_details) if gap_details else 'None'
@@ -693,17 +698,22 @@ def log_and_export_deployment_info(
         'Station ID': station_id,
         'Total Deployments': num_deployments,
         'Multiple Deployments in Window': window_change if (start_date and end_date) else 'N/A',
-        'Gap Details': gaps_str,
         'Has Bin Depth Shifts': has_depth_shifts,
         'Current Mounting Type': mounting_type,
+        'REPORTED (metadata) Gap Details': gaps_str,
+        'ACTUAL (observed) Gap Details': actual_gap_str
     }
 
     df = pd.DataFrame([row_dict])
 
     with _csv_export_lock:
+        if station_id in _exported_stations:
+            return
+
         try:
             write_header = not os.path.exists(csv_path)
             df.to_csv(csv_path, mode='a', index=False, header=write_header)
+            _exported_stations.add(station_id)
         except Exception as e:
             logger.error('Failed to write deployment summary to CSV for station %s: %s', station_id, e)
 
@@ -1161,16 +1171,6 @@ def _retrieve_currents_all_bins(
         )
     # --------------------------------------
 
-    # ---> Trigger the CSV export <---
-    log_and_export_deployment_info(
-        station_id=station_id,
-        mdapi_url=mdapi_url,
-        control_files_path=control_files_path,
-        logger=logger,
-        start_date=start_date,
-        end_date=end_date
-    )
-
     bins_payload = get_station_depth(station_id, mdapi_url, logger)
     bin_records = _extract_bin_records(bins_payload)
     deployment_info = get_station_deployment(station_id, mdapi_url, logger)
@@ -1215,8 +1215,10 @@ def _retrieve_currents_all_bins(
             'classification against MDAPI deployments.',
             station_id, raw_orient)
 
+    final_result = None
+
     if mounting_type == 'side':
-        return _retrieve_side_looking_currents(
+        final_result = _retrieve_side_looking_currents(
             station_id=station_id,
             start_dt_0=start_dt_0,
             end_dt_0=end_dt_0,
@@ -1235,8 +1237,8 @@ def _retrieve_currents_all_bins(
     # returns valid per-bin depths for these orientations (verified
     # across all 48 non-side stations); the bin-depth ordering reflects
     # the orientation (ascending for down, descending for up).
-    if not bin_records:
-        return _retrieve_currents_legacy_fallback(
+    elif not bin_records:
+        final_result = _retrieve_currents_legacy_fallback(
             station_id=station_id,
             start_dt_0=start_dt_0,
             end_dt_0=end_dt_0,
@@ -1251,68 +1253,102 @@ def _retrieve_currents_all_bins(
             logger=logger,
         )
 
-    result: dict[int, pd.DataFrame] = {}
-    missing_depth: list[int] = []
-    for entry in bin_records:
-        try:
-            bin_num = int(entry.get('num', entry.get('bin')))  # type: ignore[arg-type]
-        except (KeyError, TypeError, ValueError):
-            continue
+    else:
+        result: dict[int, pd.DataFrame] = {}
+        missing_depth: list[int] = []
+        for entry in bin_records:
+            try:
+                bin_num = int(entry.get('num', entry.get('bin')))  # type: ignore[arg-type]
+            except (KeyError, TypeError, ValueError):
+                continue
 
-        # Restrict to CSV-requested bins when provided. Skips both the
-        # datagetter HTTP call and any downstream processing for bins
-        # the user did not pin.
-        if only_bins is not None and bin_num not in only_bins:
-            continue
+            # Restrict to CSV-requested bins when provided. Skips both the
+            # datagetter HTTP call and any downstream processing for bins
+            # the user did not pin.
+            if only_bins is not None and bin_num not in only_bins:
+                continue
 
-        depth = _bin_depth_from_record(entry)
-        if depth is None:
-            missing_depth.append(bin_num)
-            depth = 0.0
+            depth = _bin_depth_from_record(entry)
+            if depth is None:
+                missing_depth.append(bin_num)
+                depth = 0.0
 
-        df = _fetch_currents_chunked(
-            station_id=station_id,
-            bin_num=bin_num,
-            start_dt_0=start_dt_0,
-            end_dt_0=end_dt_0,
-            api_url=api_url,
-            logger=logger,
-            deployment_info=deployment_info,  # <-- ADDED
+            df = _fetch_currents_chunked(
+                station_id=station_id,
+                bin_num=bin_num,
+                start_dt_0=start_dt_0,
+                end_dt_0=end_dt_0,
+                api_url=api_url,
+                logger=logger,
+                deployment_info=deployment_info,  # <-- ADDED
+            )
+            if df is None:
+                continue
+
+            df['DEP01'] = pd.to_numeric(depth)
+            df.attrs['bin'] = bin_num
+            df.attrs['depth'] = depth
+            df.attrs['orientation'] = orientation_label
+            df.attrs['mounting_type'] = mounting_type
+            df.attrs['height_from_bottom'] = hfb
+            df.attrs['has_historical_depth_shifts'] = has_depth_shifts
+            result[bin_num] = df
+
+        if missing_depth:
+            # ERROR rather than WARNING for non-side stations: the bins
+            # endpoint should always populate depth for up/down/unknown.
+            # A null here is a real anomaly worth investigating, distinct
+            # from the side-looking case (which never enters this branch).
+            logger.error(
+                'CO-OPS station %s (%s) bins endpoint returned no depth for '
+                'bins %s; depth recorded as 0.0 m. This is unexpected for '
+                'non-side ADCPs — check MDAPI metadata.',
+                station_id, mounting_type, missing_depth)
+
+        if not result:
+            logger.info(
+                'CO-OPS currents retrieval for station %s returned no bins '
+                'with data.', station_id)
+            final_result = None
+        else:
+            _record_mounting(mounting_type)
+            logger.info(
+                'CO-OPS currents retrieval for station %s (%s, %d bin(s)): %s',
+                station_id, mounting_type, len(result), sorted(result.keys()))
+            final_result = result
+
+    # --- CALCULATE OVERALL ACTUAL GAP AND TRIGGER CSV EXPORT ---
+    actual_gap_str = 'N/A'
+    if final_result:
+        # Determine the maximum gap found across all successfully returned bins
+        max_gap_days = max(
+            (df.attrs.get('actual_gap_days', 0.0) for df in final_result.values()),
+            default=0.0
         )
-        if df is None:
-            continue
+        if max_gap_days > 0.01:
+            actual_gap_str = f'{max_gap_days:.2f} days'
+        else:
+            actual_gap_str = 'None'
+    else:
+        # Complete failure/empty window
+        try:
+            s_dt = datetime.strptime(start_date, '%Y%m%d')
+            e_dt = datetime.strptime(end_date, '%Y%m%d')
+            actual_gap_str = f'{(e_dt - s_dt).days} days (No Data)'
+        except Exception:
+            actual_gap_str = 'No Data'
 
-        df['DEP01'] = pd.to_numeric(depth)
-        df.attrs['bin'] = bin_num
-        df.attrs['depth'] = depth
-        df.attrs['orientation'] = orientation_label
-        df.attrs['mounting_type'] = mounting_type
-        df.attrs['height_from_bottom'] = hfb
-        df.attrs['has_historical_depth_shifts'] = has_depth_shifts
-        result[bin_num] = df
+    log_and_export_deployment_info(
+        station_id=station_id,
+        mdapi_url=mdapi_url,
+        control_files_path=control_files_path,
+        logger=logger,
+        start_date=start_date,
+        end_date=end_date,
+        actual_gap_str=actual_gap_str
+    )
 
-    if missing_depth:
-        # ERROR rather than WARNING for non-side stations: the bins
-        # endpoint should always populate depth for up/down/unknown.
-        # A null here is a real anomaly worth investigating, distinct
-        # from the side-looking case (which never enters this branch).
-        logger.error(
-            'CO-OPS station %s (%s) bins endpoint returned no depth for '
-            'bins %s; depth recorded as 0.0 m. This is unexpected for '
-            'non-side ADCPs — check MDAPI metadata.',
-            station_id, mounting_type, missing_depth)
-
-    if not result:
-        logger.info(
-            'CO-OPS currents retrieval for station %s returned no bins '
-            'with data.', station_id)
-        return None
-
-    _record_mounting(mounting_type)
-    logger.info(
-        'CO-OPS currents retrieval for station %s (%s, %d bin(s)): %s',
-        station_id, mounting_type, len(result), sorted(result.keys()))
-    return result
+    return final_result
 
 
 def _resolve_height_from_bottom(
@@ -1747,8 +1783,10 @@ def _fetch_currents_chunked(
 
                             forward_cur += delta
                 else:
-                    logger.info('Data complete for period %s to %s.',
-                                p_start.strftime('%Y-%m-%d'), p_end.strftime('%Y-%m-%d'))
+                    logger.info('Data complete for period %s to %s, station %s '
+                                'bin %s.',
+                                p_start.strftime('%Y-%m-%d'), p_end.strftime('%Y-%m-%d'),
+                                station_id, bin_num)
 
         # Final check against the absolute expected end (the final physical retrieval date)
         final_max_dt = pd.to_datetime(max(dates)) if dates else start_dt_0 - timedelta(days=1)
@@ -1794,6 +1832,57 @@ def _fetch_currents_chunked(
 
     # Handles overlapping duplicates generated by the expanding 3-hour windows
     df = df.sort_values(by='DateTime').drop_duplicates()
+
+    # --- CALCULATE OBSERVED GAP (DEPLOYMENT BOUNDARIES ONLY) ---
+    total_gap_seconds = 0.0
+
+    # 1. Safely resolve active physical deployment periods from metadata
+    _active_periods = []
+    if deployment_info and deployment_info.get('deployments'):
+        for dep in deployment_info['deployments']:
+            dep_str = dep.get('deployed')
+            ret_str = dep.get('retrieved')
+            if not dep_str:
+                continue
+            try:
+                dep_dt = datetime.strptime(dep_str, '%Y-%m-%d %H:%M:%S')
+                ret_dt = datetime.strptime(ret_str, '%Y-%m-%d %H:%M:%S') if ret_str else datetime.max
+
+                # Intersect this deployment with the requested date window
+                if dep_dt <= end_dt_0 and ret_dt >= start_dt_0:
+                    p_start = max(start_dt_0, dep_dt)
+                    p_end = min(end_dt_0, ret_dt)
+                    if p_start <= p_end:
+                        _active_periods.append((p_start, p_end))
+            except ValueError:
+                continue
+
+        # Sort chronologically
+        _active_periods.sort()
+
+    # 2. Sum ONLY the observed data gaps between adjacent physical deployments
+    if len(_active_periods) > 1:
+        for i in range(len(_active_periods) - 1):
+            dep1_end = _active_periods[i][1]
+            dep2_start = _active_periods[i+1][0]
+
+            # Find the last recorded observation during the prior deployment
+            last_obs_series = df[df['DateTime'] <= dep1_end]['DateTime']
+
+            # Find the first recorded observation during the next deployment
+            first_obs_series = df[df['DateTime'] >= dep2_start]['DateTime']
+
+            if not last_obs_series.empty and not first_obs_series.empty:
+                last_obs = last_obs_series.max()
+                first_obs = first_obs_series.min()
+
+                # Calculate the exact observed gap spanning the deployment change
+                if first_obs > last_obs:
+                    total_gap_seconds += (first_obs - last_obs).total_seconds()
+
+    # Save to attributes for upstream retrieval in the main function
+    df.attrs['actual_gap_days'] = total_gap_seconds / 86400.0
+    # -----------------------------------
 
     # 5. Final completion check logging
     final_max_dt = df['DateTime'].max()

--- a/src/ofs_skill/obs_retrieval/retrieve_t_and_c_station.py
+++ b/src/ofs_skill/obs_retrieval/retrieve_t_and_c_station.py
@@ -694,6 +694,11 @@ def log_and_export_deployment_info(
 
     csv_path = os.path.join(control_files_path, f'coops_deployment_summary_{start_date}_{end_date}.csv')
 
+    # --- DOUBLE-CHECK SAFETY ---
+    # Guarantee no gap is reported if Multiple Deployments is False
+    if not window_change:
+        actual_gap_str = 'N/A'
+
     row_dict = {
         'Station ID': station_id,
         'Total Deployments': num_deployments,
@@ -1838,6 +1843,7 @@ def _fetch_currents_chunked(
 
     # 1. Safely resolve active physical deployment periods from metadata
     _active_periods = []
+    _has_boundary_in_window = False
     if deployment_info and deployment_info.get('deployments'):
         for dep in deployment_info['deployments']:
             dep_str = dep.get('deployed')
@@ -1847,6 +1853,10 @@ def _fetch_currents_chunked(
             try:
                 dep_dt = datetime.strptime(dep_str, '%Y-%m-%d %H:%M:%S')
                 ret_dt = datetime.strptime(ret_str, '%Y-%m-%d %H:%M:%S') if ret_str else datetime.max
+
+                # Check if a physical deploy/retrieve event strictly happened in this window
+                if (start_dt_0 <= dep_dt <= end_dt_0) or (start_dt_0 <= ret_dt <= end_dt_0):
+                    _has_boundary_in_window = True
 
                 # Intersect this deployment with the requested date window
                 if dep_dt <= end_dt_0 and ret_dt >= start_dt_0:
@@ -1860,8 +1870,8 @@ def _fetch_currents_chunked(
         # Sort chronologically
         _active_periods.sort()
 
-    # 2. Sum ONLY the observed data gaps between adjacent physical deployments
-    if len(_active_periods) > 1:
+    # 2. Sum ONLY the observed data gaps if a boundary actually occurred during this fetch window
+    if _has_boundary_in_window and len(_active_periods) > 1:
         for i in range(len(_active_periods) - 1):
             dep1_end = _active_periods[i][1]
             dep2_start = _active_periods[i+1][0]

--- a/src/ofs_skill/obs_retrieval/retrieve_t_and_c_station.py
+++ b/src/ofs_skill/obs_retrieval/retrieve_t_and_c_station.py
@@ -25,7 +25,7 @@ import os
 import random
 import threading
 import time
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from logging import Logger
 from typing import Any, Optional, Union
 from urllib.error import HTTPError
@@ -534,7 +534,7 @@ def check_bin_depth_changes(
         return False
 
     # Group bins by their specific deployment ID
-    deployment_profiles = {}
+    deployment_profiles: dict[Any, dict[int, float]] = {}
     for b in bins_list:
         # Protect against anomalous non-dict items in the list
         if not isinstance(b, dict):
@@ -561,7 +561,7 @@ def check_bin_depth_changes(
     profiles = list(deployment_profiles.values())
     baseline_profile = profiles[0]
 
-    for i, profile in enumerate(profiles[1:], start=1):
+    for profile in profiles[1:]:
         if profile != baseline_profile:
             logger.warning(
                 'CO-OPS station %s has shifting bin depths across deployments! '
@@ -573,10 +573,22 @@ def check_bin_depth_changes(
     logger.info('CO-OPS station %s bin depths are consistent across all deployments.', station_id)
     return False
 
+def _csv_safe(value: Any) -> Any:
+    """Neutralise spreadsheet formula injection in exported CSV cells.
+
+    A cell that begins with ``=``, ``+``, ``-`` or ``@`` is interpreted as a
+    formula when the CSV is opened in Excel/Sheets. Prefix such strings with a
+    single quote so they render literally. Non-strings pass through unchanged.
+    """
+    if isinstance(value, str) and value[:1] in ('=', '+', '-', '@'):
+        return "'" + value
+    return value
+
+
 def log_and_export_deployment_info(
     station_id: str,
     mdapi_url: str,
-    control_files_path: str,
+    control_files_path: Optional[str],
     logger: Logger,
     start_date: Optional[str] = None,
     end_date: Optional[str] = None,
@@ -631,15 +643,18 @@ def log_and_export_deployment_info(
                     r_val = dep.get('retrieved')
                     if d_val:
                         d_dt = datetime.strptime(d_val, '%Y-%m-%d %H:%M:%S')
-                        # Active deployments lack a retrieved date; cap at current time
-                        r_dt = datetime.strptime(r_val, '%Y-%m-%d %H:%M:%S') if r_val else datetime.utcnow()
+                        # Active deployments lack a retrieved date; cap at current
+                        # time (naive UTC to stay consistent with the strptime values)
+                        r_dt = (datetime.strptime(r_val, '%Y-%m-%d %H:%M:%S')
+                                if r_val
+                                else datetime.now(UTC).replace(tzinfo=None))
                         dep_intervals.append((d_dt, r_dt))
 
                 # Sort intervals chronologically by start date
                 dep_intervals.sort(key=lambda x: x[0])
 
                 # Merge overlapping deployments to define solid coverage blocks
-                merged_coverage = []
+                merged_coverage: list[tuple[datetime, datetime]] = []
                 for current in dep_intervals:
                     if not merged_coverage:
                         merged_coverage.append(current)
@@ -668,7 +683,8 @@ def log_and_export_deployment_info(
                     overlap_end = min(gap_end, e_dt)
 
                     if overlap_start < overlap_end:
-                        window_gap_days = (overlap_end - overlap_start).seconds/60/24
+                        window_gap_days = (
+                            (overlap_end - overlap_start).total_seconds() / 86400.0)
                         total_gap_days += window_gap_days
                         gap_details.append(
                             f"{ overlap_start.strftime('%Y-%m-%d')} to {overlap_end.strftime('%Y-%m-%d')} ({window_gap_days:.2f} days)"
@@ -676,14 +692,18 @@ def log_and_export_deployment_info(
 
                 gaps_str = '; '.join(gap_details) if gap_details else 'None'
 
-        except Exception as ex:
-            logger.debug('Failed to parse dates for window checks on %s: %s', station_id, ex)
+        except (ValueError, KeyError, TypeError) as ex:
+            # A malformed deployment record should not silently zero out the
+            # gap diagnostic this feature exists to surface — surface it.
+            logger.warning(
+                'Failed to parse deployment dates for window checks on %s: %s. '
+                'Reported gap details may be incomplete.', station_id, ex)
 
     # 3. Emit the Log
     logger.info(
         'Station %s deployment summary: %d total deployments, '
         'has_historical_shifts=%s, change_in_requested_window=%s, '
-        'gap_days_in_window=%d, mounting=%s',
+        'gap_days_in_window=%.2f, mounting=%s',
         station_id, num_deployments, has_depth_shifts,
         window_change, total_gap_days, mounting_type
     )
@@ -700,13 +720,13 @@ def log_and_export_deployment_info(
         actual_gap_str = 'N/A'
 
     row_dict = {
-        'Station ID': station_id,
+        'Station ID': _csv_safe(station_id),
         'Total Deployments': num_deployments,
         'Multiple Deployments in Window': window_change if (start_date and end_date) else 'N/A',
         'Has Bin Depth Shifts': has_depth_shifts,
-        'Current Mounting Type': mounting_type,
-        'REPORTED (metadata) Gap Details': gaps_str,
-        'ACTUAL (observed) Gap Details': actual_gap_str
+        'Current Mounting Type': _csv_safe(mounting_type),
+        'REPORTED (metadata) Gap Details': _csv_safe(gaps_str),
+        'ACTUAL (observed) Gap Details': _csv_safe(actual_gap_str)
     }
 
     df = pd.DataFrame([row_dict])
@@ -849,7 +869,7 @@ _get_station_deployment = get_station_deployment
 def retrieve_t_and_c_station(
     retrieve_input: Any,
     logger: Logger,
-    control_files_path: Any,
+    control_files_path: Optional[str] = None,
     only_bins: Optional[set[int]] = None,
     config_file=None,
 ) -> Optional[Union[pd.DataFrame, dict[int, pd.DataFrame]]]:
@@ -1285,7 +1305,8 @@ def _retrieve_currents_all_bins(
                 end_dt_0=end_dt_0,
                 api_url=api_url,
                 logger=logger,
-                deployment_info=deployment_info,  # <-- ADDED
+                deployment_info=deployment_info,
+                has_depth_shifts=has_depth_shifts,
             )
             if df is None:
                 continue
@@ -1456,7 +1477,8 @@ def _retrieve_side_looking_currents(
             end_dt_0=end_dt_0,
             api_url=api_url,
             logger=logger,
-            deployment_info=deployment_info,  # <-- ADDED
+            deployment_info=deployment_info,
+            has_depth_shifts=has_depth_shifts,
         )
         if df is None:
             logger.info(
@@ -1530,7 +1552,8 @@ def _retrieve_currents_legacy_fallback(
         end_dt_0=end_dt_0,
         api_url=api_url,
         logger=logger,
-        deployment_info=deployment_info,  # <-- ADDED
+        deployment_info=deployment_info,
+        has_depth_shifts=has_depth_shifts,
     )
     if legacy is None:
         return None
@@ -1584,6 +1607,54 @@ def _legacy_fallback_bin(
                 return rtb
     return 1
 
+def _active_deployment_periods(
+    deployment_info: Optional[dict],
+    start_dt_0: datetime,
+    end_dt_0: datetime,
+    logger: Optional[Logger] = None,
+) -> tuple[list[tuple[datetime, datetime]], bool]:
+    """Intersect each deployment with ``[start_dt_0, end_dt_0]``.
+
+    Returns ``(periods, has_boundary)`` where ``periods`` is the sorted list of
+    ``(start, end)`` tuples for deployments overlapping the window, and
+    ``has_boundary`` is True when a physical deploy/retrieve event falls inside
+    the window. Active deployments (no ``retrieved`` date) are capped at
+    ``datetime.max``.
+    """
+    periods: list[tuple[datetime, datetime]] = []
+    has_boundary = False
+    if not (deployment_info and deployment_info.get('deployments')):
+        return periods, has_boundary
+
+    for dep in deployment_info['deployments']:
+        dep_str = dep.get('deployed')
+        ret_str = dep.get('retrieved')
+        if not dep_str:
+            continue
+        try:
+            dep_dt = datetime.strptime(dep_str, '%Y-%m-%d %H:%M:%S')
+            ret_dt = (datetime.strptime(ret_str, '%Y-%m-%d %H:%M:%S')
+                      if ret_str else datetime.max)
+        except ValueError as exc:
+            if logger is not None:
+                logger.debug('Failed to parse deployment dates: %s', exc)
+            continue
+
+        # A physical deploy/retrieve event strictly inside the window
+        if (start_dt_0 <= dep_dt <= end_dt_0) or (start_dt_0 <= ret_dt <= end_dt_0):
+            has_boundary = True
+
+        # Intersect this deployment with the requested date window
+        if dep_dt <= end_dt_0 and ret_dt >= start_dt_0:
+            p_start = max(start_dt_0, dep_dt)
+            p_end = min(end_dt_0, ret_dt)
+            if p_start <= p_end:
+                periods.append((p_start, p_end))
+
+    periods.sort()
+    return periods, has_boundary
+
+
 def _fetch_currents_chunked(
     station_id: str,
     bin_num: Optional[int],
@@ -1592,6 +1663,7 @@ def _fetch_currents_chunked(
     api_url: str,
     logger: Logger,
     deployment_info: Optional[dict] = None,
+    has_depth_shifts: bool = False,
 ) -> Optional[pd.DataFrame]:
     """Pull currents data for a station (optionally a specific bin) in
     30-day chunks and return a DataFrame with DateTime/DIR/OBS columns.
@@ -1664,32 +1736,8 @@ def _fetch_currents_chunked(
 
     if deployment_info and deployment_info.get('deployments'):
         # Compile a list of active deployment periods within the requested window
-        active_periods = []
-        for dep in deployment_info['deployments']:
-            dep_str = dep.get('deployed')
-            ret_str = dep.get('retrieved')
-
-            if not dep_str:
-                continue
-
-            try:
-                dep_dt = datetime.strptime(dep_str, '%Y-%m-%d %H:%M:%S')
-                if ret_str:
-                    ret_dt = datetime.strptime(ret_str, '%Y-%m-%d %H:%M:%S')
-                else:
-                    ret_dt = datetime.max
-
-                # Intersect this deployment with the requested date window
-                if dep_dt <= end_dt_0 and ret_dt >= start_dt_0:
-                    p_start = max(start_dt_0, dep_dt)
-                    p_end = min(end_dt_0, ret_dt)
-                    if p_start <= p_end:
-                        active_periods.append((p_start, p_end))
-            except ValueError as e:
-                logger.debug('Failed to parse deployment dates for %s: %s', station_id, e)
-                continue
-
-        active_periods.sort()
+        active_periods, _ = _active_deployment_periods(
+            deployment_info, start_dt_0, end_dt_0, logger)
 
         if not active_periods:
             logger.info(
@@ -1835,42 +1883,41 @@ def _fetch_currents_chunked(
     if df.empty:
         return None
 
-    # Handles overlapping duplicates generated by the expanding 3-hour windows
-    df = df.sort_values(by='DateTime').drop_duplicates()
+    # Drop duplicate timestamps generated by the expanding 3-hour windows
+    # (and by overlapping deployments). Dedup on DateTime only — two instruments
+    # reporting the same bin number at the same time with slightly different
+    # speed/dir must not both survive, or downstream time-alignment breaks.
+    df = df.sort_values(by='DateTime').drop_duplicates(subset='DateTime')
+
+    # Resolve the physical deployment periods overlapping the requested window.
+    _active_periods, _has_boundary_in_window = _active_deployment_periods(
+        deployment_info, start_dt_0, end_dt_0, logger)
+
+    # When bin depths shift across deployments, observations recorded at
+    # different physical depths share one bin number. Concatenating them and
+    # comparing against a single fixed model node depth corrupts the skill
+    # statistics, so restrict to the most recent deployment period (whose depth
+    # matches the label stamped on this series downstream) rather than mixing.
+    if has_depth_shifts and len(_active_periods) > 1:
+        keep_start, keep_end = _active_periods[-1]
+        before = len(df)
+        df = df[(df['DateTime'] >= keep_start) & (df['DateTime'] <= keep_end)]
+        logger.warning(
+            'CO-OPS station %s (bin=%s) has bin-depth shifts across '
+            'deployments; restricting to the most recent deployment '
+            '(%s to %s) and dropping %d cross-boundary observation(s) to '
+            'avoid mixing physical depths in one skill comparison.',
+            station_id, bin_num,
+            keep_start.strftime('%Y-%m-%d %H:%M'),
+            keep_end.strftime('%Y-%m-%d %H:%M'),
+            before - len(df))
+        if df.empty:
+            return None
 
     # --- CALCULATE OBSERVED GAP (DEPLOYMENT BOUNDARIES ONLY) ---
     total_gap_seconds = 0.0
 
-    # 1. Safely resolve active physical deployment periods from metadata
-    _active_periods = []
-    _has_boundary_in_window = False
-    if deployment_info and deployment_info.get('deployments'):
-        for dep in deployment_info['deployments']:
-            dep_str = dep.get('deployed')
-            ret_str = dep.get('retrieved')
-            if not dep_str:
-                continue
-            try:
-                dep_dt = datetime.strptime(dep_str, '%Y-%m-%d %H:%M:%S')
-                ret_dt = datetime.strptime(ret_str, '%Y-%m-%d %H:%M:%S') if ret_str else datetime.max
-
-                # Check if a physical deploy/retrieve event strictly happened in this window
-                if (start_dt_0 <= dep_dt <= end_dt_0) or (start_dt_0 <= ret_dt <= end_dt_0):
-                    _has_boundary_in_window = True
-
-                # Intersect this deployment with the requested date window
-                if dep_dt <= end_dt_0 and ret_dt >= start_dt_0:
-                    p_start = max(start_dt_0, dep_dt)
-                    p_end = min(end_dt_0, ret_dt)
-                    if p_start <= p_end:
-                        _active_periods.append((p_start, p_end))
-            except ValueError:
-                continue
-
-        # Sort chronologically
-        _active_periods.sort()
-
-    # 2. Sum ONLY the observed data gaps if a boundary actually occurred during this fetch window
+    # Sum ONLY the observed data gaps if a boundary actually occurred during this fetch window
     if _has_boundary_in_window and len(_active_periods) > 1:
         for i in range(len(_active_periods) - 1):
             dep1_end = _active_periods[i][1]

--- a/src/ofs_skill/obs_retrieval/write_obs_ctlfile.py
+++ b/src/ofs_skill/obs_retrieval/write_obs_ctlfile.py
@@ -181,7 +181,8 @@ def _emit_coops_currents_entries(
 def _process_coops_station(id_number, name, x_value, y_value,
                            start_date, end_date, variable, name_var,
                            datum, datum_list, ofs, logger,
-                           bin_overrides=None, config_file=None):
+                           bin_overrides=None, config_file=None,
+                           control_files_path=None):
     """Process a single CO-OPS station.
 
     Returns a list of CTL entry strings. For most variables the list
@@ -211,7 +212,7 @@ def _process_coops_station(id_number, name, x_value, y_value,
         )
         timeseries = retrieve_t_and_c_station(
             retrieve_input, logger, only_bins=only_bins,
-            config_file=config_file)
+            config_file=config_file, control_files_path=control_files_path)
         if variable == 'water_level':
             datum_found = None
             if (isinstance(timeseries, pd.DataFrame)
@@ -374,7 +375,7 @@ def _process_coops_station(id_number, name, x_value, y_value,
             return _emit_coops_currents_entries(
                 id_number, name, x_value, y_value, ofs, name_var,
                 timeseries, bin_overrides, logger,
-            )
+                )
     except Exception as ex:
         logger.info(
             'CO-OPS %s data not found for '
@@ -761,6 +762,7 @@ def _process_variable(variable, inventory, var_to_col, start_date, end_date,
                     datum, datum_list, ofs, logger,
                     station_overrides,
                     config_file=config_file,
+                    control_files_path=control_files_path
                 ))
             for future in futures:
                 result = future.result()

--- a/src/ofs_skill/skill_assessment/get_skill.py
+++ b/src/ofs_skill/skill_assessment/get_skill.py
@@ -16,6 +16,7 @@ from pathlib import Path
 
 import numpy as np
 import pandas as pd
+from pandas.errors import EmptyDataError
 
 from ofs_skill.model_processing import do_horizon_skill
 from ofs_skill.model_processing.get_fcst_cycle import get_fcst_dates
@@ -208,11 +209,13 @@ def prepare_series(read_station_ctl_file, read_ofs_ctl_file, prop,
                 result = get_node_ofs(prop, logger,
                                       model_dataset=cached)
                 _set_cached_model(prop, result)
-
-            ofs_df = pd.read_csv(prd_path,
-                sep=r'\s+',
-                header=None,
-                )
+            try:
+                ofs_df = pd.read_csv(prd_path,
+                    sep=r'\s+',
+                    header=None,
+                    )
+            except EmptyDataError:
+                return None
 
         if (
             ofs_df is not None

--- a/src/ofs_skill/skill_assessment/make_skill_maps.py
+++ b/src/ofs_skill/skill_assessment/make_skill_maps.py
@@ -15,6 +15,7 @@ import os
 from logging import Logger
 from typing import Any
 
+import numpy as np
 import pandas as pd
 import plotly
 import plotly.express as px
@@ -102,6 +103,21 @@ def make_skill_maps(
     if df.empty:
         logger.error('No stations with valid coordinates; cannot make skill maps!')
         return
+
+    # ========================================================
+    #                     ADD JITTER
+    # ========================================================
+    # Identify stations with the exact same coordinates
+    duplicates = df.duplicated(subset=['X ', 'Y '], keep=False)
+
+    if duplicates.any():
+        logger.info(f'Adding jitter to {duplicates.sum()} overlapping points.')
+        # Roughly 0.0005 degrees is ~50 meters. Adjust this if you need more/less spread.
+        jitter_amount = 0.005
+
+        # Add random uniform noise to both X and Y for just the duplicate rows
+        df.loc[duplicates, 'X '] += np.random.uniform(-jitter_amount, jitter_amount, size=duplicates.sum())
+        df.loc[duplicates, 'Y '] += np.random.uniform(-jitter_amount, jitter_amount, size=duplicates.sum())
 
     # Absolute mean bias for marker sizing
     df['Abs mean bias '] = df['Mean bias '].abs()
@@ -221,9 +237,6 @@ def make_skill_maps(
     actual_max_mb = df['Mean bias '].max()
     actual_min_mb = df['Mean bias '].min()
 
-    # NEW: Full Diverging Scale (Blue -> White -> Red)
-    # Hard jumps at the +/- target threshold to maintain visual boundaries.
-    # The acceptable colors (-Target to +Target) are more saturated/darker to stand out.
     color_scale_mb = [
         [0.0, '#08519c'],           # -3x target (Dark Blue)
         [1/3, '#3182bd'],           # -Target limit (Medium Blue)
@@ -244,7 +257,6 @@ def make_skill_maps(
     #                     BUILD COMBINED FIGURE
     # ========================================================
 
-    # 1. Define custom data arrays to strictly control hover order
     cols_rmse = [
         'RMSE ', 'Target RMSE ', 'Mean bias ', 'Central freq ',
         'CF pass/fail ', 'R ', 'Positive outlier freq ',
@@ -263,17 +275,14 @@ def make_skill_maps(
         'PO freq pass/fail ', 'Negative outlier freq ', 'NO freq pass/fail '
     ]
 
-    # Helper function to build a clean, perfectly ordered hover template
     def build_hovertemplate(cols):
         template = '<b>%{hovertext}</b><br><br>'
         for i, col in enumerate(cols):
-            label = col.strip() # Cleans up the trailing spaces in your column names
+            label = col.strip()
             template += f'{label}: %{{customdata[{i}]}}<br>'
-        template += '<extra></extra>' # Hides the secondary trace name box
+        template += '<extra></extra>'
         return template
 
-    # Build a (colored trace, black outline trace) pair per view.
-    # Returns plotly Scattermapbox traces ready to add to the final figure.
     def build_view(color_col, size_col, custom_cols, coloraxis_id):
         fig_tmp = px.scatter_mapbox(
             df, lat='Y ', lon='X ', color=color_col, hover_name='ID ',
@@ -316,6 +325,9 @@ def make_skill_maps(
     fig.add_trace(mb_outline)
     fig.add_trace(mb_trace)
 
+    # ADD CLUSTERING TO MAPBOX TRACES
+    fig.update_traces(cluster=dict(enabled=False))
+
     # 5. Layout & Dropdown Menus
     fig.update_layout(
         mapbox_style='carto-positron',
@@ -356,7 +368,7 @@ def make_skill_maps(
         # Tertiary Colorbar (Mean Bias) - Hidden by default
         coloraxis3=dict(
             colorscale=color_scale_mb,
-            cmin=-mb_cap, cmax=mb_cap, # Bounded entirely between -3x and +3x target
+            cmin=-mb_cap, cmax=mb_cap,
             showscale=False,
             colorbar=dict(
                 title=dict(text=f'Mean bias ({title_unit})', font=dict(color='black')),

--- a/src/ofs_skill/skill_assessment/make_skill_maps.py
+++ b/src/ofs_skill/skill_assessment/make_skill_maps.py
@@ -111,13 +111,18 @@ def make_skill_maps(
     duplicates = df.duplicated(subset=['X ', 'Y '], keep=False)
 
     if duplicates.any():
-        logger.info(f'Adding jitter to {duplicates.sum()} overlapping points.')
-        # Roughly 0.0005 degrees is ~50 meters. Adjust this if you need more/less spread.
-        jitter_amount = 0.005
+        n_dupes = int(duplicates.sum())
+        logger.info('Adding jitter to %d overlapping points.', n_dupes)
+        # ~0.0005 degrees is roughly 50 m; enough to separate co-located
+        # markers without materially misplacing them on the map.
+        jitter_amount = 0.0005
 
-        # Add random uniform noise to both X and Y for just the duplicate rows
-        df.loc[duplicates, 'X '] += np.random.uniform(-jitter_amount, jitter_amount, size=duplicates.sum())
-        df.loc[duplicates, 'Y '] += np.random.uniform(-jitter_amount, jitter_amount, size=duplicates.sum())
+        # Seeded RNG so marker positions are reproducible run-to-run.
+        rng = np.random.default_rng(0)
+        df.loc[duplicates, 'X '] += rng.uniform(
+            -jitter_amount, jitter_amount, size=n_dupes)
+        df.loc[duplicates, 'Y '] += rng.uniform(
+            -jitter_amount, jitter_amount, size=n_dupes)
 
     # Absolute mean bias for marker sizing
     df['Abs mean bias '] = df['Mean bias '].abs()
@@ -325,7 +330,9 @@ def make_skill_maps(
     fig.add_trace(mb_outline)
     fig.add_trace(mb_trace)
 
-    # ADD CLUSTERING TO MAPBOX TRACES
+    # Marker clustering is disabled here: skill maps show every station
+    # individually (jitter above separates co-located points). Set
+    # enabled=True if dense maps ever need clustering.
     fig.update_traces(cluster=dict(enabled=False))
 
     # 5. Layout & Dropdown Menus

--- a/src/ofs_skill/visualization/plotting_scalar.py
+++ b/src/ofs_skill/visualization/plotting_scalar.py
@@ -245,7 +245,7 @@ def oned_scalar_plot(
             namekey = [name.split('.')[1] if isinstance(name, str) else '' \
                        for name in list(now_fores_paired[i].filename)]
             hovertemplate = f"{seriesname.split(' ')[1]}: %{{y:.2f}}<br><i>Model cycle: %{{text}}<i><extra></extra>"
-        except AttributeError:
+        except (AttributeError, IndexError):
             logger.error('No hoverinfo filenames available!')
             hovertemplate='%{y:.2f}'
             namekey = None

--- a/src/ofs_skill/visualization/plotting_vector.py
+++ b/src/ofs_skill/visualization/plotting_vector.py
@@ -217,7 +217,7 @@ def oned_vector_plot1(
             namekey = [name.split('.')[1] if isinstance(name, str) else '' \
                        for name in list(now_fores_paired[i].filename)]
             hovertemplate = f"{seriesname.split(' ')[1]}: %{{y:.2f}}<br><i>Model cycle: %{{text}}<i><extra></extra>"
-        except AttributeError:
+        except (AttributeError, IndexError):
             logger.error('No hoverinfo filenames available!')
             hovertemplate='%{y:.2f}'
             namekey = None

--- a/src/ofs_skill/visualization/plotting_vector.py
+++ b/src/ofs_skill/visualization/plotting_vector.py
@@ -205,7 +205,7 @@ def oned_vector_plot1(
         elif prop.whichcasts[i].capitalize() == 'Nowcast':
             seriesname = 'Model Nowcast Guidance'
         else:
-            seriesname = prop.whichcasts[i].capitalize(
+            seriesname = 'Model ' + prop.whichcasts[i].capitalize(
             ) + ' Guidance'  # + f"{i}",
         # Parse filenames from key
         try:
@@ -306,7 +306,7 @@ def oned_vector_plot1(
             namekey = [name.split('.')[1] if isinstance(name, str) else '' \
                        for name in list(now_fores_paired[i].filename)]
             hovertemplate = f"{seriesname.split(' ')[1]}: %{{y:.2f}}<br><i>Model cycle: %{{text}}<i><extra></extra>"
-        except AttributeError:
+        except (AttributeError, IndexError):
             logger.error('No hoverinfo filenames available!')
             hovertemplate='%{y:.2f}'
             namekey = None
@@ -344,7 +344,7 @@ def oned_vector_plot1(
         elif prop.whichcasts[i].capitalize() == 'Forecast_a':
             sdboxName = 'Forecast ' + prop.forecast_hr[:-1] + 'z - Obs.'
         else:
-            sdboxName = 'Model'+str(i+1)+' - Obs.'
+            sdboxName = prop.whichcasts[i].capitalize() + ' - Obs.'
         fig.add_trace(
             go.Scattergl(
                 x=list(now_fores_paired[i].DateTime),

--- a/src/ofs_skill/visualization/summary_barplots.py
+++ b/src/ofs_skill/visualization/summary_barplots.py
@@ -176,8 +176,13 @@ def write_html_summary_bars(df: pd.DataFrame, name_var: str, variable: str,
     """Two-row plotly figure: RMSE on top, CF on bottom."""
     x1, _ = plotting_functions.get_error_range(name_var, prop, logger)
     labels = _x_labels(df, name_var)
-    rmse_vals = [float(v) if pd.notna(v) else None for v in df['rmse']]
-    cf_vals = [float(v) if pd.notna(v) else None for v in df['central_freq']]
+    rmse_vals = [float(v) if pd.notna(v) and v != '<5 data points' else None for v in df['rmse']]
+    cf_vals = [float(v) if pd.notna(v) and v != '<5 data points' else None for v in df['central_freq']]
+
+    if all(v is None for v in rmse_vals):
+        logger.warning('Cannot create summary bar plots because there are not '
+                       'enough data points to calculate statistics.')
+        return None
 
     custom = list(zip(
         df.get('ID', pd.Series([''] * len(df))).astype(str),

--- a/src/ofs_skill/visualization/summary_barplots.py
+++ b/src/ofs_skill/visualization/summary_barplots.py
@@ -192,8 +192,8 @@ def write_html_summary_bars(df: pd.DataFrame, name_var: str, variable: str,
         shared_xaxes=True,
         vertical_spacing=0.08,
         subplot_titles=(
-            f'RMSE per station (target {x1})',
-            'Central frequency per station (≥ 90% pass)',
+            f'RMSE (target {x1})',
+            'Central frequency (≥ 90% pass)',
         ),
     )
     for annot in fig['layout']['annotations']:


### PR DESCRIPTION
This PR introduces support for using custom model input files in the skill assessment workflow, along with enhancements to CO-OPS currents data retrieval, deployment monitoring, and deployment gap detection. 

Closes #145, #161, #160, #157, #179

---
## Description of changes

### 1. Custom Model File Support
- **User-Provided File Lists**: Load model files from user-specified text files (local paths, S3 URIs, or HTTPS URLs)
- **File Verification**: Validates that all custom files exist before processing
- **Configuration Options**: Easy enable/disable via `ofs_dps.conf` settings
- **Date Range Validation**: Automatic checking for overlap between custom file dates and requested date range

### 2. Enhanced CO-OPS Currents Retrieval
- **Bin Depth Change Detection**: Identifies when ADCP stations have shifted bin depths across deployments
- **Deployment-Aware Gap Filling**: Intelligently fills data gaps at deployment boundaries using expanding window searches
- **Deployment Summary Export**: Generates CSV reports tracking deployment changes, gaps, and data completeness
- **Thread-Safe CSV Export**: Prevents race conditions when multiple concurrent station workers write to shared files
- **Historic Station Retrieval Eanbled**: Retrieves observations from stations that are not currently deployed, but have observations available within the user-specified date range.

### 3. Improved Data Quality Tracking
- **Deployment Metadata Analysis**: Logs detailed station deployment information
- **Gap Duration Calculation**: Distinguishes between reported metadata gaps and actual observed gaps
- **Window-Based Analysis**: Identifies deployment changes within requested date ranges

### 4. Configuration
- **`conf/ofs_dps.conf.example`**
  - Added `use_custom_filenames` setting (default: False)
  - Added `filename_path` configuration parameter

Config file changes in `[settings]`:

```ini
# Use a custom list of model files?
# True = load filenames from user-provided text file
# False = default; SA will fetch file names either from the S3 bucket, or locally
use_custom_filenames=False
filename_path=path/to/filename.txt
```

---
### Expected Outcome of Changes

1. Flexibility in Data Sourcing
Users can now supply their own custom model files instead of relying solely on the default S3 bucket or local directory structure. This enables:
- Testing with experimental or alternative model runs
- Using locally pre-processed model files

2. Improved CO-OPS Currents Data Quality
- Detects deployment changes: Identifies when physical instruments are swapped (which changes bin depths)
- Fills gaps intelligently: At deployment boundaries, the tool now searches backwards to retrieve any missed data from deployment edges
- Tracks data completeness: Generates detailed CSV reports showing where gaps exist, whether they're due to instrument changes or actual data outages

4. Better Diagnostics & Transparency
New deployment summary CSV files document:
- How many times an instrument was deployed/retrieved
- Whether bin depths shifted (affecting data interpretation)
- What gaps exist in the requested date window
- How much of the gap is actual observed data loss vs. metadata-reported changes

### Developer Questions and Checklist
**Is this a high priority PR? If yes, why and is there a date by which it needs to be merged?**
No. Standard priority.

**Are there any changes needed to how the code should be run on the server? (Commands, flags, job timings, etc.)**
No.

**Does this update need to be installed on the server?**
yes.

**Does this update require front end/web app changes? (If yes, provide documentation to Min)**
No.

**Does this impact code development work on adding SCHISM? (If yes, tag Atieh)**
No.

**Does this impact code development work on adding ADCIRC?**
No.

**Does this impact the expected number of output files for integration tests (i.e., will the integration test fail even though code changes result in desired change in the number of outputs?)**
No.

- [x] Developer's name is removed throughout the code?
- [x] Did you add relevant labels to the PR?
- [x] Have you run pylint and is the code at an acceptable pylint score? (>8.0)
- [x] Jobs contain the appropriate file checking and handle errors for any missing data?
- [x] Is log free of critical ERRORs or WARNINGs? For errors that are not critical and can remain in code, is there sufficient handling and logging?

### Testing Instructions

**First, contact @plimbernoaa for a list of custom hindcast NECOFS file names and inventory file for testing.**

**Test 1: Input list of custom file names**

In `ofs_dps.conf`, enable custom file name input and provide the path to the file name text file. Add the provided NECOFS inventory file to `./control_files/`.

Complete a `hindcast` run for NECOFS using CO-OPS current stations:

`python ./bin/visualization/create_1dplot.py -o necofs -p ./ -s 2017-01-01T00:00:00Z -e 2017-03-31T00:00:00Z -d navd88 -vs currents -ws hindcast -so co-ops`

When the run is complete, verify:
1) Generation of all expected output for 13 out of 18 stations in the inventory file, and that the output looks correct;
2) A CSV file is written to `./control_files/coops_deployment_summary_{start_date}_{end_date}.csv`;
3) The deployment summary CSV contains relevant information;
4) A pause at the beginning of the run, shown in the log file, to warn users that custom model file input is enabled;

**Test 2: Obs retrieval across deployments**

In `ofs_dps.conf`, add **cb0301** to the `station_ID_list` in the section `[station_IDs]`. Then run:

`python ./bin/visualization/create_1dplot.py -o cbofs -p ./ -s 2024-05-02T00:00:00Z -e 2024-05-05T23:59:59Z -vs currents -so list -ws forecast_b`

On 05/02, there is a station retrieval at 16:16 and redployment at 20:45. Please check the `.obs` file for this data gap, and that the observations time series continues after 20:45. Prior to this update, the obs time series would not have continued after 20:45.

**Test 3: Obs retrieval from historic stations**

Station **cb1101** in CBOFS is not currently deployed, and is a historic station. It has data available between 2024-02-07 16:00:00 and 2024-09-10 18:30:00. Do a CBOFS run for a date range within this deployment window, for example:

`python ./bin/visualization/create_1dplot.py -o cbofs -p ./ -s 2024-05-02T00:00:00Z -e 2024-05-05T23:59:59Z -vs currents -ws forecast_b`

and verify that station cb1101 appears in the inventory and observation control files.
 

### Reminder checklist for PR reviewer:
- [x] Run PEP8 compliance tests to ensure the code follows best practices
- [x] Check that documentation in the script is sufficient
- [x] Validate the output values (if applicable) to make sure the calculations are correct and make scientific/physical sense; include a comment on the pull request including what validation you performed, for replicability.
- [x] Test code both locally and on the linux server, using several OFS as test cases
- [x] **Test for all ‘cast’ options: forecast_a, forecast_b, and nowcast**
- [x] When approving or commenting on a pull request, add information on the calls you use in case they need to be replicated.
