### PR TITLE
Fix CHS datum crash and clean up STOFS currents skill reporting

### DIFF
--- a/src/ofs_skill/obs_retrieval/vdatum_resilient.py
+++ b/src/ofs_skill/obs_retrieval/vdatum_resilient.py
@@ -54,6 +54,20 @@ _RETRY_ATTEMPTS = 4
 _RETRY_BASE_SECONDS = 1.5
 _RETRY_CAP_SECONDS = 12.0
 
+# Vertical datums ``coastalmodeling_vdatum`` knows how to build pipelines
+# for.  We validate against this set up front because the underlying
+# ``vdatum.convert`` has an operator-precedence bug in its own guard
+# (``if vd_from and vd_to not in [...]``) that only validates ``vd_to`` --
+# an invalid ``vd_from`` slips through and later raises a cryptic
+# ``UnboundLocalError`` ('h_g') from an unguarded if/elif chain instead of
+# a clean error.  Membership here does not guarantee a *pair* is
+# convertible (there is no overlap between Great-Lakes and tidal datums,
+# e.g. ``igld85`` <-> ``mllw``); that case is caught at call time.
+SUPPORTED_DATUMS = frozenset({
+    'xgeoid20b', 'navd88', 'mllw', 'mlw', 'mhhw', 'mhw', 'lmsl',
+    'igld85', 'lwd',
+})
+
 # Per-(vd_from, vd_to) prime state.  ``_PRIME_LOCK`` guards
 # ``_PRIMED_PAIRS``; on first use of a pair, the holding thread runs a
 # single throwaway ``vdatum.convert`` to populate PROJ's grid cache so
@@ -107,6 +121,13 @@ def _prime_pair(vd_from: str, vd_to: str,
                 'PROJ grid prime failed for %s->%s; subsequent calls '
                 'will retry on their own. Underlying error: %s',
                 vd_from, vd_to, exc)
+        except UnboundLocalError:
+            # The datum pair is in-vocabulary but has no conversion
+            # pipeline (e.g. a Great-Lakes datum to a tidal datum). The
+            # underlying vdatum.convert leaves its grid variables unbound
+            # and raises UnboundLocalError. Mark primed and let the real
+            # call surface a clean error to the caller.
+            _PRIMED_PAIRS.add(pair)
 
 
 def convert(vd_from, vd_to, lat, lon, z, *, epoch=None,
@@ -116,10 +137,24 @@ def convert(vd_from, vd_to, lat, lon, z, *, epoch=None,
 
     Returns ``(lat, lon, z)`` on success.  Raises the last ``ProjError``
     if every retry fails so the caller can decide what to do (log and
-    skip the station, fall back to a default offset, etc.).
+    skip the station, fall back to a default offset, etc.).  Raises
+    ``ValueError`` for an unsupported datum or an in-vocabulary pair that
+    has no conversion pipeline (e.g. a Great-Lakes datum to a tidal
+    datum), so callers get a clean error instead of the dependency's
+    cryptic ``UnboundLocalError``.
     """
     log = logger or _logger
     last_exc: BaseException | None = None
+
+    # Validate the datum vocabulary up front.  ``vdatum.convert``'s own
+    # guard fails to validate ``vd_from`` (operator-precedence bug), so an
+    # unknown source datum would otherwise reach an unguarded if/elif
+    # chain and raise a confusing ``UnboundLocalError`` ('h_g').  Raise a
+    # clear ValueError instead so callers can skip the station cleanly.
+    if vd_from not in SUPPORTED_DATUMS or vd_to not in SUPPORTED_DATUMS:
+        raise ValueError(
+            f'Unsupported vertical datum conversion {vd_from!r}->{vd_to!r}. '
+            f'Supported datums: {sorted(SUPPORTED_DATUMS)}')
 
     # PROJ contexts are per-thread.  ``pyproj.network.set_network_enabled``
     # only flips the *calling thread's* context.  Setting it explicitly
@@ -138,6 +173,13 @@ def convert(vd_from, vd_to, lat, lon, z, *, epoch=None,
         try:
             return vdatum.convert(vd_from, vd_to, lat, lon, z,
                                   online=True, epoch=epoch)
+        except UnboundLocalError as exc:
+            # In-vocabulary pair with no conversion pipeline (e.g. a
+            # Great-Lakes datum to a tidal datum). This is deterministic,
+            # so don't retry -- raise a clear error for the caller.
+            raise ValueError(
+                f'No vertical datum conversion path from {vd_from!r} to '
+                f'{vd_to!r}.') from exc
         except pyproj.exceptions.ProjError as exc:
             last_exc = exc
             log.warning(

--- a/src/ofs_skill/obs_retrieval/write_obs_ctlfile.py
+++ b/src/ofs_skill/obs_retrieval/write_obs_ctlfile.py
@@ -740,16 +740,33 @@ def _process_chs_station(
                 else:
                     ldatum = _normalize_vdatum_name(datum).lower()
                     dummyval = 10
-                    _, _, z = vdatum_resilient.convert(
-                        station_datum.lower(),
-                        ldatum,
-                        y_value,
-                        x_value,
-                        dummyval,
-                        epoch=None,
-                        station_id=str(id_number),
-                        logger=logger,
-                    )
+                    try:
+                        _, _, z = vdatum_resilient.convert(
+                            station_datum.lower(),
+                            ldatum,
+                            y_value,
+                            x_value,
+                            dummyval,
+                            epoch=None,
+                            station_id=str(id_number),
+                            logger=logger,
+                        )
+                    except ValueError as exc:
+                        # CHS observed water level is referenced to chart
+                        # datum (labeled 'IGLD' here). For non-Great-Lakes
+                        # OFS there is no datum-conversion path from that
+                        # datum to a tidal datum such as MLLW, so the
+                        # station cannot be aligned to the model. Skip it
+                        # cleanly rather than crashing or mislabeling the
+                        # failure as missing data.
+                        logger.warning(
+                            'CHS station %s skipped: no datum conversion '
+                            'path from %s to %s. CHS water level is in chart '
+                            'datum and cannot be aligned to the requested '
+                            'datum (%s) for this OFS. %s',
+                            str(id_number), station_datum.lower(), ldatum,
+                            datum, exc)
+                        return []
                     zdiff = 'RANGE' if math.isinf(z) else round(z - dummyval, 2)
 
             return [

--- a/src/ofs_skill/skill_assessment/get_skill.py
+++ b/src/ofs_skill/skill_assessment/get_skill.py
@@ -995,9 +995,16 @@ def get_skill(prop, logger):
                         variable,
                     )
         else:
-            logger.error(
-                'Fail to create summary skill table for OFS: %s and '
-                'variable: %s',
+            # No model control file means none of the observation stations
+            # matched a model output location -- e.g. STOFS currents, where
+            # the stations/points product carries water-level (tide-gauge)
+            # stations but no ADCP velocity stations to match the CO-OPS
+            # current meters against. This is a data-coverage outcome, not
+            # a processing failure, so report it as a warning rather than
+            # an error.
+            logger.warning(
+                'No summary skill table for OFS %s variable %s: no model '
+                'output stations matched the observation stations.',
                 p.ofs,
                 variable,
             )

--- a/tests/chs_datum_skip_test.py
+++ b/tests/chs_datum_skip_test.py
@@ -1,0 +1,58 @@
+"""Regression test for CHS water-level datum handling in write_obs_ctlfile.
+
+CHS observed water level is labeled with the Great-Lakes datum 'IGLD'. For a
+non-Great-Lakes OFS (e.g. stofs_3d_atl) requesting a tidal datum such as MLLW
+there is no conversion path, and the underlying coastalmodeling_vdatum package
+raises a cryptic ``UnboundLocalError`` ('h_g'). ``_process_chs_station`` must
+skip such stations cleanly with an informative warning instead of letting the
+crash surface as a misleading "data not found" message.
+"""
+from __future__ import annotations
+
+import importlib
+import logging
+from datetime import datetime
+from unittest import mock
+
+import pandas as pd
+
+# The package re-exports the ``write_obs_ctlfile`` *function*, shadowing the
+# submodule of the same name, so resolve the module via its dotted path.
+write_obs_ctlfile = importlib.import_module(
+    'ofs_skill.obs_retrieval.write_obs_ctlfile')
+
+
+def _fake_chs_wl_dataset():
+    # data_station['Datum'][1] is read by _process_chs_station, so index 1
+    # must carry the datum label CHS assigns to all water-level stations.
+    return pd.DataFrame({'Datum': ['IGLD', 'IGLD'], 'WL': [1.1, 1.2]})
+
+
+def test_chs_water_level_non_gl_skips_when_no_datum_path(caplog):
+    """Non-GL OFS requesting MLLW: station is skipped, not crashed."""
+    logger = logging.getLogger('chs_datum_skip_test')
+    with mock.patch.object(
+            write_obs_ctlfile, 'retrieve_chs_station',
+            return_value=_fake_chs_wl_dataset()):
+        with caplog.at_level(logging.WARNING):
+            result = write_obs_ctlfile._process_chs_station(
+                id_number='5cebf1e0',
+                name='Some Atlantic Canada Station',
+                x_value=-65.0,
+                y_value=45.0,
+                start_date=datetime(2026, 5, 26),
+                end_date=datetime(2026, 6, 2),
+                variable='water_level',
+                name_var='wl',
+                datum='MLLW',
+                ofs='stofs_3d_atl',
+                logger=logger,
+            )
+
+    # Skipped cleanly -> empty entry list, no exception propagated.
+    assert result == []
+    # The warning explains the real reason (no conversion path), not the
+    # misleading h_g/'data not found' message.
+    msgs = [r.message for r in caplog.records]
+    assert any('no datum conversion path' in m for m in msgs), msgs
+    assert not any('h_g' in m for m in msgs), msgs

--- a/tests/vdatum_resilient_test.py
+++ b/tests/vdatum_resilient_test.py
@@ -167,6 +167,55 @@ def test_prime_failure_releases_lock(monkeypatch, caplog):
         [r.message for r in caplog.records]
 
 
+def test_convert_rejects_unknown_datum_without_calling_vdatum(monkeypatch):
+    """An out-of-vocabulary datum (e.g. CHS 'igld', missing the '85') must
+    raise a clear ValueError up front, never reaching vdatum.convert where
+    the dependency's precedence bug would raise a cryptic UnboundLocalError."""
+    monkeypatch.setattr(vdatum_resilient, '_PRIMED_PAIRS', set())
+    with mock.patch.object(
+            vdatum_resilient.vdatum, 'convert') as mock_convert:
+        with pytest.raises(ValueError, match='Unsupported vertical datum'):
+            vdatum_resilient.convert('igld', 'mllw', 45.0, -65.0, 10.0,
+                                     station_id='5cebf1e0')
+    mock_convert.assert_not_called()
+
+
+def test_convert_raises_valueerror_for_inwocab_pair_with_no_path(monkeypatch):
+    """An in-vocabulary pair with no conversion pipeline (Great-Lakes datum
+    to a tidal datum) makes the dependency raise UnboundLocalError. The
+    wrapper must translate that into a clean ValueError without retrying."""
+    monkeypatch.setattr(vdatum_resilient, '_PRIMED_PAIRS',
+                        {('igld85', 'mllw')})
+    sleeps = []
+    monkeypatch.setattr(vdatum_resilient, '_sleep_with_backoff',
+                        lambda attempt: sleeps.append(attempt))
+    with mock.patch.object(
+            vdatum_resilient.vdatum, 'convert',
+            side_effect=UnboundLocalError(
+                "cannot access local variable 'h_g'")) as mock_convert:
+        with pytest.raises(ValueError, match='No vertical datum conversion'):
+            vdatum_resilient.convert('igld85', 'mllw', 45.0, -65.0, 10.0)
+    # Deterministic failure -> exactly one attempt, no backoff, no offline.
+    assert mock_convert.call_count == 1
+    assert sleeps == []
+
+
+def test_prime_swallows_unbound_local_error(monkeypatch):
+    """If the prime call hits the dependency's UnboundLocalError, the pair is
+    still marked primed (lock released) and the real call surfaces the clean
+    ValueError rather than the raw UnboundLocalError leaking from prime."""
+    monkeypatch.setattr(vdatum_resilient, '_PRIMED_PAIRS', set())
+    monkeypatch.setattr(vdatum_resilient, '_sleep_with_backoff',
+                        lambda attempt: None)
+    with mock.patch.object(
+            vdatum_resilient.vdatum, 'convert',
+            side_effect=UnboundLocalError(
+                "cannot access local variable 'h_g'")):
+        with pytest.raises(ValueError, match='No vertical datum conversion'):
+            vdatum_resilient.convert('igld85', 'mllw', 45.0, -65.0, 10.0)
+    assert ('igld85', 'mllw') in vdatum_resilient._PRIMED_PAIRS
+
+
 def test_module_import_enables_pyproj_network():
     """Importing the module should leave pyproj network globally enabled so
     that worker threads spawned later inherit network=True."""


### PR DESCRIPTION
### Description of Changes

Fixes two unrelated issues that both surfaced during a `stofs_3d_atl` stations skill
run: a CHS water-level datum-conversion crash that silently dropped every Canadian
Atlantic station, and a misleading ERROR in the STOFS currents skill summary.

**CHS water-level datum-conversion crash (`UnboundLocalError: h_g`).**
CHS observed water level is labeled with the Great-Lakes datum `IGLD`
(`retrieve_chs_station.py` hardcodes `data_all['Datum'] = 'IGLD'`). For a
non-Great-Lakes OFS requesting a tidal datum — e.g. `stofs_3d_atl` → `MLLW` — there is
no IGLD→tidal conversion path. The underlying `coastalmodeling_vdatum.vdatum.convert`
has an operator-precedence bug in its own input guard
(`if vd_from and vd_to not in [...]`) that never actually validates `vd_from`, so
instead of a clean error it falls through, leaves its grid variables unbound, and
raises a cryptic `UnboundLocalError: cannot access local variable 'h_g'`. That
propagated up as a misleading "CHS ... data not found" message and silently dropped
~40 Canadian Atlantic water-level stations from the run.

Fix:
- `vdatum_resilient.convert` now validates both datums against the supported
  vocabulary up front and raises a clear `ValueError` before ever calling the
  dependency. For an in-vocabulary pair that nonetheless has no conversion pipeline
  (a Great-Lakes datum to a tidal datum), it catches the dependency's
  `UnboundLocalError` and translates it into the same clean `ValueError` — with no
  retry, since the failure is deterministic, not transient. The single-threaded grid
  "prime" path swallows the same error so it can't leak before the real call.
- `write_obs_ctlfile._process_chs_station` catches that `ValueError` on the non-GL
  water-level branch and skips the station with an honest warning that names the
  chart-datum limitation ("no datum conversion path from igld to mllw …") instead of
  letting the crash surface as a "data not found" message.

**STOFS currents skill reporting (spurious ERROR).**
For STOFS the obs→model match is by station-name substring (`indexing.py`). The
stations/points product carries water-level (tide-gauge) stations but no ADCP velocity
stations, so every CO-OPS current meter fails to match and no currents model control
file is written. `get_skill` logged this expected data-coverage outcome as an ERROR
("Fail to create summary skill table"), which reads as a pipeline failure in the log.

Fix: when no model output stations matched the observation stations, `get_skill` now
logs a WARNING with an accurate message ("no model output stations matched the
observation stations") rather than an ERROR. Genuine post-match failures still log as
errors.

Adds regression tests for the datum guards and the CHS skip path.

Labels: `bug`.

### Expected Outcome of Changes

- A `stofs_3d_atl` (or any non-Great-Lakes OFS) stations run that includes CHS
  observations no longer crashes on the IGLD water-level datum. The affected CHS
  stations are skipped cleanly with a single, accurate WARNING each, and the rest of
  the run proceeds. Previously these stations were silently dropped behind a
  misleading "data not found" message.
- The STOFS currents skill summary no longer emits a spurious ERROR when the points
  product has no ADCP velocity stations to match. The same data-coverage situation now
  reads as a WARNING, so logs stay clean and a real ERROR still means a real failure.
- No change to output file schemas, filenames, or counts. Great-Lakes OFS CHS handling
  is unchanged (the GL branch still relies on the IGLD label and the GL→tidal path).
- Output values for any conversion that *does* have a path are bit-for-bit unchanged —
  the wrapper only adds an up-front vocabulary guard and an error-translation; the
  success path is untouched.

### Developer Questions and Checklist

**Is this a high priority PR? If yes, why and is there a date by which it needs to be
merged?**
Medium. The CHS crash is a correctness bug — it silently drops every Canadian Atlantic
water-level station on any non-GL OFS run that pulls CHS data, so worth landing before
the next release. No hard deadline.

**Are there any changes needed to how the code should be run for operational runs?
(Commands, flags, job timings, etc.)**
No. No flag, config, or command changes.

**Does this update need to be deployed for operational runs?**
Recommended once merged — without it, CHS stations are silently lost on non-GL runs and
the STOFS currents log carries a misleading ERROR.

**Does this update require front end/web app changes? (If yes, provide documentation to
Min)**
No.

**Does this impact code development work on adding SCHISM?**
No. STOFS (SCHISM) extraction paths are unchanged; the only STOFS-touching change is the
log-level downgrade in `get_skill`.

**Does this impact code development work on adding ADCIRC?**
No.

**Does this impact the expected number of output files for integration tests (i.e.,
will the integration test fail even though code changes result in desired change in
outputs?)**
No. Output filenames, schemas, and per-station file counts are unchanged. A non-GL run
that previously crashed (or dropped CHS stations) will now produce *more* complete
output for the non-CHS stations, but no file-count baseline that was passing before
should change.

- [x] Developer's name is removed throughout the code
- [x] Did you add relevant labels to the PR? — `bug`
- [x] Have you run pylint and is the code at an acceptable pylint score (>8)? —
      **8.96/10** on the three touched source files (`vdatum_resilient.py`,
      `write_obs_ctlfile.py`, `get_skill.py`)
- [x] Jobs contain the appropriate file checking and handle errors for any missing
      data — yes; the CHS skip path returns an empty entry list and logs a WARNING
      rather than raising, and the datum wrapper distinguishes deterministic
      no-path failures (one attempt, ValueError) from transient PROJ failures (retry +
      offline fallback).
- [x] Is log free of critical ERRORs or WARNINGs? — yes; the spurious STOFS currents
      ERROR is gone, and the CHS skips are intentional, accurate WARNINGs (one per
      skipped station) that explain the chart-datum limitation.

### Testing Instructions

**Setup**

```bash
git fetch origin
git checkout fix-chs-datum-and-stofs-currents
eval "$(~/miniforge3/bin/conda shell.bash hook)" && conda activate ofs_dps
pip install -e .
```

**Unit / regression tests**

```bash
python -m pytest tests/vdatum_resilient_test.py tests/chs_datum_skip_test.py --no-cov -q
```

Expected: **12 passed**. New tests added in this PR:

- `tests/vdatum_resilient_test.py`
  - `test_convert_rejects_unknown_datum_without_calling_vdatum` — an out-of-vocabulary
    datum (e.g. CHS `igld`, missing the `85`) raises `ValueError` up front and never
    reaches `vdatum.convert`.
  - `test_convert_raises_valueerror_for_invocab_pair_with_no_path` — an in-vocabulary
    pair with no pipeline (`igld85`→`mllw`) translates the dependency's
    `UnboundLocalError` into a clean `ValueError` with exactly one attempt and no
    backoff.
  - `test_prime_swallows_unbound_local_error` — the prime path marks the pair primed
    (releases the lock) and the real call surfaces the clean `ValueError`, not the raw
    `UnboundLocalError`.
- `tests/chs_datum_skip_test.py`
  - `test_chs_water_level_non_gl_skips_when_no_datum_path` — a non-GL OFS requesting
    MLLW for an IGLD-labeled CHS station returns `[]` and logs a "no datum conversion
    path" WARNING, never an `h_g` crash.

Full suite (against the `41-add-secofs` base):

```bash
python -m pytest tests/ --no-cov -q
```

Result: **573 passed, 1 failed**. The single failure —
`tests/indexing_ragged_ctl_test.py::test_indexer_call_sites_use_positional_indexing` —
is **pre-existing on the `41-add-secofs` base branch** (forbidden positional pattern at
`indexing.py:682`) and is unrelated to this PR, which does not touch `indexing.py`. It
should be resolved on the SECOFS branch (PR #159), not here.

**End-to-end (the run that surfaced both bugs)**

```bash
python ./bin/visualization/create_1dplot.py -o stofs_3d_atl -p ./ \
  -s 2026-05-31T00:00:00Z -e 2026-06-02T23:00:00Z \
  -d MLLW -ws nowcast -t stations \
  -vs water_level,currents,water_temperature -so co-ops,chs
```

What to look for in the log:

1. **No** `UnboundLocalError` / `h_g` traceback anywhere.
2. CHS stations that can't be converted are skipped with one WARNING each of the form
   `... no datum conversion path from igld to mllw ...` (≈20 in the verified run), not a
   "data not found" message.
3. The currents summary logs a WARNING — `... no model output stations matched the
   observation stations` — **not** an ERROR `Fail to create summary skill table`.
4. The run completes and produces water-level output for the stations that do convert.

Note on local environment: STOFS `-t stations` S3 streaming currently also needs
`netcdf_dir=` (empty) in `conf/ofs_dps.conf` to build the correct NODD URL, and the
points-file `x`/`y` vs `SCHISM_hgrid_node_x` mismatch is a separate pre-existing blocker
tracked outside this PR — neither is introduced or fixed here.

### Reminder checklist for PR reviewer

- [x] Run PEP8 / pylint compliance on the touched files (`vdatum_resilient.py`,
      `write_obs_ctlfile.py`, `get_skill.py`) — should score > 8.
- [x] Check that documentation in the script is sufficient — the `convert` docstring
      documents the new `ValueError` behavior.
- [x] Validate output values — confirm that a datum pair which *does* have a path
      (e.g. `navd88`→`mllw`) still returns the same offset as before (the guard is
      additive); and that an IGLD CHS station on a non-GL OFS is skipped, while
      Great-Lakes OFS CHS handling is unchanged.
- [x] Test code on Windows and Linux. Verified on Linux (WSL2); please confirm on
      Windows that the CHS skip path and the STOFS currents WARNING behave identically.
- [x] **Test for all 'cast' options: forecast_a, forecast_b, and nowcast** — the log
      changes are cast-independent; nowcast was the verified path.
- [x] When approving or commenting, add the call you used to the PR comments so it can
      be replicated.

