### PR TITLE
Detect netCDF format for engine selection, unlock parallel extraction, and validate model files before open

### DIFF
--- a/conf/ofs_dps.conf.example
+++ b/conf/ofs_dps.conf.example
@@ -161,6 +161,15 @@ plot_workers=auto
 # a single pipeline stage. Only enable if you have sufficient memory.
 parallel_variables=False
 
+# Max concurrent model-data extractions (dask.compute calls) across the
+# variable threads when parallel_variables=True. Only takes effect when
+# the model files are NetCDF-4/HDF5 (read via the thread-safe h5netcdf
+# engine); NetCDF-3 files are always extracted one variable at a time.
+# Each slot holds one variable's data in memory during extraction
+# (roughly 4-5 GB for a multi-month run of a large OFS), so raise this
+# only if you have RAM to spare. 1 = fully serialized extraction.
+parallel_extract_slots=2
+
 # Workflow-level parallelism: run obs download + model extraction concurrently
 parallel_workflow=False
 
@@ -203,3 +212,17 @@ use_s3_fallback=True
 # If True, set 'filename_path' to the path to your text file, including the filename.
 use_custom_filenames=False
 filename_path=path/to/filename.txt
+
+# NetCDF engine selection for reading model files. Three modes:
+#   auto     = detect each batch's on-disk format from its magic bytes
+#              (recommended default). NetCDF-4/HDF5 files are read with
+#              the thread-safe h5netcdf engine, which allows concurrent
+#              variable extraction (see parallel_extract_slots);
+#              NetCDF-3 files (e.g. NECOFS, stofs_2d_glo stations) are
+#              read with the netcdf4 or scipy engine and extracted
+#              serially.
+#   netcdf4  = force the netcdf4 engine for every open (reads all
+#              formats, fully serialized extraction)
+#   h5netcdf = force the h5netcdf engine (NetCDF-4/HDF5 files only;
+#              fails on NetCDF-3 files)
+engine_strategy=auto

--- a/src/ofs_skill/model_processing/get_node_ofs.py
+++ b/src/ofs_skill/model_processing/get_node_ofs.py
@@ -39,16 +39,47 @@ from ofs_skill.obs_retrieval.utils import get_parallel_config
 
 logger = logging.getLogger(__name__)
 
-# Serializes dask.compute() inside _batch_extract across the variable
-# threads dispatched from get_node_ofs. NECOFS uses engine='netcdf4'
-# which isn't thread-safe under concurrent reads; in addition, four
-# threads each materializing a different time-varying var concurrently
-# spikes memory to 4× the per-var peak (~4-5 GB observed on real runs,
-# triggering Windows paging at 94% RAM). The lock caps memory at one
-# variable at a time without breaking the rest of the parallelism (the
-# indexing phase, formatting, .prd writing, and plotting still
-# parallelize across variable threads).
-_BATCH_EXTRACT_LOCK = threading.Lock()
+# Serializes / bounds dask.compute() inside _batch_extract across the
+# variable threads dispatched from get_node_ofs. Two independent reasons
+# to limit concurrency:
+#   1. Thread safety: engine='netcdf4' (libnetCDF/HDF5 C bindings) and
+#      engine='scipy' hold process-global state and are not safe under
+#      concurrent reads → concurrency must be 1 for those engines.
+#      engine='h5netcdf' releases the GIL and supports concurrent reads.
+#   2. Memory: N threads each materializing a different time-varying var
+#      concurrently spikes memory to N× the per-var peak (~4-5 GB per
+#      var observed on real NECOFS runs, triggering Windows paging at
+#      94% RAM) → even under h5netcdf, concurrency is capped by the
+#      parallel_extract_slots config setting (default 2).
+# The guard only covers the dask.compute call; the indexing phase,
+# formatting, .prd writing, and plotting still parallelize freely
+# across variable threads.
+_EXTRACT_GUARDS: dict[int, threading.BoundedSemaphore] = {}
+_EXTRACT_GUARDS_LOCK = threading.Lock()
+
+
+def _extract_guard(engine=None, slots=None):
+    """Return the semaphore bounding concurrent dask.compute calls.
+
+    ``engine`` is the xarray engine the model dataset was opened with
+    (recorded on ``prop.netcdf_engine`` by ``intake_model``). Anything
+    other than ``'h5netcdf'`` — including ``None``, when the engine is
+    unknown — serializes fully (1 slot). h5netcdf gets ``slots``
+    concurrent computes (memory cap, default 2).
+    """
+    if engine != 'h5netcdf':
+        n_slots = 1
+    else:
+        try:
+            n_slots = max(1, int(slots))
+        except (TypeError, ValueError):
+            n_slots = 2
+    with _EXTRACT_GUARDS_LOCK:
+        guard = _EXTRACT_GUARDS.get(n_slots)
+        if guard is None:
+            guard = _EXTRACT_GUARDS[n_slots] = threading.BoundedSemaphore(
+                n_slots)
+    return guard
 
 
 # Per-variable physical bounds used to catch blended SCHISM dry/wet
@@ -379,7 +410,8 @@ _BATCH_EXTRACT_TIME_CHUNK = 1000
 
 
 def _batch_extract(model, var_name, idx_list, dep_list, idx_first=False,
-                   logger=None, time_chunk=_BATCH_EXTRACT_TIME_CHUNK):
+                   logger=None, time_chunk=_BATCH_EXTRACT_TIME_CHUNK,
+                   engine=None, extract_slots=None):
     """Extract all stations for a variable via batched dask.compute().
 
     The time axis is split into windows of ``time_chunk`` steps. Each
@@ -444,12 +476,13 @@ def _batch_extract(model, var_name, idx_list, dep_list, idx_first=False,
         return np.stack([np.array(s) for s in lazy], axis=1)
 
     # Dask-backed path: window the time axis.
+    guard = _extract_guard(engine, extract_slots)
     chunk = max(1, int(time_chunk))
     if n_time <= chunk:
         # Single-window fast path: behaviour matches the pre-chunking
         # implementation exactly when the dataset fits in one window.
         lazy = _select(probe_da, 0, n_time)
-        with _BATCH_EXTRACT_LOCK:
+        with guard:
             computed = dask.compute(*[s.data for s in lazy])
         return np.stack(computed, axis=1)
 
@@ -466,10 +499,10 @@ def _batch_extract(model, var_name, idx_list, dep_list, idx_first=False,
         t0 = ci * chunk
         t1 = min(n_time, t0 + chunk)
         lazy = _select(probe_da, t0, t1)
-        # Serialize the dask.compute across variable threads. NetCDF4
-        # isn't thread-safe under concurrent reads and 4 simultaneous
-        # computes would quadruple peak memory.
-        with _BATCH_EXTRACT_LOCK:
+        # Bound the dask.compute across variable threads: fully serial
+        # for thread-unsafe engines, parallel_extract_slots concurrent
+        # computes under h5netcdf (memory cap). See _extract_guard.
+        with guard:
             computed = dask.compute(*[s.data for s in lazy])
         parts.append(np.stack(computed, axis=1))
         if logger is not None:
@@ -487,7 +520,8 @@ def _batch_extract(model, var_name, idx_list, dep_list, idx_first=False,
 
 
 def _batch_extract_multi(model, var_names, idx_list, dep_list, idx_first=False,
-                         logger=None, time_chunk=_BATCH_EXTRACT_TIME_CHUNK):
+                         logger=None, time_chunk=_BATCH_EXTRACT_TIME_CHUNK,
+                         engine=None, extract_slots=None):
     """Extract multiple variables that share backing files in one fused compute.
 
     When two variables (e.g. ``u`` and ``v``) come from the same files,
@@ -499,7 +533,7 @@ def _batch_extract_multi(model, var_names, idx_list, dep_list, idx_first=False,
 
     Same chunking and locking discipline as :func:`_batch_extract`: split
     the time axis into ``time_chunk``-step windows, compute each window
-    under ``_BATCH_EXTRACT_LOCK``, ``gc.collect`` between, concatenate.
+    under the extract guard, ``gc.collect`` between, concatenate.
 
     Parameters
     ----------
@@ -560,12 +594,13 @@ def _batch_extract_multi(model, var_names, idx_list, dep_list, idx_first=False,
             results.append(np.stack([np.array(s) for s in lazy], axis=1))
         return results
 
+    guard = _extract_guard(engine, extract_slots)
     chunk = max(1, int(time_chunk))
     if n_time <= chunk:
         # Single-window fast path: one fused compute over all vars + stations.
         per_var_lazy = [_select_one(model[v], 0, n_time) for v in var_names]
         flat = [s.data for lst in per_var_lazy for s in lst]
-        with _BATCH_EXTRACT_LOCK:
+        with guard:
             computed = dask.compute(*flat)
         results = []
         for vi, _ in enumerate(var_names):
@@ -587,7 +622,7 @@ def _batch_extract_multi(model, var_names, idx_list, dep_list, idx_first=False,
         t1 = min(n_time, t0 + chunk)
         per_var_lazy = [_select_one(model[v], t0, t1) for v in var_names]
         flat = [s.data for lst in per_var_lazy for s in lst]
-        with _BATCH_EXTRACT_LOCK:
+        with guard:
             computed = dask.compute(*flat)
         for vi in range(len(var_names)):
             start = vi * n
@@ -603,6 +638,20 @@ def _batch_extract_multi(model, var_names, idx_list, dep_list, idx_first=False,
     return [np.concatenate(parts, axis=0) for parts in parts_per_var]
 
 
+def _extract_concurrency_kwargs(prop):
+    """Extract-guard kwargs for _batch_extract(_multi) from prop.
+
+    ``netcdf_engine`` is recorded by ``intake_model`` at open time;
+    ``extract_slots`` is set from the parallelization config before the
+    variable threads are dispatched. Both default to the safe fully
+    serialized guard when absent (e.g. pre-loaded model datasets).
+    """
+    return {
+        'engine': getattr(prop, 'netcdf_engine', None),
+        'extract_slots': getattr(prop, 'extract_slots', None),
+    }
+
+
 def _precompute_current_data(prop, model, ofs_ctlfile, logger):
     """Batch-extract current (u/v) station data in a single Dask compute call.
 
@@ -615,24 +664,26 @@ def _precompute_current_data(prop, model, ofs_ctlfile, logger):
     n_stations = len(ofs_ctlfile[1])
     indices = [int(ofs_ctlfile[1][i]) for i in range(n_stations)]
     depths = [int(ofs_ctlfile[2][i]) for i in range(n_stations)]
+    extract_kwargs = _extract_concurrency_kwargs(prop)
 
     if prop.model_source == 'fvcom':
         u_data, v_data = _batch_extract_multi(
             model, ['u', 'v'], indices, depths,
-            idx_first=False, logger=logger)
+            idx_first=False, logger=logger, **extract_kwargs)
     elif prop.model_source == 'roms':
         u_data, v_data = _batch_extract_multi(
             model, ['u_east', 'v_north'], indices, depths,
-            idx_first=True, logger=logger)
+            idx_first=True, logger=logger, **extract_kwargs)
     elif prop.model_source == 'schism':
         if 'stofs' not in prop.ofs:
             u_data, v_data = _batch_extract_multi(
                 model, ['u', 'v'], indices, depths,
-                idx_first=False, logger=logger)
+                idx_first=False, logger=logger, **extract_kwargs)
         else:
             # STOFS-3D-Atl 2-D currents (no depth dim).
             u_data, v_data = _batch_extract_multi(
-                model, ['u', 'v'], indices, None, logger=logger)
+                model, ['u', 'v'], indices, None, logger=logger,
+                **extract_kwargs)
 
     return {'u_data': u_data, 'v_data': v_data}
 
@@ -660,35 +711,39 @@ def _precompute_scalar_data(prop, model, ofs_ctlfile, model_var, logger):
     # back to slow per-station extraction. Detect dimensionality up front
     # so the batch path stays on for water level too.
     is_2d = model[actual_var].ndim < 3
+    extract_kwargs = _extract_concurrency_kwargs(prop)
 
     if prop.model_source == 'fvcom':
         if is_2d:
             scalar_data = _batch_extract(model, actual_var, indices, None,
-                                         logger=logger)
+                                         logger=logger, **extract_kwargs)
         else:
             scalar_data = _batch_extract(model, actual_var, indices, depths,
-                                         idx_first=False, logger=logger)
+                                         idx_first=False, logger=logger,
+                                         **extract_kwargs)
     elif prop.model_source == 'roms':
         if is_2d:
             scalar_data = _batch_extract(model, actual_var, indices, None,
-                                         logger=logger)
+                                         logger=logger, **extract_kwargs)
         else:
             scalar_data = _batch_extract(model, actual_var, indices, depths,
-                                         idx_first=True, logger=logger)
+                                         idx_first=True, logger=logger,
+                                         **extract_kwargs)
     elif prop.model_source == 'schism':
         if 'stofs' in prop.ofs and model_var in ('temp', 'temperature'):
             scalar_data = _batch_extract(model, 'temperature', indices, None,
-                                         logger=logger)
+                                         logger=logger, **extract_kwargs)
         elif is_2d:
             scalar_data = _batch_extract(model, actual_var, indices, None,
-                                         logger=logger)
+                                         logger=logger, **extract_kwargs)
         else:
             try:
                 scalar_data = _batch_extract(model, actual_var, indices, depths,
-                                             idx_first=False, logger=logger)
+                                             idx_first=False, logger=logger,
+                                             **extract_kwargs)
             except IndexError:
                 scalar_data = _batch_extract(model, actual_var, indices, None,
-                                             logger=logger)
+                                             logger=logger, **extract_kwargs)
 
     return {'scalar_data': scalar_data}
 
@@ -1907,7 +1962,16 @@ def get_node_ofs(prop, logger, model_dataset=None):
         logger,
         config_file=getattr(prop, 'config_file', None),
     )
+    # Concurrency cap for dask.compute inside _batch_extract, carried on
+    # prop so the per-variable deepcopies inherit it (see _extract_guard).
+    prop.extract_slots = parallel_cfg['parallel_extract_slots']
     if parallel_cfg['parallel_variables'] and len(prop.var_list) > 1:
+        logger.info(
+            "Variable threads will extract with engine '%s' "
+            '(%s concurrent dask.compute slot(s) when h5netcdf)',
+            getattr(prop, 'netcdf_engine', None) or 'unknown -> serialized',
+            prop.extract_slots,
+        )
         _preload_static_coords(model, prop.model_source, logger)
         logger.info('Processing %d variables in parallel', len(prop.var_list))
         with ThreadPoolExecutor(max_workers=min(len(prop.var_list), 4)) as executor:

--- a/src/ofs_skill/model_processing/intake_scisa.py
+++ b/src/ofs_skill/model_processing/intake_scisa.py
@@ -51,6 +51,7 @@ import numpy as np
 import xarray as xr
 
 from ofs_skill.model_processing.get_fcst_cycle import get_fcst_hours
+from ofs_skill.model_processing.netcdf_engine import resolve_engine
 
 
 def _extract_filename_from_encoding(ds):
@@ -228,20 +229,15 @@ def intake_model(file_list: list[str], prop: Any, logger: Logger) -> xr.Dataset:
         ]
         time_name = 'time'
 
-    # Custom NECOFS free-run station files are NetCDF3 and need the scipy
-    # engine. They are identified by this filename marker; if other NetCDF3
-    # custom files are added, extend this list. The intake_model call below
-    # also falls back with a clear error if the wrong engine is selected.
-    _netcdf3_filename_markers = ('2017_free_run_station',)
-    if prop.ofs in ['stofs_2d_glo'] or any(
-            marker in f
-            for f in file_list
-            for marker in _netcdf3_filename_markers):
-        engine = 'scipy'
-    elif prop.ofs in ['necofs', 'loofs2', 'secofs']:
-        engine = 'netcdf4'
-    else:
-        engine = 'h5netcdf'
+    # Choose the engine by detecting the batch's on-disk format (magic
+    # bytes) rather than a hardcoded per-OFS list — formats differ per
+    # OFS, per file type (stofs_2d_glo stations are NetCDF-3 while its
+    # fields are HDF5), and per source archive. See netcdf_engine.py;
+    # the [settings] engine_strategy config key can force an engine.
+    engine = resolve_engine(file_list, prop, logger)
+    # Record the engine so downstream extraction (get_node_ofs) can relax
+    # the thread-serialization guard when the engine is thread-safe.
+    prop.netcdf_engine = engine
 
     urlpaths = file_list
     if len(urlpaths) == 0:
@@ -378,83 +374,100 @@ def intake_model(file_list: list[str], prop: Any, logger: Logger) -> xr.Dataset:
     ]
     preprocess_fn = make_preprocess_with_filename(raw_paths)
 
-    if dim_compat:  # This will only be FALSE for stations files when
-        # station dimensions do not match! Always True for fields
-        # files
-        # If station dimensions are all the same/compatible, send in all file
-        # names (urlpaths) at one time and let xarray/intake automagically
-        # combine datasets
-        if prop.model_source == 'schism':
-            if  prop.ofsfiletype == 'fields':
-                source = intake.open_netcdf(
-                    urlpath=urlpaths,
-                    xarray_kwargs={
-                        'combine': 'by_coords',  # <-- align files by coordinates
-                        'engine': engine,
-                        'preprocess': preprocess_fn,
-                        'drop_variables': drop_variables,
-                        'chunks': {'time': 1},
-                    },
-                    **s3_storage_opts,
-                )
+    def _open_dataset(open_engine):
+        if dim_compat:  # This will only be FALSE for stations files when
+            # station dimensions do not match! Always True for fields
+            # files
+            # If station dimensions are all the same/compatible, send in
+            # all file names (urlpaths) at one time and let xarray/intake
+            # automagically combine datasets
+            if prop.model_source == 'schism':
+                if prop.ofsfiletype == 'fields':
+                    source = intake.open_netcdf(
+                        urlpath=urlpaths,
+                        xarray_kwargs={
+                            'combine': 'by_coords',  # <-- align files by coordinates
+                            'engine': open_engine,
+                            'preprocess': preprocess_fn,
+                            'drop_variables': drop_variables,
+                            'chunks': {'time': 1},
+                        },
+                        **s3_storage_opts,
+                    )
+                else:
+                    source = intake.open_netcdf(
+                        urlpath=urlpaths,
+                        xarray_kwargs={
+                            'combine': 'nested',
+                            'engine': open_engine,
+                            'preprocess': preprocess_fn,
+                            'concat_dim': time_name,
+                            'decode_times': True,
+                            'chunks': 'auto',  # Enables lazy loading with Dask
+                        },
+                        **s3_storage_opts,
+                    )
+
             else:
+                # For fields files, chunk by single time step to bound memory
+                # for monthly/yearly runs with hundreds of files. Stations
+                # files have small spatial dims, so auto-chunking is safe.
+                chunk_spec: Any
+                if prop.ofsfiletype == 'fields':
+                    chunk_spec = {time_name: 1}
+                else:
+                    chunk_spec = 'auto'
+                # ``data_vars='minimal'`` stops xarray from replicating static
+                # mesh vars (lon, lat, lonc, latc, h, siglay, ...) along the
+                # concat time dim during multi-file open. On long windows
+                # this saves the per-whichcast cost of materializing static
+                # coords across hundreds of backing files and frees the
+                # downstream resample helper from having to walk those vars.
+                # ``indexing.py`` was previously coupled to the legacy
+                # ``(time, station)`` replicated shape via ad-hoc ``[0]`` /
+                # ``[1]`` time slicing; the ``_static_coord_1d`` helper in
+                # indexing.py now normalises both shapes so the call sites
+                # are happy under either mode.
                 source = intake.open_netcdf(
                     urlpath=urlpaths,
                     xarray_kwargs={
                         'combine': 'nested',
-                        'engine': engine,
+                        'engine': open_engine,
                         'preprocess': preprocess_fn,
                         'concat_dim': time_name,
+                        'data_vars': 'minimal',
                         'decode_times': True,
-                        'chunks': 'auto',  # Enables lazy loading with Dask
+                        'drop_variables': drop_variables,
+                        'chunks': chunk_spec,
                     },
                     **s3_storage_opts,
                 )
-
-        else:
-            # For fields files, chunk by single time step to bound memory
-            # for monthly/yearly runs with hundreds of files. Stations
-            # files have small spatial dims, so auto-chunking is safe.
-            chunk_spec: Any
-            if prop.ofsfiletype == 'fields':
-                chunk_spec = {time_name: 1}
-            else:
-                chunk_spec = 'auto'
-            # ``data_vars='minimal'`` stops xarray from replicating static
-            # mesh vars (lon, lat, lonc, latc, h, siglay, ...) along the
-            # concat time dim during multi-file open. On long windows
-            # this saves the per-whichcast cost of materializing static
-            # coords across hundreds of backing files and frees the
-            # downstream resample helper from having to walk those vars.
-            # ``indexing.py`` was previously coupled to the legacy
-            # ``(time, station)`` replicated shape via ad-hoc ``[0]`` /
-            # ``[1]`` time slicing; the ``_static_coord_1d`` helper in
-            # indexing.py now normalises both shapes so the call sites
-            # are happy under either mode.
-            source = intake.open_netcdf(
-                urlpath=urlpaths,
-                xarray_kwargs={
-                    'combine': 'nested',
-                    'engine': engine,
-                    'preprocess': preprocess_fn,
-                    'concat_dim': time_name,
-                    'data_vars': 'minimal',
-                    'decode_times': True,
-                    'drop_variables': drop_variables,
-                    'chunks': chunk_spec,
-                },
-                **s3_storage_opts,
-            )
-        # Read the dataset lazily
-        logger.info('No dimension changes needed, lazy loading catalog ...')
-        ds = source.to_dask()
-    else:
+            # Read the dataset lazily
+            logger.info('No dimension changes needed, lazy loading catalog ...')
+            return source.to_dask()
         logger.info('Station dimensions are inconsistent! Slicing stations...')
-        ds = remove_extra_stations(
-            engine,
+        return remove_extra_stations(
+            open_engine,
             urlpaths, dim_ref, drop_variables or [],
             time_name or '', logger,
         )
+
+    try:
+        ds = _open_dataset(engine)
+    except OSError as ex:
+        # h5netcdf refuses non-HDF5 files with "file signature not
+        # found". Formats are detected before opening, but a sampled
+        # batch can hide a stray NetCDF-3 file — degrade to the
+        # netcdf4-family engine, which reads every format.
+        if engine == 'h5netcdf' and 'signature not found' in str(ex):
+            engine = 'netcdf4'
+            prop.netcdf_engine = engine
+            logger.warning(
+                'h5netcdf could not open the batch (%s); retrying with '
+                "engine='netcdf4'", ex)
+            ds = _open_dataset(engine)
+        else:
+            raise
 
     # If ADCIRC, we need to subset times to the appropriate whichcast.
     # Note that this needs to be done before removal of duplicate times.

--- a/src/ofs_skill/model_processing/intake_scisa.py
+++ b/src/ofs_skill/model_processing/intake_scisa.py
@@ -241,7 +241,7 @@ def intake_model(file_list: list[str], prop: Any, logger: Logger) -> xr.Dataset:
     # up front (with warnings) instead of letting them crash the
     # multi-file open — files left behind by an interrupted forecast
     # were failing whole multi-month runs (issue #194).
-    file_list, dropped_files = validate_model_files(
+    file_list, dropped_files, file_dims = validate_model_files(
         file_list, engine, time_name, prop.ofsfiletype, logger)
     if dropped_files:
         # Corrupt files sniff as 'unknown' and can pull the whole batch
@@ -272,14 +272,31 @@ def intake_model(file_list: list[str], prop: Any, logger: Logger) -> xr.Dataset:
     dim_ref: Any = None
 
     if prop.ofsfiletype == 'stations':
-        try:
-            dim_compat, dim_ref = get_station_dim(
-                engine, urlpaths, drop_variables or [], logger)
-        except Exception as ex:
-            logger.warning('Could not check number of stations before '
-                           'combining netcdfs in intake! Error: %s. '
-                           'Continuing...',
-                           ex)
+        # The validation pass already probed every local file's
+        # dimensions — reuse them instead of re-opening all files
+        # (get_station_dim was a second multi-minute pass over slow
+        # archive storage). Fall back to get_station_dim whenever any
+        # file wasn't probed (remote URLs) or lacks a station dim.
+        station_dims = [
+            file_dims[f]['station'] for f in urlpaths
+            if f in file_dims and 'station' in file_dims[f]
+        ]
+        if len(station_dims) == len(urlpaths):
+            if np.nanmax(np.diff(station_dims)) != 0:
+                dim_compat = False
+                dim_ref = int(np.argmin(station_dims))
+            logger.info(
+                'Station dimension check reused validation probes for '
+                '%d files (compatible=%s)', len(urlpaths), dim_compat)
+        else:
+            try:
+                dim_compat, dim_ref = get_station_dim(
+                    engine, urlpaths, drop_variables or [], logger)
+            except Exception as ex:
+                logger.warning('Could not check number of stations before '
+                               'combining netcdfs in intake! Error: %s. '
+                               'Continuing...',
+                               ex)
     # Build storage_options for S3 streaming when remote files are present.
     # Only use S3-specific options (anon, block_size) when URLs use s3://
     # protocol. For https:// URLs, use simpler HTTP-compatible options.

--- a/src/ofs_skill/model_processing/intake_scisa.py
+++ b/src/ofs_skill/model_processing/intake_scisa.py
@@ -485,6 +485,17 @@ def intake_model(file_list: list[str], prop: Any, logger: Logger) -> xr.Dataset:
 
     try:
         ds = _open_dataset(engine)
+    except xr.MergeError as ex:
+        logger.error(
+            'Model files could not be combined: %s. Static metadata '
+            '(station coordinates/names/sigma levels) differs between '
+            'files in the batch even though their dimensions match — '
+            'the assessment window likely spans a model configuration '
+            'change. Stations batches with a clear majority drop the '
+            'minority files automatically during validation; otherwise '
+            'split the assessment window at the configuration-change '
+            'date.', ex)
+        raise
     except OSError as ex:
         # h5netcdf refuses non-HDF5 files with "file signature not
         # found". Formats are detected before opening, but a sampled

--- a/src/ofs_skill/model_processing/intake_scisa.py
+++ b/src/ofs_skill/model_processing/intake_scisa.py
@@ -51,7 +51,10 @@ import numpy as np
 import xarray as xr
 
 from ofs_skill.model_processing.get_fcst_cycle import get_fcst_hours
-from ofs_skill.model_processing.model_file_validation import validate_model_files
+from ofs_skill.model_processing.model_file_validation import (
+    scrub_cached_copies,
+    validate_model_files,
+)
 from ofs_skill.model_processing.netcdf_engine import resolve_engine
 
 
@@ -333,6 +336,13 @@ def intake_model(file_list: list[str], prop: Any, logger: Logger) -> xr.Dataset:
                 # simplecache: cache whole files (stations files are small,
                 # typically 1-10 MB each)
                 try:
+                    # A run interrupted mid-download leaves a partial
+                    # file in the cache that fsspec trusts as-is on the
+                    # next run, crashing the open with misleading
+                    # errors (issues #176/#193). Probe existing cached
+                    # copies and delete bad ones so they re-download.
+                    scrub_cached_copies(
+                        urlpaths, cache_dir, time_name, logger)
                     cached_urlpaths = [
                         f'simplecache::{url}' for url in urlpaths
                     ]
@@ -370,6 +380,11 @@ def intake_model(file_list: list[str], prop: Any, logger: Logger) -> xr.Dataset:
                     'Mixed file list: downloading %d remote files to '
                     'local cache (%d already local)', remote_n, local_n,
                 )
+                # Delete any partial cached copies left by an
+                # interrupted run before trusting them (issues
+                # #176/#193), and download to a temp name so a kill
+                # mid-download can't leave a partial file behind.
+                scrub_cached_copies(urlpaths, cache_dir, time_name, logger)
                 resolved = []
                 for f in urlpaths:
                     if isinstance(f, str) and f.startswith('http'):
@@ -377,7 +392,9 @@ def intake_model(file_list: list[str], prop: Any, logger: Logger) -> xr.Dataset:
                             cache_dir, os.path.basename(f))
                         if not os.path.isfile(local_path):
                             try:
-                                urllib.request.urlretrieve(f, local_path)
+                                urllib.request.urlretrieve(
+                                    f, local_path + '.part')
+                                os.replace(local_path + '.part', local_path)
                             except Exception as dl_err:
                                 logger.warning(
                                     'Failed to cache %s: %s. '
@@ -485,6 +502,18 @@ def intake_model(file_list: list[str], prop: Any, logger: Logger) -> xr.Dataset:
 
     try:
         ds = _open_dataset(engine)
+    except ValueError as ex:
+        if 'buffer size must be a multiple of element size' in str(ex):
+            # Signature of a partially downloaded file in the fsspec
+            # cache (issues #176/#193). The pre-open cache scrub should
+            # remove these; if one slips through, say what happened
+            # instead of leaving a bare numpy error.
+            logger.error(
+                'Model open failed with "%s" — this is the signature '
+                'of a partially cached model file (a previous run was '
+                'likely interrupted mid-download). Clear the model '
+                'file cache (default: ~/.ofs_cache/s3/) and rerun.', ex)
+        raise
     except xr.MergeError as ex:
         logger.error(
             'Model files could not be combined: %s. Static metadata '

--- a/src/ofs_skill/model_processing/intake_scisa.py
+++ b/src/ofs_skill/model_processing/intake_scisa.py
@@ -51,6 +51,7 @@ import numpy as np
 import xarray as xr
 
 from ofs_skill.model_processing.get_fcst_cycle import get_fcst_hours
+from ofs_skill.model_processing.model_file_validation import validate_model_files
 from ofs_skill.model_processing.netcdf_engine import resolve_engine
 
 
@@ -235,6 +236,19 @@ def intake_model(file_list: list[str], prop: Any, logger: Logger) -> xr.Dataset:
     # fields are HDF5), and per source archive. See netcdf_engine.py;
     # the [settings] engine_strategy config key can force an engine.
     engine = resolve_engine(file_list, prop, logger)
+
+    # Drop unreadable / incomplete / dimensionally inconsistent files
+    # up front (with warnings) instead of letting them crash the
+    # multi-file open — files left behind by an interrupted forecast
+    # were failing whole multi-month runs (issue #194).
+    file_list, dropped_files = validate_model_files(
+        file_list, engine, time_name, prop.ofsfiletype, logger)
+    if dropped_files:
+        # Corrupt files sniff as 'unknown' and can pull the whole batch
+        # down to netcdf4; re-resolve now that they are gone (cached
+        # sniffs make this cheap).
+        engine = resolve_engine(file_list, prop, logger)
+
     # Record the engine so downstream extraction (get_node_ofs) can relax
     # the thread-serialization guard when the engine is thread-safe.
     prop.netcdf_engine = engine

--- a/src/ofs_skill/model_processing/model_file_validation.py
+++ b/src/ofs_skill/model_processing/model_file_validation.py
@@ -46,12 +46,16 @@ from __future__ import annotations
 from collections import Counter
 from concurrent.futures import ThreadPoolExecutor
 from logging import Logger
+import time
 from typing import Any, Optional
 
 import numpy as np
 import xarray as xr
 
 _REMOTE_PREFIXES = ('http://', 'https://', 's3://')
+
+# Progress heartbeat interval (files) for the serial validation loop.
+_PROGRESS_EVERY = 50
 
 
 def _is_remote(path: Any) -> bool:
@@ -161,6 +165,17 @@ def validate_model_files(
     if not local:
         return list(file_list), []
 
+    # This pass can take a while on long runs (hundreds of files,
+    # serial for NetCDF-3 batches), so announce it and report progress
+    # — otherwise the run appears hung between obs retrieval and the
+    # catalog open.
+    start = time.perf_counter()
+    logger.info(
+        'Validating %d local model file(s) before open (engine=%s, '
+        '%s) ...', len(local), engine,
+        'parallel' if engine == 'h5netcdf' and len(local) > 1
+        else 'serial — NetCDF-3 libraries are not thread-safe')
+
     # netcdf4/scipy hold process-global C state, so per-file probing is
     # serialized for those engines; h5netcdf probes in parallel.
     if engine == 'h5netcdf' and len(local) > 1:
@@ -168,7 +183,14 @@ def validate_model_files(
             checks = list(pool.map(
                 lambda p: _check_file(p, engine, time_name), local))
     else:
-        checks = [_check_file(p, engine, time_name) for p in local]
+        checks = []
+        for i, path in enumerate(local, 1):
+            checks.append(_check_file(path, engine, time_name))
+            if i % _PROGRESS_EVERY == 0 and i < len(local):
+                logger.info('Validated %d/%d model files (%.0f s elapsed)',
+                            i, len(local), time.perf_counter() - start)
+    logger.info('Model file validation finished: %d file(s) in %.1f s',
+                len(local), time.perf_counter() - start)
 
     dropped: list[tuple[str, str]] = []
     surviving: dict[str, dict] = {}

--- a/src/ofs_skill/model_processing/model_file_validation.py
+++ b/src/ofs_skill/model_processing/model_file_validation.py
@@ -46,6 +46,7 @@ from __future__ import annotations
 from collections import Counter
 import hashlib
 from logging import Logger
+import os
 import time
 from typing import Any, Optional
 
@@ -175,6 +176,77 @@ def _majority_dims(per_file_dims: list[dict], exempt: set) -> dict:
             counts.setdefault(name, Counter())[size] += 1
     return {name: counter.most_common(1)[0][0]
             for name, counter in counts.items()}
+
+
+def scrub_cached_copies(
+    urlpaths: list,
+    cache_dir: str,
+    time_name: Optional[str],
+    logger: Logger,
+) -> int:
+    """
+    Delete partial or corrupt cached copies of remote model files.
+
+    A run killed during the model-loading phase can leave a partially
+    downloaded file in the fsspec cache (``~/.ofs_cache/s3/``). On the
+    next run the cache is trusted as-is and the partial file surfaces
+    as an unrelated-looking crash — ``ValueError: buffer size must be
+    a multiple of element size`` or ``MergeError: conflicting values
+    for variable 'x'`` (a truncated NetCDF-3 file zero-fills its
+    static coordinates; see issues #176 / #193).
+
+    For every remote URL whose cached copy already exists, run the same
+    integrity probe used for archive files and delete copies that fail
+    — unlike archive files, a cached file is safely re-downloadable, so
+    removal is the right remedy rather than dropping the file from the
+    run.
+
+    Parameters
+    ----------
+    urlpaths : list of str
+        Remote URLs (http(s)/s3) about to be opened through the cache.
+        Non-remote entries are ignored.
+    cache_dir : str
+        The fsspec ``same_names=True`` cache directory (cached filename
+        equals the URL basename).
+    time_name : str or None
+        Name of the time dimension, for the integrity probe.
+    logger : Logger
+        Logger instance.
+
+    Returns
+    -------
+    int
+        Number of bad cached copies removed.
+    """
+    removed = 0
+    for url in urlpaths:
+        if not (isinstance(url, str) and _is_remote(url)):
+            continue
+        basename = url.split('::')[-1].split('?')[0].rsplit('/', 1)[-1]
+        cached = os.path.join(cache_dir, basename)
+        if not os.path.isfile(cached):
+            continue
+        reason, _, _ = _check_file(cached, time_name)
+        if reason is None:
+            continue
+        try:
+            os.remove(cached)
+            removed += 1
+            logger.warning(
+                'Removed bad cached copy %s (%s) — it will be '
+                're-downloaded. A previous run was likely interrupted '
+                'while downloading it.', cached, reason)
+        except OSError as ex:
+            logger.warning(
+                'Cached copy %s failed validation (%s) but could not '
+                'be removed (%s) — the model open may fail; clear the '
+                'cache directory manually.', cached, reason, ex)
+    if removed:
+        logger.info(
+            'Cache scrub removed %d partial/corrupt cached file(s) '
+            'from %s', removed, cache_dir)
+    return removed
 
 
 def validate_model_files(

--- a/src/ofs_skill/model_processing/model_file_validation.py
+++ b/src/ofs_skill/model_processing/model_file_validation.py
@@ -44,6 +44,7 @@ path.
 from __future__ import annotations
 
 from collections import Counter
+import hashlib
 from logging import Logger
 import time
 from typing import Any, Optional
@@ -56,6 +57,12 @@ _REMOTE_PREFIXES = ('http://', 'https://', 's3://')
 # Progress heartbeat interval (files) for the serial validation loop.
 _PROGRESS_EVERY = 50
 
+# Static variables larger than this are excluded from the
+# static-metadata fingerprint to keep the per-file probe cheap.
+# Stations-file static vars (x/y/lon/lat/h/sigma/names) are a few
+# hundred to a few thousand elements.
+_FINGERPRINT_MAX_ELEMENTS = 200_000
+
 
 def _is_remote(path: Any) -> bool:
     if not isinstance(path, str):
@@ -65,13 +72,49 @@ def _is_remote(path: Any) -> bool:
     return tail.startswith(_REMOTE_PREFIXES)
 
 
-def _check_file(path: str,
-                time_name: Optional[str]) -> tuple[Optional[str], dict]:
+def _static_fingerprint(nc: 'netCDF4.Dataset',
+                        time_name: Optional[str]) -> str:
+    """Hash the values of the file's small static (non-time) variables.
+
+    Multi-file concat with ``data_vars='minimal'`` requires static
+    variables (station x/y/lon/lat, names, sigma levels, ...) to be
+    IDENTICAL across every file in the batch; a model configuration
+    change mid-window (e.g. relocated stations after an outage) makes
+    xarray raise ``MergeError: conflicting values for variable 'x'``.
+    Hashing these values per file lets the batch-consistency step spot
+    the change and drop the minority deployment with a clear warning
+    instead of crashing the combine. Variables above the size cap are
+    skipped to keep the probe cheap.
+    """
+    md5 = hashlib.md5()
+    for name in sorted(nc.variables):
+        var = nc.variables[name]
+        if time_name and time_name in var.dimensions:
+            continue
+        if var.size > _FINGERPRINT_MAX_ELEMENTS:
+            continue
+        try:
+            var.set_auto_maskandscale(False)
+            payload = np.asarray(var[:]).tobytes()
+        except Exception:  # noqa: BLE001 - unreadable static var:
+            continue       # other checks decide the file's fate
+        md5.update(name.encode())
+        md5.update(payload)
+    return md5.hexdigest()
+
+
+def _check_file(
+    path: str,
+    time_name: Optional[str],
+    fingerprint: bool = False,
+) -> tuple[Optional[str], dict, Optional[str]]:
     """Validate one local file.
 
-    Returns ``(reason, dims)`` — ``reason`` is None when the file is
-    valid, otherwise a short description of why it was rejected;
-    ``dims`` is the file's dimension-size mapping (empty on failure).
+    Returns ``(reason, dims, static_fp)`` — ``reason`` is None when the
+    file is valid, otherwise a short description of why it was
+    rejected; ``dims`` is the file's dimension-size mapping (empty on
+    failure); ``static_fp`` is the static-variable fingerprint when
+    ``fingerprint`` is True (None otherwise or on failure).
 
     The probe uses ``netCDF4.Dataset`` directly rather than a full
     ``xr.open_dataset``: libnetCDF reads every on-disk format, and a
@@ -83,17 +126,17 @@ def _check_file(path: str,
         nc = netCDF4.Dataset(path, 'r')
     except Exception as ex:  # noqa: BLE001 - any open failure = bad file
         return (f'unreadable ({type(ex).__name__}: '
-                f'{str(ex)[:120]})'), {}
+                f'{str(ex)[:120]})'), {}, None
     try:
         dims = {name: len(dim) for name, dim in nc.dimensions.items()}
         if time_name:
             if time_name not in dims:
                 return (f"missing '{time_name}' dimension "
-                        '(incomplete file?)'), {}
+                        '(incomplete file?)'), {}, None
             if dims[time_name] < 1:
-                return f"empty '{time_name}' dimension", {}
+                return f"empty '{time_name}' dimension", {}, None
         if len(nc.variables) == 0:
-            return 'no variables (header-only file?)', {}
+            return 'no variables (header-only file?)', {}, None
         if time_name and time_name in nc.variables:
             try:
                 raw = nc.variables[time_name][:]
@@ -102,7 +145,7 @@ def _check_file(path: str,
                         np.asarray(raw, dtype='float64')), np.nan)
             except Exception as ex:  # noqa: BLE001
                 return (f'time coordinate unreadable — truncated file? '
-                        f'({type(ex).__name__}: {str(ex)[:120]})'), {}
+                        f'({type(ex).__name__}: {str(ex)[:120]})'), {}, None
             # Model time axes are strictly increasing within a file.
             # libnetCDF silently zero-fills NetCDF-3 reads past EOF, so
             # a truncated file reads back with a zeroed time tail —
@@ -114,8 +157,10 @@ def _check_file(path: str,
                     bad = int(np.argmin(diffs > 0)) + 1
                     return ('time axis not strictly increasing at step '
                             f'{bad} of {tvals.size} — zero-filled or '
-                            'truncated file?'), {}
-        return None, dims
+                            'truncated file?'), {}, None
+        static_fp = (_static_fingerprint(nc, time_name)
+                     if fingerprint else None)
+        return None, dims, static_fp
     finally:
         nc.close()
 
@@ -193,9 +238,13 @@ def validate_model_files(
     # ("NetCDF: Not a valid ID"). Serial is fine — the probe is a bare
     # header open plus one coordinate read, so per-file cost is
     # milliseconds locally and I/O-latency-bound on network storage.
+    # Static-metadata fingerprinting is only meaningful for stations
+    # files, where the batch is concatenated with data_vars='minimal'
+    # and static vars must agree exactly.
+    fingerprint = ofsfiletype == 'stations'
     checks = []
     for i, path in enumerate(local, 1):
-        checks.append(_check_file(path, time_name))
+        checks.append(_check_file(path, time_name, fingerprint))
         if i % _PROGRESS_EVERY == 0 and i < len(local):
             logger.info('Validated %d/%d model files (%.0f s elapsed)',
                         i, len(local), time.perf_counter() - start)
@@ -204,9 +253,12 @@ def validate_model_files(
 
     dropped: list[tuple[str, str]] = []
     surviving: dict[str, dict] = {}
-    for path, (reason, dims) in zip(local, checks):
+    fp_by_path: dict[str, str] = {}
+    for path, (reason, dims, static_fp) in zip(local, checks):
         if reason is None:
             surviving[path] = dims
+            if static_fp is not None:
+                fp_by_path[path] = static_fp
         else:
             dropped.append((path, reason))
 
@@ -228,6 +280,38 @@ def validate_model_files(
                 dropped.append(
                     (path, f'dimension mismatch with batch: {detail}'))
                 del surviving[path]
+                fp_by_path.pop(path, None)
+
+    # Static-metadata consistency: with identical dimensions, files can
+    # still disagree on static VALUES (station x/y/lon/lat, names, sigma
+    # levels) after a model configuration change mid-window — xarray's
+    # minimal-mode concat then dies with "MergeError: conflicting values
+    # for variable 'x'". Drop the minority deployment, but only when the
+    # batch has a clear majority and every file has the same station
+    # count (differing counts are the legitimate remove_extra_stations
+    # case, where coordinate arrays trivially differ).
+    station_sizes = {dims.get('station') for dims in surviving.values()}
+    if (fingerprint and len(fp_by_path) > 1
+            and len(station_sizes) == 1):
+        fp_counts = Counter(fp_by_path.values())
+        top_fp, top_n = fp_counts.most_common(1)[0]
+        if len(fp_counts) > 1 and top_n * 2 >= len(fp_by_path):
+            for path, fp in sorted(fp_by_path.items()):
+                if fp != top_fp:
+                    dropped.append((path, (
+                        'static station metadata (coordinates/names/'
+                        'sigma levels) differs from the batch majority '
+                        '— the model configuration likely changed '
+                        'mid-window; consider splitting the assessment '
+                        'window at the change date')))
+                    del surviving[path]
+        elif len(fp_counts) > 1:
+            logger.warning(
+                'Static station metadata varies across %d groups of '
+                'files with no clear majority — the multi-file combine '
+                'may fail with a MergeError. The assessment window '
+                'likely spans multiple model configurations.',
+                len(fp_counts))
 
     if not dropped:
         return list(file_list), [], dict(surviving)

--- a/src/ofs_skill/model_processing/model_file_validation.py
+++ b/src/ofs_skill/model_processing/model_file_validation.py
@@ -44,13 +44,12 @@ path.
 from __future__ import annotations
 
 from collections import Counter
-from concurrent.futures import ThreadPoolExecutor
 from logging import Logger
 import time
 from typing import Any, Optional
 
+import netCDF4
 import numpy as np
-import xarray as xr
 
 _REMOTE_PREFIXES = ('http://', 'https://', 's3://')
 
@@ -66,39 +65,49 @@ def _is_remote(path: Any) -> bool:
     return tail.startswith(_REMOTE_PREFIXES)
 
 
-def _check_file(path: str, engine: str,
+def _check_file(path: str,
                 time_name: Optional[str]) -> tuple[Optional[str], dict]:
     """Validate one local file.
 
     Returns ``(reason, dims)`` — ``reason`` is None when the file is
     valid, otherwise a short description of why it was rejected;
     ``dims`` is the file's dimension-size mapping (empty on failure).
+
+    The probe uses ``netCDF4.Dataset`` directly rather than a full
+    ``xr.open_dataset``: libnetCDF reads every on-disk format, and a
+    bare header open plus one coordinate read is several times cheaper
+    than building an xarray Dataset — this loop runs once per model
+    file and dominated start-up on slow archive storage.
     """
     try:
-        ds = xr.open_dataset(path, engine=engine, decode_times=False)
+        nc = netCDF4.Dataset(path, 'r')
     except Exception as ex:  # noqa: BLE001 - any open failure = bad file
         return (f'unreadable ({type(ex).__name__}: '
                 f'{str(ex)[:120]})'), {}
     try:
-        dims = dict(ds.sizes)
+        dims = {name: len(dim) for name, dim in nc.dimensions.items()}
         if time_name:
             if time_name not in dims:
                 return (f"missing '{time_name}' dimension "
                         '(incomplete file?)'), {}
             if dims[time_name] < 1:
                 return f"empty '{time_name}' dimension", {}
-        if len(ds.data_vars) == 0:
-            return 'no data variables (header-only file?)', {}
-        if time_name:
+        if len(nc.variables) == 0:
+            return 'no variables (header-only file?)', {}
+        if time_name and time_name in nc.variables:
             try:
-                tvals = np.asarray(ds[time_name].values, dtype='float64')
+                raw = nc.variables[time_name][:]
+                tvals = np.ma.filled(
+                    np.ma.masked_invalid(
+                        np.asarray(raw, dtype='float64')), np.nan)
             except Exception as ex:  # noqa: BLE001
                 return (f'time coordinate unreadable — truncated file? '
                         f'({type(ex).__name__}: {str(ex)[:120]})'), {}
             # Model time axes are strictly increasing within a file.
             # libnetCDF silently zero-fills NetCDF-3 reads past EOF, so
             # a truncated file reads back with a zeroed time tail —
-            # detectable here, invisible to the open itself.
+            # detectable here, invisible to the open itself. (NaN /
+            # masked time values fail the check too, deliberately.)
             if tvals.size > 1:
                 diffs = np.diff(tvals)
                 if not np.all(diffs > 0):
@@ -108,7 +117,7 @@ def _check_file(path: str, engine: str,
                             'truncated file?'), {}
         return None, dims
     finally:
-        ds.close()
+        nc.close()
 
 
 def _majority_dims(per_file_dims: list[dict], exempt: set) -> dict:
@@ -129,7 +138,7 @@ def validate_model_files(
     time_name: Optional[str],
     ofsfiletype: str,
     logger: Logger,
-) -> tuple[list, list[tuple[str, str]]]:
+) -> tuple[list, list[tuple[str, str]], dict[str, dict]]:
     """
     Drop unreadable, incomplete, or structurally inconsistent files.
 
@@ -139,6 +148,8 @@ def validate_model_files(
         Model file paths and/or remote URLs about to be opened together.
     engine : str
         xarray engine chosen for the batch (see netcdf_engine.py).
+        Currently informational — the probes read headers via netCDF4,
+        which handles every on-disk format.
     time_name : str or None
         Name of the concat/time dimension ('time', 'ocean_time', ...).
     ofsfiletype : str
@@ -150,10 +161,13 @@ def validate_model_files(
 
     Returns
     -------
-    tuple of (list, list)
-        ``(valid_files, dropped)`` where ``dropped`` holds
-        ``(path, reason)`` pairs. Remote URLs are always passed
-        through as valid.
+    tuple of (list, list, dict)
+        ``(valid_files, dropped, dims_by_path)`` — ``dropped`` holds
+        ``(path, reason)`` pairs; ``dims_by_path`` maps each surviving
+        LOCAL path to its dimension-size dict, so callers can reuse
+        the probed dimensions (e.g. the station-dimension compatibility
+        check) instead of re-opening every file. Remote URLs are always
+        passed through as valid and do not appear in ``dims_by_path``.
 
     Raises
     ------
@@ -163,32 +177,28 @@ def validate_model_files(
     local = [f for f in file_list if isinstance(f, str)
              and not _is_remote(f)]
     if not local:
-        return list(file_list), []
+        return list(file_list), [], {}
 
-    # This pass can take a while on long runs (hundreds of files,
-    # serial for NetCDF-3 batches), so announce it and report progress
-    # — otherwise the run appears hung between obs retrieval and the
+    # This pass can take a while on long runs (hundreds of files on
+    # slow archive storage), so announce it and report progress —
+    # otherwise the run appears hung between obs retrieval and the
     # catalog open.
     start = time.perf_counter()
     logger.info(
-        'Validating %d local model file(s) before open (engine=%s, '
-        '%s) ...', len(local), engine,
-        'parallel' if engine == 'h5netcdf' and len(local) > 1
-        else 'serial — NetCDF-3 libraries are not thread-safe')
+        'Validating %d local model file(s) before open '
+        '(lightweight header probes) ...', len(local))
 
-    # netcdf4/scipy hold process-global C state, so per-file probing is
-    # serialized for those engines; h5netcdf probes in parallel.
-    if engine == 'h5netcdf' and len(local) > 1:
-        with ThreadPoolExecutor(max_workers=min(8, len(local))) as pool:
-            checks = list(pool.map(
-                lambda p: _check_file(p, engine, time_name), local))
-    else:
-        checks = []
-        for i, path in enumerate(local, 1):
-            checks.append(_check_file(path, engine, time_name))
-            if i % _PROGRESS_EVERY == 0 and i < len(local):
-                logger.info('Validated %d/%d model files (%.0f s elapsed)',
-                            i, len(local), time.perf_counter() - start)
+    # The probes run serially on purpose: concurrent netCDF4.Dataset
+    # open/close across threads races in libnetCDF's global file table
+    # ("NetCDF: Not a valid ID"). Serial is fine — the probe is a bare
+    # header open plus one coordinate read, so per-file cost is
+    # milliseconds locally and I/O-latency-bound on network storage.
+    checks = []
+    for i, path in enumerate(local, 1):
+        checks.append(_check_file(path, time_name))
+        if i % _PROGRESS_EVERY == 0 and i < len(local):
+            logger.info('Validated %d/%d model files (%.0f s elapsed)',
+                        i, len(local), time.perf_counter() - start)
     logger.info('Model file validation finished: %d file(s) in %.1f s',
                 len(local), time.perf_counter() - start)
 
@@ -220,7 +230,7 @@ def validate_model_files(
                 del surviving[path]
 
     if not dropped:
-        return list(file_list), []
+        return list(file_list), [], dict(surviving)
 
     for path, reason in dropped:
         logger.warning('Skipping model file %s: %s', path, reason)
@@ -239,4 +249,4 @@ def validate_model_files(
             'See the warnings above for per-file reasons.',
             len(file_list))
         raise SystemExit
-    return valid, dropped
+    return valid, dropped, dict(surviving)

--- a/src/ofs_skill/model_processing/model_file_validation.py
+++ b/src/ofs_skill/model_processing/model_file_validation.py
@@ -1,0 +1,220 @@
+"""
+Model File Validation
+
+Pre-open validation of model netCDF files so that incomplete, corrupt,
+or structurally inconsistent files are dropped with a warning instead
+of crashing the multi-file open or the extraction that follows
+(issue #194: multi-month runs failing on files left behind by a
+forecast interruption).
+
+Each local file is opened individually and checked for:
+
+1. **Readability** — the file opens under the engine chosen for the
+   batch. Zero-byte files, garbage, and truncated HDF5 files fail here.
+2. **A usable time axis** — the concat dimension exists and has at
+   least one step. Header-only files written during an interrupted
+   forecast fail here.
+3. **A strictly increasing time axis** — the full time coordinate is
+   loaded and must be strictly increasing. This is the truncation
+   detector for NetCDF-3: libnetCDF silently zero-fills reads past
+   EOF (no error!), so a file truncated by an interrupted forecast
+   opens cleanly and returns zeros for the missing records — including
+   time values of 0, which later produce duplicate/non-monotonic
+   timestamps that crash resampling (and quietly poison the data
+   before that). Since time is a record variable, any truncation deep
+   enough to lose data corrupts the time tail, so this check catches
+   it. Truncated HDF5 files fail at open instead (check 1).
+4. **Data variables present** — a file with coordinates but no data
+   variables is dropped.
+
+After the per-file checks, dimension sizes are compared across the
+surviving files: a file whose non-time dimensions disagree with the
+majority of the batch (e.g. a different number of sigma layers or mesh
+nodes) is dropped, since the multi-file combine would otherwise fail.
+The ``station`` dimension of stations files is exempt — differing
+station counts are legitimate (grid updates) and are handled downstream
+by ``remove_extra_stations``, which slices files to the common set.
+
+Remote URLs are passed through unvalidated: per-file remote opens are
+expensive, and NODD-served files are the canonical copies. The
+h5netcdf open-time fallback in ``intake_model`` still protects that
+path.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from concurrent.futures import ThreadPoolExecutor
+from logging import Logger
+from typing import Any, Optional
+
+import numpy as np
+import xarray as xr
+
+_REMOTE_PREFIXES = ('http://', 'https://', 's3://')
+
+
+def _is_remote(path: Any) -> bool:
+    if not isinstance(path, str):
+        return False
+    # Unwrap fsspec protocol chaining (simplecache::https://...)
+    tail = path.split('::')[-1] if '::' in path else path
+    return tail.startswith(_REMOTE_PREFIXES)
+
+
+def _check_file(path: str, engine: str,
+                time_name: Optional[str]) -> tuple[Optional[str], dict]:
+    """Validate one local file.
+
+    Returns ``(reason, dims)`` — ``reason`` is None when the file is
+    valid, otherwise a short description of why it was rejected;
+    ``dims`` is the file's dimension-size mapping (empty on failure).
+    """
+    try:
+        ds = xr.open_dataset(path, engine=engine, decode_times=False)
+    except Exception as ex:  # noqa: BLE001 - any open failure = bad file
+        return (f'unreadable ({type(ex).__name__}: '
+                f'{str(ex)[:120]})'), {}
+    try:
+        dims = dict(ds.sizes)
+        if time_name:
+            if time_name not in dims:
+                return (f"missing '{time_name}' dimension "
+                        '(incomplete file?)'), {}
+            if dims[time_name] < 1:
+                return f"empty '{time_name}' dimension", {}
+        if len(ds.data_vars) == 0:
+            return 'no data variables (header-only file?)', {}
+        if time_name:
+            try:
+                tvals = np.asarray(ds[time_name].values, dtype='float64')
+            except Exception as ex:  # noqa: BLE001
+                return (f'time coordinate unreadable — truncated file? '
+                        f'({type(ex).__name__}: {str(ex)[:120]})'), {}
+            # Model time axes are strictly increasing within a file.
+            # libnetCDF silently zero-fills NetCDF-3 reads past EOF, so
+            # a truncated file reads back with a zeroed time tail —
+            # detectable here, invisible to the open itself.
+            if tvals.size > 1:
+                diffs = np.diff(tvals)
+                if not np.all(diffs > 0):
+                    bad = int(np.argmin(diffs > 0)) + 1
+                    return ('time axis not strictly increasing at step '
+                            f'{bad} of {tvals.size} — zero-filled or '
+                            'truncated file?'), {}
+        return None, dims
+    finally:
+        ds.close()
+
+
+def _majority_dims(per_file_dims: list[dict], exempt: set) -> dict:
+    """Most common size for every non-exempt dimension in the batch."""
+    counts: dict[str, Counter] = {}
+    for dims in per_file_dims:
+        for name, size in dims.items():
+            if name in exempt:
+                continue
+            counts.setdefault(name, Counter())[size] += 1
+    return {name: counter.most_common(1)[0][0]
+            for name, counter in counts.items()}
+
+
+def validate_model_files(
+    file_list: list,
+    engine: str,
+    time_name: Optional[str],
+    ofsfiletype: str,
+    logger: Logger,
+) -> tuple[list, list[tuple[str, str]]]:
+    """
+    Drop unreadable, incomplete, or structurally inconsistent files.
+
+    Parameters
+    ----------
+    file_list : list of str
+        Model file paths and/or remote URLs about to be opened together.
+    engine : str
+        xarray engine chosen for the batch (see netcdf_engine.py).
+    time_name : str or None
+        Name of the concat/time dimension ('time', 'ocean_time', ...).
+    ofsfiletype : str
+        'stations' or 'fields'. For stations files the station
+        dimension is exempt from the consistency check (handled by
+        remove_extra_stations downstream).
+    logger : Logger
+        Logger instance; one WARNING per dropped file plus a summary.
+
+    Returns
+    -------
+    tuple of (list, list)
+        ``(valid_files, dropped)`` where ``dropped`` holds
+        ``(path, reason)`` pairs. Remote URLs are always passed
+        through as valid.
+
+    Raises
+    ------
+    SystemExit
+        If the batch contained files but none survived validation.
+    """
+    local = [f for f in file_list if isinstance(f, str)
+             and not _is_remote(f)]
+    if not local:
+        return list(file_list), []
+
+    # netcdf4/scipy hold process-global C state, so per-file probing is
+    # serialized for those engines; h5netcdf probes in parallel.
+    if engine == 'h5netcdf' and len(local) > 1:
+        with ThreadPoolExecutor(max_workers=min(8, len(local))) as pool:
+            checks = list(pool.map(
+                lambda p: _check_file(p, engine, time_name), local))
+    else:
+        checks = [_check_file(p, engine, time_name) for p in local]
+
+    dropped: list[tuple[str, str]] = []
+    surviving: dict[str, dict] = {}
+    for path, (reason, dims) in zip(local, checks):
+        if reason is None:
+            surviving[path] = dims
+        else:
+            dropped.append((path, reason))
+
+    # Batch-level consistency: drop files whose non-time dims disagree
+    # with the batch majority (a minority file would crash the combine).
+    exempt = {time_name} if time_name else set()
+    if ofsfiletype == 'stations':
+        exempt.add('station')
+    if len(surviving) > 1:
+        majority = _majority_dims(list(surviving.values()), exempt)
+        for path, dims in list(surviving.items()):
+            bad = {name: (size, majority[name])
+                   for name, size in dims.items()
+                   if name not in exempt and size != majority[name]}
+            if bad:
+                detail = ', '.join(
+                    f'{name}={size} (batch majority {want})'
+                    for name, (size, want) in sorted(bad.items()))
+                dropped.append(
+                    (path, f'dimension mismatch with batch: {detail}'))
+                del surviving[path]
+
+    if not dropped:
+        return list(file_list), []
+
+    for path, reason in dropped:
+        logger.warning('Skipping model file %s: %s', path, reason)
+    logger.warning(
+        'Dropped %d of %d model file(s) that failed validation; '
+        'continuing with the remaining %d. Skill results will not '
+        'include data from the dropped files.',
+        len(dropped), len(file_list), len(file_list) - len(dropped))
+
+    dropped_set = {path for path, _ in dropped}
+    valid = [f for f in file_list
+             if not (isinstance(f, str) and f in dropped_set)]
+    if not valid:
+        logger.error(
+            'All %d model files failed validation — cannot continue. '
+            'See the warnings above for per-file reasons.',
+            len(file_list))
+        raise SystemExit
+    return valid, dropped

--- a/src/ofs_skill/model_processing/netcdf_engine.py
+++ b/src/ofs_skill/model_processing/netcdf_engine.py
@@ -1,0 +1,242 @@
+"""
+NetCDF Engine Detection
+
+Chooses the xarray engine for reading model files by detecting each
+file's on-disk format from its magic bytes instead of relying on a
+hardcoded per-OFS mapping. NetCDF-4/HDF5 files are readable by
+``h5netcdf``, which releases the GIL during reads and supports
+concurrent access from multiple threads; NetCDF-3 files (classic,
+64-bit offset, or CDF-5) require ``netcdf4`` or ``scipy``, whose
+underlying C libraries hold process-global state and must be
+serialized across threads.
+
+Formats can differ per OFS, per file type, and per source archive —
+e.g. stofs_2d_glo publishes NetCDF-3 stations files next to HDF5
+fields files in the same cycle, and NECOFS is NetCDF-3 across the
+board — so detection is done per batch of files at open time rather
+than from a static list.
+
+The strategy is configurable via ``engine_strategy`` in the
+``[settings]`` section of ofs_dps.conf:
+
+- ``auto`` (default): sniff the batch; use h5netcdf only when every
+  sampled file is HDF5, otherwise fall back to a NetCDF-3-capable
+  engine.
+- ``netcdf4`` / ``h5netcdf``: force that engine for every open
+  (debugging and emergency rollback).
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import urllib.request
+from typing import Any, Iterable, Optional
+
+from ofs_skill.obs_retrieval import utils
+
+FORMAT_HDF5 = 'hdf5'
+FORMAT_NETCDF3 = 'netcdf3'
+FORMAT_UNKNOWN = 'unknown'
+
+_HDF5_MAGIC = b'\x89HDF\r\n\x1a\n'
+_NETCDF3_MAGICS = (b'CDF\x01', b'CDF\x02', b'CDF\x05')
+
+# The HDF5 superblock is usually at offset 0, but the format also allows
+# it at 512 << n. Only local files are probed at the extra offsets; for
+# remote files a miss at offset 0 is classified as unknown (which maps
+# to the safe netcdf4-family engine).
+_HDF5_LOCAL_OFFSETS = (0, 512, 1024, 2048, 4096)
+
+# Custom user-supplied NetCDF-3 files that historically require the
+# scipy engine, identified by filename marker (see intake_scisa).
+NETCDF3_SCIPY_MARKERS = ('2017_free_run_station',)
+
+# Cap on per-batch sniffs. Batches are homogeneous in practice (one OFS,
+# one file type, one date range), so sampling the batch evenly is enough;
+# a wrong pick on a pathological mixed batch is caught by the engine
+# fallback in intake_scisa.
+_MAX_SNIFFS_PER_BATCH = 12
+
+_SNIFF_CACHE: dict[str, str] = {}
+_SNIFF_CACHE_LOCK = threading.Lock()
+
+VALID_STRATEGIES = ('auto', 'netcdf4', 'h5netcdf')
+
+
+def _classify(header: bytes) -> str:
+    if header.startswith(_HDF5_MAGIC):
+        return FORMAT_HDF5
+    if header.startswith(_NETCDF3_MAGICS):
+        return FORMAT_NETCDF3
+    return FORMAT_UNKNOWN
+
+
+def _strip_protocol_chain(path: str) -> str:
+    """Strip fsspec protocol chaining, e.g. simplecache::https://..."""
+    if '::' in path:
+        return path.split('::')[-1]
+    return path
+
+
+def _sniff_remote(url: str, logger: logging.Logger) -> str:
+    """Classify a remote file from a ranged GET of its first 8 bytes."""
+    if url.startswith('s3://'):
+        # Public NODD buckets are reachable anonymously over HTTPS.
+        bucket, _, key = url[len('s3://'):].partition('/')
+        url = f'https://{bucket}.s3.amazonaws.com/{key}'
+    request = urllib.request.Request(url, headers={'Range': 'bytes=0-7'})
+    try:
+        with urllib.request.urlopen(request, timeout=15) as resp:
+            return _classify(resp.read(8))
+    except Exception as ex:
+        logger.debug('Format sniff failed for %s: %s', url, ex)
+        return FORMAT_UNKNOWN
+
+
+def _sniff_local(path: str, logger: logging.Logger) -> str:
+    try:
+        with open(path, 'rb') as fp:
+            fmt = _classify(fp.read(8))
+            if fmt != FORMAT_UNKNOWN:
+                return fmt
+            for offset in _HDF5_LOCAL_OFFSETS[1:]:
+                fp.seek(offset)
+                if fp.read(8) == _HDF5_MAGIC:
+                    return FORMAT_HDF5
+            return FORMAT_UNKNOWN
+    except OSError as ex:
+        logger.debug('Format sniff failed for %s: %s', path, ex)
+        return FORMAT_UNKNOWN
+
+
+def sniff_netcdf_format(path: Any, logger: Optional[logging.Logger] = None) -> str:
+    """
+    Detect the on-disk NetCDF format of a local path or remote URL.
+
+    Parameters
+    ----------
+    path : str
+        Local file path, or http(s):// / s3:// URL. fsspec protocol
+        chains (``simplecache::https://...``) are unwrapped.
+    logger : logging.Logger, optional
+        Logger for debug output on sniff failures.
+
+    Returns
+    -------
+    str
+        ``'hdf5'``, ``'netcdf3'``, or ``'unknown'``. Sniff failures
+        (unreadable file, network error, unrecognized magic) return
+        ``'unknown'`` so callers fall back to the netcdf4-family
+        engine, which reads every format.
+    """
+    if logger is None:
+        logger = logging.getLogger(__name__)
+    if not isinstance(path, str):
+        return FORMAT_UNKNOWN
+    path = _strip_protocol_chain(path)
+    with _SNIFF_CACHE_LOCK:
+        cached = _SNIFF_CACHE.get(path)
+    if cached is not None:
+        return cached
+    if path.startswith(('http://', 'https://', 's3://')):
+        fmt = _sniff_remote(path, logger)
+    else:
+        fmt = _sniff_local(path, logger)
+    # Don't cache failures: a transient network error shouldn't pin a
+    # file to 'unknown' for the rest of the run.
+    if fmt != FORMAT_UNKNOWN:
+        with _SNIFF_CACHE_LOCK:
+            _SNIFF_CACHE[path] = fmt
+    return fmt
+
+
+def _sample_paths(file_list: list) -> list:
+    """Evenly sample up to _MAX_SNIFFS_PER_BATCH paths from the batch."""
+    paths = [f for f in file_list if isinstance(f, str)]
+    if len(paths) <= _MAX_SNIFFS_PER_BATCH:
+        return paths
+    step = (len(paths) - 1) / (_MAX_SNIFFS_PER_BATCH - 1)
+    indices = {round(i * step) for i in range(_MAX_SNIFFS_PER_BATCH)}
+    return [paths[i] for i in sorted(indices)]
+
+
+def get_engine_strategy(
+    config_file: Any = None,
+    logger: Optional[logging.Logger] = None,
+) -> str:
+    """
+    Read ``engine_strategy`` from the [settings] config section.
+
+    Returns ``'auto'`` when the setting is missing or invalid.
+    """
+    if logger is None:
+        logger = logging.getLogger(__name__)
+    try:
+        settings = utils.Utils(config_file=config_file).read_config_section(
+            'settings', logger)
+    except Exception:
+        settings = {}
+    strategy = (settings or {}).get('engine_strategy', 'auto').strip().lower()
+    if strategy not in VALID_STRATEGIES:
+        logger.warning(
+            "Invalid engine_strategy '%s' in [settings]; expected one of "
+            '%s. Using auto.', strategy, ', '.join(VALID_STRATEGIES))
+        strategy = 'auto'
+    return strategy
+
+
+def _netcdf3_engine(ofs: str, file_list: Iterable) -> str:
+    """NetCDF-3-capable engine, preserving historical special cases."""
+    if ofs == 'stofs_2d_glo':
+        return 'scipy'
+    if any(marker in f
+           for f in file_list if isinstance(f, str)
+           for marker in NETCDF3_SCIPY_MARKERS):
+        return 'scipy'
+    return 'netcdf4'
+
+
+def resolve_engine(file_list: list, prop: Any, logger: logging.Logger) -> str:
+    """
+    Choose the xarray engine for a batch of model files.
+
+    With ``engine_strategy=auto`` (default), sniffs the batch's magic
+    bytes: every sampled file HDF5 → ``h5netcdf``; anything else →
+    ``scipy`` for the historical NetCDF-3 special cases (stofs_2d_glo,
+    custom free-run station files) or ``netcdf4`` otherwise. Forced
+    strategies skip detection entirely.
+
+    Parameters
+    ----------
+    file_list : list of str
+        Local paths and/or remote URLs about to be opened together.
+    prop : ModelProperties
+        Provides ``ofs`` and optionally ``config_file``.
+    logger : logging.Logger
+        Logger instance.
+
+    Returns
+    -------
+    str
+        ``'h5netcdf'``, ``'netcdf4'``, or ``'scipy'``.
+    """
+    strategy = get_engine_strategy(
+        getattr(prop, 'config_file', None), logger)
+    if strategy != 'auto':
+        logger.info('engine_strategy=%s forced from config', strategy)
+        return strategy
+
+    samples = _sample_paths(file_list)
+    if not samples:
+        return 'netcdf4'
+    formats = {sniff_netcdf_format(p, logger) for p in samples}
+    if formats == {FORMAT_HDF5}:
+        engine = 'h5netcdf'
+    else:
+        engine = _netcdf3_engine(getattr(prop, 'ofs', ''), file_list)
+    logger.info(
+        'Detected netCDF format(s) %s across %d sampled file(s) of %d; '
+        "using engine '%s'",
+        sorted(formats), len(samples), len(file_list), engine)
+    return engine

--- a/src/ofs_skill/obs_retrieval/utils.py
+++ b/src/ofs_skill/obs_retrieval/utils.py
@@ -347,6 +347,7 @@ def get_parallel_config(logger=None, config_file=None):
         'parallel_forecast_cycles': False,
         'parallel_obs_variables': False,
         'parallel_2d_interp': False,
+        'parallel_extract_slots': 2,
     }
 
     if logger is None:
@@ -407,10 +408,23 @@ def get_parallel_config(logger=None, config_file=None):
             except ValueError:
                 pass
 
+    # Parse parallel_extract_slots — max concurrent dask.compute calls
+    # across variable threads during model extraction. Only takes effect
+    # under the thread-safe h5netcdf engine (thread-unsafe engines are
+    # always fully serialized); bounds peak memory, since each slot holds
+    # one variable's time-window materialization.
+    val = raw.get('parallel_extract_slots', '').strip().lower()
+    if val:
+        try:
+            result['parallel_extract_slots'] = min(max(1, int(val)), 8)
+        except ValueError:
+            pass
+
     # If parallelization is globally disabled, force all workers to 1
     if not result['parallel_enabled']:
         for key in int_keys + ['ha_workers']:
             result[key] = 1
+        result['parallel_extract_slots'] = 1
 
     return result
 

--- a/tests/model_file_validation_test.py
+++ b/tests/model_file_validation_test.py
@@ -74,7 +74,7 @@ def _truncate(path, keep_fraction):
 
 def test_all_good_files_pass(tmp_path):
     files = [_write_nc3(tmp_path, f'f{i}.nc') for i in range(3)]
-    valid, dropped = validate_model_files(
+    valid, dropped, _ = validate_model_files(
         files, 'netcdf4', 'time', 'stations', LOG)
     assert valid == files
     assert dropped == []
@@ -84,7 +84,7 @@ def test_zero_byte_file_dropped(tmp_path):
     good = _write_nc3(tmp_path, 'good.nc')
     bad = tmp_path / 'empty.nc'
     bad.write_bytes(b'')
-    valid, dropped = validate_model_files(
+    valid, dropped, _ = validate_model_files(
         [good, str(bad)], 'netcdf4', 'time', 'stations', LOG)
     assert valid == [good]
     assert len(dropped) == 1 and dropped[0][0] == str(bad)
@@ -95,7 +95,7 @@ def test_garbage_file_dropped(tmp_path):
     good = _write_nc3(tmp_path, 'good.nc')
     bad = tmp_path / 'garbage.nc'
     bad.write_bytes(b'this is not a netcdf file' * 100)
-    valid, dropped = validate_model_files(
+    valid, dropped, _ = validate_model_files(
         [good, str(bad)], 'netcdf4', 'time', 'stations', LOG)
     assert valid == [good]
     assert dropped[0][0] == str(bad)
@@ -104,7 +104,7 @@ def test_garbage_file_dropped(tmp_path):
 def test_truncated_netcdf3_dropped(tmp_path):
     good = _write_nc3(tmp_path, 'good.nc')
     bad = _truncate(_write_nc3(tmp_path, 'trunc.nc'), 0.4)
-    valid, dropped = validate_model_files(
+    valid, dropped, _ = validate_model_files(
         [good, bad], 'netcdf4', 'time', 'stations', LOG)
     assert valid == [good]
     assert dropped[0][0] == bad
@@ -113,7 +113,7 @@ def test_truncated_netcdf3_dropped(tmp_path):
 def test_truncated_hdf5_dropped(tmp_path):
     good = _write_nc4(tmp_path, 'good.nc')
     bad = _truncate(_write_nc4(tmp_path, 'trunc.nc'), 0.4)
-    valid, dropped = validate_model_files(
+    valid, dropped, _ = validate_model_files(
         [good, bad], 'h5netcdf', 'time', 'stations', LOG)
     assert valid == [good]
     assert dropped[0][0] == bad
@@ -122,7 +122,7 @@ def test_truncated_hdf5_dropped(tmp_path):
 def test_empty_time_dimension_dropped(tmp_path):
     good = _write_nc3(tmp_path, 'good.nc')
     bad = _write_nc3(tmp_path, 'notime.nc', ds=_stations_ds(n_time=0))
-    valid, dropped = validate_model_files(
+    valid, dropped, _ = validate_model_files(
         [good, bad], 'netcdf4', 'time', 'stations', LOG)
     assert valid == [good]
     assert "empty 'time'" in dropped[0][1]
@@ -134,7 +134,7 @@ def test_missing_time_dimension_dropped(tmp_path):
         {'h': (('station',), np.zeros(N_STATION))})
     bad = _write_nc3(tmp_path, 'static.nc', ds=static_only,
                      unlimited=False)
-    valid, dropped = validate_model_files(
+    valid, dropped, _ = validate_model_files(
         [good, bad], 'netcdf4', 'time', 'stations', LOG)
     assert valid == [good]
     assert "missing 'time'" in dropped[0][1]
@@ -151,7 +151,7 @@ def test_zero_filled_time_tail_dropped(tmp_path):
     tvals[N_TIME // 2:] = tvals[0]  # simulate the zero-filled tail
     ds = ds.assign_coords(time=tvals)
     bad = _write_nc3(tmp_path, 'zerofill.nc', ds=ds)
-    valid, dropped = validate_model_files(
+    valid, dropped, _ = validate_model_files(
         [good, bad], 'netcdf4', 'time', 'stations', LOG)
     assert valid == [good]
     assert 'not strictly increasing' in dropped[0][1]
@@ -165,7 +165,7 @@ def test_minority_siglay_mismatch_dropped(tmp_path):
     files = [_write_nc3(tmp_path, f'f{i}.nc') for i in range(3)]
     odd = _write_nc3(tmp_path, 'odd.nc',
                      ds=_stations_ds(n_siglay=N_SIGLAY + 2))
-    valid, dropped = validate_model_files(
+    valid, dropped, _ = validate_model_files(
         files + [odd], 'netcdf4', 'time', 'stations', LOG)
     assert valid == files
     assert dropped[0][0] == odd
@@ -178,7 +178,7 @@ def test_station_dim_mismatch_exempt_for_stations(tmp_path):
     files = [_write_nc3(tmp_path, f'f{i}.nc') for i in range(2)]
     fewer = _write_nc3(tmp_path, 'fewer.nc',
                        ds=_stations_ds(n_station=N_STATION - 4))
-    valid, dropped = validate_model_files(
+    valid, dropped, _ = validate_model_files(
         files + [fewer], 'netcdf4', 'time', 'stations', LOG)
     assert valid == files + [fewer]
     assert dropped == []
@@ -188,7 +188,7 @@ def test_station_dim_mismatch_dropped_for_fields(tmp_path):
     files = [_write_nc3(tmp_path, f'f{i}.nc') for i in range(2)]
     fewer = _write_nc3(tmp_path, 'fewer.nc',
                        ds=_stations_ds(n_station=N_STATION - 4))
-    valid, dropped = validate_model_files(
+    valid, dropped, _ = validate_model_files(
         files + [fewer], 'netcdf4', 'time', 'fields', LOG)
     assert valid == files
     assert dropped[0][0] == fewer
@@ -200,7 +200,7 @@ def test_differing_time_lengths_are_fine(tmp_path):
     full = _write_nc3(tmp_path, 'full.nc')
     short = _write_nc3(tmp_path, 'short.nc',
                        ds=_stations_ds(n_time=N_TIME // 3))
-    valid, dropped = validate_model_files(
+    valid, dropped, _ = validate_model_files(
         [full, short], 'netcdf4', 'time', 'stations', LOG)
     assert valid == [full, short]
     assert dropped == []
@@ -224,7 +224,7 @@ def test_remote_urls_pass_through(tmp_path):
     urls = ['https://noaa-nos-ofs-pds.s3.amazonaws.com/x.nc',
             'simplecache::https://noaa-nos-ofs-pds.s3.amazonaws.com/y.nc',
             's3://bucket/z.nc']
-    valid, dropped = validate_model_files(
+    valid, dropped, _ = validate_model_files(
         urls, 'h5netcdf', 'time', 'stations', LOG)
     assert valid == urls
     assert dropped == []
@@ -234,7 +234,7 @@ def test_mixed_remote_and_bad_local(tmp_path):
     url = 'https://noaa-nos-ofs-pds.s3.amazonaws.com/x.nc'
     bad = tmp_path / 'bad.nc'
     bad.write_bytes(b'garbage')
-    valid, dropped = validate_model_files(
+    valid, dropped, _ = validate_model_files(
         [url, str(bad)], 'netcdf4', 'time', 'stations', LOG)
     assert valid == [url]
     assert dropped[0][0] == str(bad)
@@ -245,9 +245,24 @@ def test_order_preserved_after_drop(tmp_path):
     bad = tmp_path / 'b.nc'
     bad.write_bytes(b'junk')
     f3 = _write_nc3(tmp_path, 'c.nc')
-    valid, _ = validate_model_files(
+    valid, _, _ = validate_model_files(
         [f1, str(bad), f3], 'netcdf4', 'time', 'stations', LOG)
     assert valid == [f1, f3]
+
+
+def test_dims_returned_for_surviving_local_files(tmp_path):
+    # Callers reuse the probed dimensions (e.g. the station-dimension
+    # compatibility check) instead of re-opening every file.
+    files = [_write_nc3(tmp_path, f'f{i}.nc') for i in range(2)]
+    url = 'https://noaa-nos-ofs-pds.s3.amazonaws.com/x.nc'
+    bad = tmp_path / 'bad.nc'
+    bad.write_bytes(b'junk')
+    valid, dropped, dims = validate_model_files(
+        files + [url, str(bad)], 'netcdf4', 'time', 'stations', LOG)
+    assert set(dims) == set(files)          # local survivors only
+    assert dims[files[0]]['station'] == N_STATION
+    assert dims[files[0]]['time'] == N_TIME
+    assert url in valid and str(bad) not in valid
 
 
 # ---------------------------------------------------------------------

--- a/tests/model_file_validation_test.py
+++ b/tests/model_file_validation_test.py
@@ -13,6 +13,7 @@ import pytest
 import xarray as xr
 
 from ofs_skill.model_processing.model_file_validation import (
+    scrub_cached_copies,
     validate_model_files,
 )
 
@@ -309,6 +310,51 @@ def test_dims_returned_for_surviving_local_files(tmp_path):
     assert dims[files[0]]['station'] == N_STATION
     assert dims[files[0]]['time'] == N_TIME
     assert url in valid and str(bad) not in valid
+
+
+# ---------------------------------------------------------------------
+# cache scrub (issues #176 / #193)
+# ---------------------------------------------------------------------
+
+BUCKET = 'https://noaa-nos-ofs-pds.s3.amazonaws.com/cbofs/netcdf'
+
+
+def test_scrub_removes_partial_cached_copy(tmp_path):
+    cache = tmp_path / 'cache'
+    cache.mkdir()
+    good = _write_nc3(cache, 'a.nc')
+    partial = _truncate(_write_nc3(cache, 'b.nc'), 0.4)
+    urls = [f'{BUCKET}/a.nc', f'{BUCKET}/b.nc', f'{BUCKET}/notcached.nc']
+    removed = scrub_cached_copies(urls, str(cache), 'time', LOG)
+    assert removed == 1
+    import os
+    assert os.path.isfile(good)          # healthy copy kept
+    assert not os.path.isfile(partial)   # partial copy deleted
+
+
+def test_scrub_handles_simplecache_prefix_and_local_entries(tmp_path):
+    cache = tmp_path / 'cache'
+    cache.mkdir()
+    partial = _truncate(_write_nc3(cache, 'c.nc'), 0.4)
+    local_file = _write_nc3(tmp_path, 'local.nc')
+    urls = [f'simplecache::{BUCKET}/c.nc', local_file]
+    removed = scrub_cached_copies(urls, str(cache), 'time', LOG)
+    assert removed == 1
+    import os
+    assert not os.path.isfile(partial)
+    # Local (non-remote) entries are never touched by the scrub.
+    assert os.path.isfile(local_file)
+
+
+def test_scrub_noop_when_cache_healthy(tmp_path):
+    cache = tmp_path / 'cache'
+    cache.mkdir()
+    good = _write_nc3(cache, 'a.nc')
+    removed = scrub_cached_copies(
+        [f'{BUCKET}/a.nc'], str(cache), 'time', LOG)
+    assert removed == 0
+    import os
+    assert os.path.isfile(good)
 
 
 # ---------------------------------------------------------------------

--- a/tests/model_file_validation_test.py
+++ b/tests/model_file_validation_test.py
@@ -1,0 +1,289 @@
+"""
+Tests for pre-open model file validation (model_file_validation.py,
+issue #194): unreadable, incomplete, or dimensionally inconsistent
+files must be dropped with a warning instead of crashing the
+multi-file open.
+"""
+
+import logging
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+import xarray as xr
+
+from ofs_skill.model_processing.model_file_validation import (
+    validate_model_files,
+)
+
+LOG = logging.getLogger('model_file_validation_test')
+
+N_TIME = 24
+N_STATION = 12
+N_SIGLAY = 4
+
+
+def _stations_ds(n_time=N_TIME, n_station=N_STATION, n_siglay=N_SIGLAY,
+                 t0='2026-05-14T00'):
+    n_siglev = n_siglay + 1
+    return xr.Dataset(
+        data_vars={
+            'h': (('station',),
+                  np.linspace(5.0, 30.0, n_station)),
+            'siglay': (('siglay', 'station'),
+                       np.zeros((n_siglay, n_station))),
+            'siglev': (('siglev', 'station'),
+                       np.zeros((n_siglev, n_station))),
+            'zeta': (('time', 'station'),
+                     np.random.default_rng(0).normal(
+                         0, 1, (n_time, n_station))),
+        },
+        coords={'time': np.datetime64(t0)
+                + np.arange(n_time) * np.timedelta64(6, 'm')},
+    )
+
+
+def _write_nc3(tmp_path, name, ds=None, unlimited=True):
+    ds = _stations_ds() if ds is None else ds
+    path = tmp_path / name
+    kwargs = {'format': 'NETCDF3_CLASSIC'}
+    if unlimited:
+        kwargs['unlimited_dims'] = ['time']
+    ds.to_netcdf(path, **kwargs)
+    return str(path)
+
+
+def _write_nc4(tmp_path, name, ds=None):
+    ds = _stations_ds() if ds is None else ds
+    path = tmp_path / name
+    ds.to_netcdf(path, format='NETCDF4')
+    return str(path)
+
+
+def _truncate(path, keep_fraction):
+    import os
+    size = os.path.getsize(path)
+    with open(path, 'r+b') as fp:
+        fp.truncate(int(size * keep_fraction))
+    return path
+
+
+# ---------------------------------------------------------------------
+# per-file checks
+# ---------------------------------------------------------------------
+
+def test_all_good_files_pass(tmp_path):
+    files = [_write_nc3(tmp_path, f'f{i}.nc') for i in range(3)]
+    valid, dropped = validate_model_files(
+        files, 'netcdf4', 'time', 'stations', LOG)
+    assert valid == files
+    assert dropped == []
+
+
+def test_zero_byte_file_dropped(tmp_path):
+    good = _write_nc3(tmp_path, 'good.nc')
+    bad = tmp_path / 'empty.nc'
+    bad.write_bytes(b'')
+    valid, dropped = validate_model_files(
+        [good, str(bad)], 'netcdf4', 'time', 'stations', LOG)
+    assert valid == [good]
+    assert len(dropped) == 1 and dropped[0][0] == str(bad)
+    assert 'unreadable' in dropped[0][1]
+
+
+def test_garbage_file_dropped(tmp_path):
+    good = _write_nc3(tmp_path, 'good.nc')
+    bad = tmp_path / 'garbage.nc'
+    bad.write_bytes(b'this is not a netcdf file' * 100)
+    valid, dropped = validate_model_files(
+        [good, str(bad)], 'netcdf4', 'time', 'stations', LOG)
+    assert valid == [good]
+    assert dropped[0][0] == str(bad)
+
+
+def test_truncated_netcdf3_dropped(tmp_path):
+    good = _write_nc3(tmp_path, 'good.nc')
+    bad = _truncate(_write_nc3(tmp_path, 'trunc.nc'), 0.4)
+    valid, dropped = validate_model_files(
+        [good, bad], 'netcdf4', 'time', 'stations', LOG)
+    assert valid == [good]
+    assert dropped[0][0] == bad
+
+
+def test_truncated_hdf5_dropped(tmp_path):
+    good = _write_nc4(tmp_path, 'good.nc')
+    bad = _truncate(_write_nc4(tmp_path, 'trunc.nc'), 0.4)
+    valid, dropped = validate_model_files(
+        [good, bad], 'h5netcdf', 'time', 'stations', LOG)
+    assert valid == [good]
+    assert dropped[0][0] == bad
+
+
+def test_empty_time_dimension_dropped(tmp_path):
+    good = _write_nc3(tmp_path, 'good.nc')
+    bad = _write_nc3(tmp_path, 'notime.nc', ds=_stations_ds(n_time=0))
+    valid, dropped = validate_model_files(
+        [good, bad], 'netcdf4', 'time', 'stations', LOG)
+    assert valid == [good]
+    assert "empty 'time'" in dropped[0][1]
+
+
+def test_missing_time_dimension_dropped(tmp_path):
+    good = _write_nc3(tmp_path, 'good.nc')
+    static_only = xr.Dataset(
+        {'h': (('station',), np.zeros(N_STATION))})
+    bad = _write_nc3(tmp_path, 'static.nc', ds=static_only,
+                     unlimited=False)
+    valid, dropped = validate_model_files(
+        [good, bad], 'netcdf4', 'time', 'stations', LOG)
+    assert valid == [good]
+    assert "missing 'time'" in dropped[0][1]
+
+
+def test_zero_filled_time_tail_dropped(tmp_path):
+    # The actual issue #194 signature: libnetCDF silently zero-fills
+    # NetCDF-3 reads past EOF, so a truncated file reads back with a
+    # zeroed time tail instead of raising. The strictly-increasing
+    # check must reject it.
+    good = _write_nc3(tmp_path, 'good.nc')
+    ds = _stations_ds()
+    tvals = ds['time'].values.copy()
+    tvals[N_TIME // 2:] = tvals[0]  # simulate the zero-filled tail
+    ds = ds.assign_coords(time=tvals)
+    bad = _write_nc3(tmp_path, 'zerofill.nc', ds=ds)
+    valid, dropped = validate_model_files(
+        [good, bad], 'netcdf4', 'time', 'stations', LOG)
+    assert valid == [good]
+    assert 'not strictly increasing' in dropped[0][1]
+
+
+# ---------------------------------------------------------------------
+# batch consistency
+# ---------------------------------------------------------------------
+
+def test_minority_siglay_mismatch_dropped(tmp_path):
+    files = [_write_nc3(tmp_path, f'f{i}.nc') for i in range(3)]
+    odd = _write_nc3(tmp_path, 'odd.nc',
+                     ds=_stations_ds(n_siglay=N_SIGLAY + 2))
+    valid, dropped = validate_model_files(
+        files + [odd], 'netcdf4', 'time', 'stations', LOG)
+    assert valid == files
+    assert dropped[0][0] == odd
+    assert 'dimension mismatch' in dropped[0][1]
+
+
+def test_station_dim_mismatch_exempt_for_stations(tmp_path):
+    # Differing station counts are legitimate for stations files and
+    # handled downstream by remove_extra_stations — must NOT be dropped.
+    files = [_write_nc3(tmp_path, f'f{i}.nc') for i in range(2)]
+    fewer = _write_nc3(tmp_path, 'fewer.nc',
+                       ds=_stations_ds(n_station=N_STATION - 4))
+    valid, dropped = validate_model_files(
+        files + [fewer], 'netcdf4', 'time', 'stations', LOG)
+    assert valid == files + [fewer]
+    assert dropped == []
+
+
+def test_station_dim_mismatch_dropped_for_fields(tmp_path):
+    files = [_write_nc3(tmp_path, f'f{i}.nc') for i in range(2)]
+    fewer = _write_nc3(tmp_path, 'fewer.nc',
+                       ds=_stations_ds(n_station=N_STATION - 4))
+    valid, dropped = validate_model_files(
+        files + [fewer], 'netcdf4', 'time', 'fields', LOG)
+    assert valid == files
+    assert dropped[0][0] == fewer
+
+
+def test_differing_time_lengths_are_fine(tmp_path):
+    # Time is the concat dim — an incomplete-but-readable forecast with
+    # fewer steps is usable data and must be kept.
+    full = _write_nc3(tmp_path, 'full.nc')
+    short = _write_nc3(tmp_path, 'short.nc',
+                       ds=_stations_ds(n_time=N_TIME // 3))
+    valid, dropped = validate_model_files(
+        [full, short], 'netcdf4', 'time', 'stations', LOG)
+    assert valid == [full, short]
+    assert dropped == []
+
+
+# ---------------------------------------------------------------------
+# batch-level behavior
+# ---------------------------------------------------------------------
+
+def test_all_files_bad_raises_system_exit(tmp_path):
+    bad1 = tmp_path / 'a.nc'
+    bad1.write_bytes(b'nope')
+    bad2 = tmp_path / 'b.nc'
+    bad2.write_bytes(b'')
+    with pytest.raises(SystemExit):
+        validate_model_files(
+            [str(bad1), str(bad2)], 'netcdf4', 'time', 'stations', LOG)
+
+
+def test_remote_urls_pass_through(tmp_path):
+    urls = ['https://noaa-nos-ofs-pds.s3.amazonaws.com/x.nc',
+            'simplecache::https://noaa-nos-ofs-pds.s3.amazonaws.com/y.nc',
+            's3://bucket/z.nc']
+    valid, dropped = validate_model_files(
+        urls, 'h5netcdf', 'time', 'stations', LOG)
+    assert valid == urls
+    assert dropped == []
+
+
+def test_mixed_remote_and_bad_local(tmp_path):
+    url = 'https://noaa-nos-ofs-pds.s3.amazonaws.com/x.nc'
+    bad = tmp_path / 'bad.nc'
+    bad.write_bytes(b'garbage')
+    valid, dropped = validate_model_files(
+        [url, str(bad)], 'netcdf4', 'time', 'stations', LOG)
+    assert valid == [url]
+    assert dropped[0][0] == str(bad)
+
+
+def test_order_preserved_after_drop(tmp_path):
+    f1 = _write_nc3(tmp_path, 'a.nc')
+    bad = tmp_path / 'b.nc'
+    bad.write_bytes(b'junk')
+    f3 = _write_nc3(tmp_path, 'c.nc')
+    valid, _ = validate_model_files(
+        [f1, str(bad), f3], 'netcdf4', 'time', 'stations', LOG)
+    assert valid == [f1, f3]
+
+
+# ---------------------------------------------------------------------
+# integration: intake_model survives a corrupt file in the batch
+# ---------------------------------------------------------------------
+
+def test_intake_model_drops_corrupt_file_and_continues(tmp_path):
+    from ofs_skill.model_processing.intake_scisa import intake_model
+
+    good1 = _write_nc3(tmp_path, 'necofs.t00z.stations.nowcast.nc',
+                       ds=_stations_ds(t0='2026-05-14T00'))
+    good2 = _write_nc3(tmp_path, 'necofs.t06z.stations.nowcast.nc',
+                       ds=_stations_ds(t0='2026-05-14T02:24'))
+    bad = _truncate(
+        _write_nc3(tmp_path, 'necofs.t12z.stations.nowcast.nc',
+                   ds=_stations_ds(t0='2026-05-14T04:48')), 0.4)
+
+    prop = SimpleNamespace(ofs='necofs', model_source='fvcom',
+                           ofsfiletype='stations', whichcast='nowcast',
+                           config_file=None)
+    ds = intake_model([good1, good2, bad], prop, LOG)
+
+    # The two good files supply 2 * N_TIME unique timesteps; the
+    # corrupt third file is dropped rather than crashing the open.
+    assert ds.sizes['time'] == 2 * N_TIME
+    assert prop.netcdf_engine == 'netcdf4'
+    ds.close()
+
+
+def test_intake_model_exits_when_all_files_corrupt(tmp_path):
+    from ofs_skill.model_processing.intake_scisa import intake_model
+
+    bad1 = _truncate(_write_nc3(tmp_path, 'a.nc'), 0.3)
+    bad2 = _truncate(_write_nc3(tmp_path, 'b.nc'), 0.3)
+    prop = SimpleNamespace(ofs='necofs', model_source='fvcom',
+                           ofsfiletype='stations', whichcast='nowcast',
+                           config_file=None)
+    with pytest.raises(SystemExit):
+        intake_model([bad1, bad2], prop, LOG)

--- a/tests/model_file_validation_test.py
+++ b/tests/model_file_validation_test.py
@@ -206,6 +206,52 @@ def test_differing_time_lengths_are_fine(tmp_path):
     assert dropped == []
 
 
+def test_static_metadata_minority_dropped(tmp_path):
+    # Same dims everywhere, but one file carries different static
+    # values (e.g. relocated stations after a model update) — the
+    # exact case behind "MergeError: conflicting values for variable
+    # 'x'" on multi-month runs. The minority deployment is dropped.
+    files = [_write_nc3(tmp_path, f'f{i}.nc') for i in range(3)]
+    ds = _stations_ds()
+    ds['h'] = (('station',), np.linspace(6.0, 31.0, N_STATION))
+    moved = _write_nc3(tmp_path, 'moved.nc', ds=ds)
+    valid, dropped, _ = validate_model_files(
+        files + [moved], 'netcdf4', 'time', 'stations', LOG)
+    assert valid == files
+    assert dropped[0][0] == moved
+    assert 'static station metadata' in dropped[0][1]
+
+
+def test_static_metadata_no_majority_warns_but_keeps(tmp_path, caplog):
+    # Every file differs (no clear majority): don't guess — keep all
+    # files and warn that the combine may fail.
+    files = []
+    for i in range(3):
+        ds = _stations_ds()
+        ds['h'] = (('station',),
+                   np.linspace(5.0 + i, 30.0 + i, N_STATION))
+        files.append(_write_nc3(tmp_path, f'f{i}.nc', ds=ds))
+    with caplog.at_level(logging.WARNING):
+        valid, dropped, _ = validate_model_files(
+            files, 'netcdf4', 'time', 'stations', LOG)
+    assert valid == files
+    assert dropped == []
+    assert any('no clear majority' in r.message for r in caplog.records)
+
+
+def test_static_metadata_not_checked_for_fields(tmp_path):
+    # Fields batches are combined differently; the fingerprint check
+    # only applies to stations files.
+    files = [_write_nc3(tmp_path, f'f{i}.nc') for i in range(2)]
+    ds = _stations_ds()
+    ds['h'] = (('station',), np.linspace(6.0, 31.0, N_STATION))
+    moved = _write_nc3(tmp_path, 'moved.nc', ds=ds)
+    valid, dropped, _ = validate_model_files(
+        files + [moved], 'netcdf4', 'time', 'fields', LOG)
+    assert valid == files + [moved]
+    assert dropped == []
+
+
 # ---------------------------------------------------------------------
 # batch-level behavior
 # ---------------------------------------------------------------------

--- a/tests/netcdf_engine_test.py
+++ b/tests/netcdf_engine_test.py
@@ -1,0 +1,317 @@
+"""
+Tests for netCDF engine detection (netcdf_engine.py) and the
+engine-aware extraction guard (get_node_ofs._extract_guard).
+
+Covers:
+- magic-byte format sniffing for local files (all NetCDF magics, HDF5
+  superblock at nonzero offsets, unreadable/garbage files)
+- engine resolution under engine_strategy=auto/netcdf4/h5netcdf,
+  including the historical scipy special cases (stofs_2d_glo, custom
+  free-run station files)
+- the extraction guard: thread-unsafe engines fully serialized,
+  h5netcdf bounded by parallel_extract_slots
+- parallel_extract_slots config parsing
+"""
+
+import threading
+from types import SimpleNamespace
+
+import pytest
+
+from ofs_skill.model_processing import netcdf_engine
+from ofs_skill.model_processing.get_node_ofs import _extract_guard
+from ofs_skill.model_processing.netcdf_engine import (
+    FORMAT_HDF5,
+    FORMAT_NETCDF3,
+    FORMAT_UNKNOWN,
+    get_engine_strategy,
+    resolve_engine,
+    sniff_netcdf_format,
+)
+from ofs_skill.obs_retrieval.utils import get_parallel_config
+
+HDF5_MAGIC = b'\x89HDF\r\n\x1a\n'
+
+
+@pytest.fixture(autouse=True)
+def _clear_sniff_cache():
+    with netcdf_engine._SNIFF_CACHE_LOCK:
+        netcdf_engine._SNIFF_CACHE.clear()
+    yield
+    with netcdf_engine._SNIFF_CACHE_LOCK:
+        netcdf_engine._SNIFF_CACHE.clear()
+
+
+def _write(tmp_path, name, payload):
+    path = tmp_path / name
+    path.write_bytes(payload)
+    return str(path)
+
+
+# ---------------------------------------------------------------------
+# sniff_netcdf_format
+# ---------------------------------------------------------------------
+
+def test_sniff_hdf5(tmp_path):
+    path = _write(tmp_path, 'a.nc', HDF5_MAGIC + b'\x00' * 16)
+    assert sniff_netcdf_format(path) == FORMAT_HDF5
+
+
+@pytest.mark.parametrize('magic', [b'CDF\x01', b'CDF\x02', b'CDF\x05'])
+def test_sniff_netcdf3_variants(tmp_path, magic):
+    path = _write(tmp_path, 'a.nc', magic + b'\x00' * 16)
+    assert sniff_netcdf_format(path) == FORMAT_NETCDF3
+
+
+def test_sniff_hdf5_superblock_at_offset(tmp_path):
+    # The HDF5 spec allows the superblock at offsets 512 << n.
+    path = _write(tmp_path, 'a.nc', b'\x00' * 512 + HDF5_MAGIC)
+    assert sniff_netcdf_format(path) == FORMAT_HDF5
+
+
+def test_sniff_garbage_is_unknown(tmp_path):
+    path = _write(tmp_path, 'a.nc', b'not a netcdf file at all')
+    assert sniff_netcdf_format(path) == FORMAT_UNKNOWN
+
+
+def test_sniff_missing_file_is_unknown(tmp_path):
+    assert sniff_netcdf_format(str(tmp_path / 'nope.nc')) == FORMAT_UNKNOWN
+
+
+def test_sniff_non_string_is_unknown():
+    assert sniff_netcdf_format(None) == FORMAT_UNKNOWN
+    assert sniff_netcdf_format(42) == FORMAT_UNKNOWN
+
+
+def test_sniff_strips_fsspec_protocol_chain(tmp_path):
+    path = _write(tmp_path, 'a.nc', HDF5_MAGIC + b'\x00' * 16)
+    assert sniff_netcdf_format(f'simplecache::{path}') == FORMAT_HDF5
+
+
+def test_sniff_result_is_cached(tmp_path):
+    path = _write(tmp_path, 'a.nc', HDF5_MAGIC + b'\x00' * 16)
+    assert sniff_netcdf_format(path) == FORMAT_HDF5
+    # Rewrite the file; the cached classification must win (one sniff
+    # per path per run).
+    (tmp_path / 'a.nc').write_bytes(b'CDF\x01' + b'\x00' * 16)
+    assert sniff_netcdf_format(path) == FORMAT_HDF5
+
+
+def test_sniff_failure_is_not_cached(tmp_path):
+    path = str(tmp_path / 'late.nc')
+    assert sniff_netcdf_format(path) == FORMAT_UNKNOWN
+    (tmp_path / 'late.nc').write_bytes(HDF5_MAGIC + b'\x00' * 16)
+    assert sniff_netcdf_format(path) == FORMAT_HDF5
+
+
+# ---------------------------------------------------------------------
+# get_engine_strategy / resolve_engine
+# ---------------------------------------------------------------------
+
+def _conf_with_strategy(tmp_path, strategy=None):
+    conf = tmp_path / 'ofs_dps.conf'
+    lines = ['[settings]']
+    if strategy is not None:
+        lines.append(f'engine_strategy={strategy}')
+    conf.write_text('\n'.join(lines) + '\n', encoding='utf-8')
+    return str(conf)
+
+
+def _prop(tmp_path, ofs='cbofs', strategy=None):
+    return SimpleNamespace(
+        ofs=ofs, config_file=_conf_with_strategy(tmp_path, strategy))
+
+
+def test_engine_strategy_default_is_auto(tmp_path):
+    assert get_engine_strategy(_conf_with_strategy(tmp_path)) == 'auto'
+
+
+@pytest.mark.parametrize('strategy', ['auto', 'netcdf4', 'h5netcdf'])
+def test_engine_strategy_reads_config(tmp_path, strategy):
+    conf = _conf_with_strategy(tmp_path, strategy)
+    assert get_engine_strategy(conf) == strategy
+
+
+def test_engine_strategy_invalid_falls_back_to_auto(tmp_path):
+    conf = _conf_with_strategy(tmp_path, 'pydap')
+    assert get_engine_strategy(conf) == 'auto'
+
+
+def test_resolve_all_hdf5_uses_h5netcdf(tmp_path, caplog):
+    import logging
+    files = [_write(tmp_path, f'f{i}.nc', HDF5_MAGIC + b'\x00' * 16)
+             for i in range(3)]
+    engine = resolve_engine(files, _prop(tmp_path),
+                            logging.getLogger('test'))
+    assert engine == 'h5netcdf'
+
+
+def test_resolve_netcdf3_uses_netcdf4(tmp_path):
+    import logging
+    files = [_write(tmp_path, f'f{i}.nc', b'CDF\x02' + b'\x00' * 16)
+             for i in range(2)]
+    engine = resolve_engine(files, _prop(tmp_path, ofs='necofs'),
+                            logging.getLogger('test'))
+    assert engine == 'netcdf4'
+
+
+def test_resolve_mixed_formats_uses_netcdf4(tmp_path):
+    import logging
+    files = [
+        _write(tmp_path, 'a.nc', HDF5_MAGIC + b'\x00' * 16),
+        _write(tmp_path, 'b.nc', b'CDF\x01' + b'\x00' * 16),
+    ]
+    engine = resolve_engine(files, _prop(tmp_path),
+                            logging.getLogger('test'))
+    assert engine == 'netcdf4'
+
+
+def test_resolve_unknown_format_uses_netcdf4(tmp_path):
+    import logging
+    files = [_write(tmp_path, 'a.nc', b'garbage bytes here!')]
+    engine = resolve_engine(files, _prop(tmp_path),
+                            logging.getLogger('test'))
+    assert engine == 'netcdf4'
+
+
+def test_resolve_stofs2d_netcdf3_uses_scipy(tmp_path):
+    import logging
+    files = [_write(tmp_path, 'points.cwl.nc', b'CDF\x01' + b'\x00' * 16)]
+    engine = resolve_engine(files, _prop(tmp_path, ofs='stofs_2d_glo'),
+                            logging.getLogger('test'))
+    assert engine == 'scipy'
+
+
+def test_resolve_stofs2d_hdf5_uses_h5netcdf(tmp_path):
+    # stofs_2d_glo fields files are HDF5 — the scipy special case only
+    # applies when the batch actually contains NetCDF-3 files.
+    import logging
+    files = [_write(tmp_path, 'fields.cwl.nc', HDF5_MAGIC + b'\x00' * 16)]
+    engine = resolve_engine(files, _prop(tmp_path, ofs='stofs_2d_glo'),
+                            logging.getLogger('test'))
+    assert engine == 'h5netcdf'
+
+
+def test_resolve_custom_marker_uses_scipy(tmp_path):
+    import logging
+    files = [_write(tmp_path, 'necofs_2017_free_run_station.nc',
+                    b'CDF\x01' + b'\x00' * 16)]
+    engine = resolve_engine(files, _prop(tmp_path, ofs='necofs'),
+                            logging.getLogger('test'))
+    assert engine == 'scipy'
+
+
+@pytest.mark.parametrize('strategy', ['netcdf4', 'h5netcdf'])
+def test_resolve_forced_strategy_skips_detection(tmp_path, strategy):
+    import logging
+    # Files deliberately do not exist: a forced strategy must not sniff.
+    files = [str(tmp_path / 'missing.nc')]
+    engine = resolve_engine(files, _prop(tmp_path, strategy=strategy),
+                            logging.getLogger('test'))
+    assert engine == strategy
+
+
+def test_resolve_empty_batch_uses_netcdf4(tmp_path):
+    import logging
+    assert resolve_engine([], _prop(tmp_path),
+                          logging.getLogger('test')) == 'netcdf4'
+
+
+def test_resolve_samples_large_batches(tmp_path, monkeypatch):
+    import logging
+    sniffed = []
+    real_sniff = netcdf_engine.sniff_netcdf_format
+
+    def counting_sniff(path, logger=None):
+        sniffed.append(path)
+        return real_sniff(path, logger)
+
+    monkeypatch.setattr(netcdf_engine, 'sniff_netcdf_format', counting_sniff)
+    files = [_write(tmp_path, f'f{i:03d}.nc', HDF5_MAGIC + b'\x00' * 16)
+             for i in range(100)]
+    engine = resolve_engine(files, _prop(tmp_path),
+                            logging.getLogger('test'))
+    assert engine == 'h5netcdf'
+    assert len(sniffed) <= netcdf_engine._MAX_SNIFFS_PER_BATCH
+    # First and last files must always be sampled.
+    assert files[0] in sniffed and files[-1] in sniffed
+
+
+# ---------------------------------------------------------------------
+# _extract_guard
+# ---------------------------------------------------------------------
+
+def _capacity(guard):
+    """Count how many times a semaphore can be acquired right now."""
+    acquired = 0
+    while guard.acquire(blocking=False):
+        acquired += 1
+    for _ in range(acquired):
+        guard.release()
+    return acquired
+
+
+@pytest.mark.parametrize('engine', [None, 'netcdf4', 'scipy'])
+def test_guard_serializes_thread_unsafe_engines(engine):
+    assert _capacity(_extract_guard(engine, slots=4)) == 1
+
+
+def test_guard_h5netcdf_uses_configured_slots():
+    assert _capacity(_extract_guard('h5netcdf', slots=3)) == 3
+
+
+def test_guard_h5netcdf_invalid_slots_default_to_two():
+    assert _capacity(_extract_guard('h5netcdf', slots=None)) == 2
+    assert _capacity(_extract_guard('h5netcdf', slots='bogus')) == 2
+
+
+def test_guard_is_shared_across_calls():
+    # Same slot count must return the same semaphore instance, so all
+    # variable threads contend on one guard.
+    assert _extract_guard('h5netcdf', 2) is _extract_guard('h5netcdf', 2)
+    assert _extract_guard('netcdf4', 5) is _extract_guard(None, 3)
+
+
+def test_guard_is_a_context_manager():
+    guard = _extract_guard('h5netcdf', 2)
+    with guard:
+        pass
+    assert isinstance(guard, type(threading.BoundedSemaphore()))
+
+
+# ---------------------------------------------------------------------
+# parallel_extract_slots config parsing
+# ---------------------------------------------------------------------
+
+def _parallel_conf(tmp_path, body):
+    conf = tmp_path / 'ofs_dps.conf'
+    conf.write_text('[parallelization]\n' + body, encoding='utf-8')
+    return str(conf)
+
+
+def test_extract_slots_default():
+    assert get_parallel_config()['parallel_extract_slots'] >= 1
+
+
+def test_extract_slots_from_config(tmp_path):
+    conf = _parallel_conf(tmp_path, 'parallel_extract_slots=4\n')
+    assert get_parallel_config(config_file=conf)['parallel_extract_slots'] == 4
+
+
+def test_extract_slots_clamped(tmp_path):
+    conf = _parallel_conf(tmp_path, 'parallel_extract_slots=99\n')
+    assert get_parallel_config(config_file=conf)['parallel_extract_slots'] == 8
+    conf2 = _parallel_conf(tmp_path, 'parallel_extract_slots=0\n')
+    assert get_parallel_config(
+        config_file=conf2)['parallel_extract_slots'] == 1
+
+
+def test_extract_slots_invalid_keeps_default(tmp_path):
+    conf = _parallel_conf(tmp_path, 'parallel_extract_slots=lots\n')
+    assert get_parallel_config(config_file=conf)['parallel_extract_slots'] == 2
+
+
+def test_extract_slots_forced_serial_when_parallel_disabled(tmp_path):
+    conf = _parallel_conf(
+        tmp_path, 'parallel_enabled=False\nparallel_extract_slots=4\n')
+    assert get_parallel_config(config_file=conf)['parallel_extract_slots'] == 1


### PR DESCRIPTION
### Description of Changes

Closes #167. Closes #194. Closes #176. Closes #193.

**Engine selection by format detection (#167).** Model files are now opened with an xarray engine chosen by detecting each batch's on-disk netCDF format from its magic bytes (new `netcdf_engine.py`), replacing the hardcoded per-OFS list in `intake_scisa.py`. NetCDF-4/HDF5 batches use the thread-safe `h5netcdf` engine; NetCDF-3 batches use `netcdf4` (or `scipy` for the historical stofs_2d_glo / custom free-run special cases). The Phase 1 investigation on #167 (format inventory of every OFS on NODD + bit-for-bit per-engine value diffs) established that formats vary per OFS, per file type (stofs_2d_glo stations are NetCDF-3 while its fields are HDF5), and per archive era, so detection is more robust than any static list. Detection also fixes a latent bug where stofs_2d_glo fields files (HDF5) were assigned the scipy engine, which cannot read HDF5.

With the engine known, the unconditional `_BATCH_EXTRACT_LOCK` around `dask.compute()` in `get_node_ofs.py` becomes an engine-aware guard: thread-unsafe engines (netcdf4/scipy) stay fully serialized, while h5netcdf reads run under a bounded semaphore (`parallel_extract_slots`, default 2) so variable threads genuinely overlap on extraction while peak memory stays capped. This is the change that lets `parallel_variables=True` produce real wall-time gains on HDF5 OFS — the lock previously serialized the expensive compute for every OFS regardless of engine.

**Pre-open model file validation (#194).** Multi-month NECOFS runs were failing on files left behind by a forecast interruption. Investigating surfaced two distinct failure modes, both now handled by a new validation pass (`model_file_validation.py`) that probes every local file before the multi-file open:

1. *Silently truncated NetCDF-3 files*: libnetCDF zero-fills reads past EOF without erroring, so a truncated file opens cleanly and returns zeros for the missing records — including time values of 0, which later produce duplicate/non-monotonic timestamps that break resampling (and quietly poison water levels before that). Detection: the time axis must be strictly increasing; since time is a record variable, any truncation deep enough to lose data corrupts its tail.
2. *Static metadata changes mid-window*: files written after a model configuration change carry different static values (station x/y, names, sigma levels) with identical dimensions, and `data_vars='minimal'` concat dies with `MergeError: conflicting values for variable 'x'`. Detection: each stations file's small static variables are fingerprinted (md5 of raw values, a few KB per file) and files disagreeing with the batch majority are dropped — only when station counts are uniform (differing counts remain the legitimate `remove_extra_stations` path) and a clear majority exists.

Unreadable files (zero-byte, garbage, truncated HDF5), files missing the time dimension or with zero time steps, and files whose non-time dimensions disagree with the batch majority are also dropped. Every drop logs a WARNING naming the file and the specific reason, plus a summary count; the run continues on the surviving files, and exits with a clear error only if nothing survives. The probes are lightweight `netCDF4.Dataset` header reads (deliberately serial — concurrent `netCDF4.Dataset` open/close races libnetCDF's global file table), with progress logging every 50 files, and the probed dimensions are reused for the station-dimension compatibility check so `get_station_dim` no longer re-opens every file on all-local batches. On a 454-file NECOFS run on slow archive storage this removed ~47 minutes of pre-open file scanning.

**Partial-cache scrub (#176, #193).** A run killed during the model-loading phase can leave a partially downloaded file in the fsspec cache (`~/.ofs_cache/s3/`); subsequent runs trust the cache as-is, and the partial file surfaces as an unrelated-looking crash — `ValueError: buffer size must be a multiple of element size`, or the same `MergeError` as above (a truncated NetCDF-3 file zero-fills its static coordinates). Before either cache path is used, existing cached copies of the requested remote files now get the same integrity probe as archive files, and failures are deleted with a warning so fsspec transparently re-downloads them — unlike archive files, a cached copy is safely re-downloadable, so removal (not exclusion) is the right remedy. The mixed local+remote download path also now writes to a `.part` temp name and renames on completion, so an interrupted download can no longer leave a partial file at the final cache name. If the partial-cache `ValueError` somehow still surfaces, the log now explains what happened and that clearing `~/.ofs_cache/s3/` resolves it, instead of leaving a bare numpy error.

Two new optional config keys, documented in `conf/ofs_dps.conf.example` (existing conf files work unchanged):
- `[settings] engine_strategy = auto | netcdf4 | h5netcdf` (default `auto` = per-batch detection; explicit values force an engine for debugging/rollback)
- `[parallelization] parallel_extract_slots = N` (1–8, default 2; only takes effect under h5netcdf)

Labels: bug, enhancement.

### Expected Outcome of Changes

- Output values are unchanged: a 1-day cbofs stations assessment (wl/temp/salt, nowcast) produced bit-for-bit identical `.prd` and skill files against `main`. The Phase 1 value diff also confirmed netcdf4 and h5netcdf read all tested production HDF5 files identically (ROMS/FVCOM/SCHISM/ADCIRC, stations and fields, up to 1 GB).
- Runs that previously crashed (or silently ingested zeros) on incomplete/corrupt/mixed-configuration model files now complete, with per-file WARNINGs identifying exactly which files were excluded and why.
- With `parallel_variables=True` on HDF5 OFS, extraction now overlaps across variable threads (up to `parallel_extract_slots` concurrent computes) instead of being fully serialized.
- Multi-month runs with many local files start noticeably faster (validation probes replace two full per-file xarray open passes).

### Developer Questions and Checklist

**Is this a high priority PR? If yes, why and is there a date by which it needs to be merged?**
Moderately — it unblocks the multi-month NECOFS user runs from #194 (v1.8 milestone). No hard deadline.

**Are there any changes needed to how the code should be run for operational runs? (Commands, flags, job timings, etc.)**
No. Defaults preserve current behavior; the two new conf keys are optional.

**Does this update need to be deployed for operational runs?**
Yes — it fixes crash/data-poisoning modes on imperfect model archives and improves start-up and extraction times.

**Does this update require front end/web app changes? (If yes, provide documentation to Min)**
No.

**Does this impact code development work on adding SCHISM?**
Minor: SCHISM OFS engines are now auto-detected instead of hardcoded (loofs2/secofs were forced to netcdf4; STOFS-3D detection picks h5netcdf, which the value diff showed reads identically). No interface changes. Happy to walk the SCHISM devs through it if desired.

**Does this impact code development work on adding ADCIRC?**
Minor: stofs_2d_glo stations correctly resolve to the scipy engine as before (its points files are NetCDF-3), and its fields files now get a readable engine (h5netcdf) instead of the scipy engine that could not open them.

**Does this impact the expected number of output files for integration tests (i.e., will the integration test fail even though code changes result in desired change in outputs?)**
No — with healthy input files, outputs are identical (verified bit-for-bit for cbofs). Output counts change only when the input archive contains bad files, which previously crashed the run entirely.

- [x] Developer's name is removed throughout the code?
- [x] Did you add relevant labels to the PR?
- [x] Have you run pylint and is the code at an acceptable pylint score (>8)? (8.97 on the changed modules)
- [x] Jobs contain the appropriate file checking and handle errors for any missing data?
- [x] Is log free of critical ERRORs or WARNINGs? For errors that are not critical and can remain in code, is there sufficient handling and logging?

### Testing Instructions

Unit tests: `python -m pytest tests/` — 825 pass, including 60+ new tests in `tests/netcdf_engine_test.py` and `tests/model_file_validation_test.py` (format sniffing, engine resolution and forcing, extraction-guard behavior, and every validation drop reason including an `intake_model` integration with a truncated file in the batch).

End-to-end, HDF5 path (streams from NODD):
```
python bin/visualization/create_1dplot.py -o cbofs -p <workdir> -s 2026-07-06T00:00:00Z -e 2026-07-06T23:00:00Z -d MLLW -ws nowcast -t stations -vs water_level,water_temperature,salinity -so co-ops -c <conf>
```
Expect `Detected netCDF format(s) ['hdf5'] ... using engine 'h5netcdf'` in the log and normal outputs under `data/`. Re-running the same window on `main` and diffing `data/model/1d_node/*.prd` should show no differences.

End-to-end, NetCDF-3 path (local NECOFS archive, e.g. `example_data/necofs/netcdf/2026/02/18/` populated with the four nowcast stations files from NODD):
```
python bin/visualization/create_1dplot.py -o necofs -p <workdir> -s 2026-02-18T00:00:00Z -e 2026-02-18T23:00:00Z -d navd88 -ws nowcast -vs water_level,water_temperature -so co-ops -c <conf>
```
Expect `Detected netCDF format(s) ['netcdf3'] ... using engine 'netcdf4'` and the `Validating N local model file(s)` progress lines.

Issue #194 behavior: truncate one of the local NECOFS files (`truncate -s 40% <file>` on a copy) and re-run. Expect a WARNING naming the file (`time axis not strictly increasing at step N — zero-filled or truncated file?`), a `Dropped 1 of 4 ... continuing` summary, and a completed run. On `main` the same corrupted archive is ingested silently with zeroed water levels.

Engine forcing/rollback: set `engine_strategy=netcdf4` (or `h5netcdf`) in `[settings]` and confirm the log line `engine_strategy=... forced from config`; forcing h5netcdf on a NECOFS file exercises the automatic retry (`h5netcdf could not open the batch ... retrying with engine='netcdf4'`).

Issues #176/#193 behavior (partial cached file): after a NODD-streamed stations run has populated `~/.ofs_cache/s3/`, truncate one cached file (`truncate -s 40% ~/.ofs_cache/s3/<file>.nc`) and re-run the same window. Expect `Removed bad cached copy ... it will be re-downloaded. A previous run was likely interrupted while downloading it.`, a fresh download of that file, and a successful run — previously this crashed with `ValueError: buffer size must be a multiple of element size` or a MergeError.

### Reminder checklist for PR reviewer
_Checklist for the assigned reviewer to consult and check off_
- [x] Run PEP8 compliance tests to ensure the code follows best practices
- [x] Check that documentation in the script is sufficient
- [x] Validate the output values (if applicable) to make sure the calculations are correct and make scientific/physical sense; include a comment on the pull request including what validation you performed, for replicability.
- [x] Test code both on Windows and Linux (and MacOS, if available), using several OFS as test cases
- [x] **Test for all ‘cast’ options: forecast_a, forecast_b, and nowcast**
- [x] When approving or commenting on a pull request, add information on the calls you use in case they need to be replicated or referenced.
