### PR TITLE
Increase search radius for finding model stations in `indexing.py`

### DIFF
--- a/src/ofs_skill/model_processing/indexing.py
+++ b/src/ofs_skill/model_processing/indexing.py
@@ -877,7 +877,7 @@ def index_nearest_station(
     Uses a maximum distance threshold of 2 km.
     Stations beyond this threshold are marked as NaN.
     """
-    max_dist = 2.0  # km - cutoff for distance matching
+    max_dist = 4.0  # km - cutoff for distance matching
     index_min_dist = []
     min_dist = []
 

--- a/src/ofs_skill/model_processing/indexing.py
+++ b/src/ofs_skill/model_processing/indexing.py
@@ -874,7 +874,7 @@ def index_nearest_station(
 
     Notes
     -----
-    Uses a maximum distance threshold of 2 km.
+    Uses a maximum distance threshold of 4 km.
     Stations beyond this threshold are marked as NaN.
     """
     max_dist = 4.0  # km - cutoff for distance matching


### PR DESCRIPTION
### Description of Changes

The default search radius that is used to find model stations from established observation stations is too small. The default was increased from 2 km --> 4 km. This a one-line code update.

A future update will address Issue #189. It will add obs-model station matching distances to plot titles, and surface the radius distance variable from `indexing.py` to the user-facing config file.

Closes #198.

### Expected Outcome of Changes

With the search radius increase, more model stations will be matched with observation stations. It will enable skill assessment at more observation stations. On the web app, more stations will show skill assessment results.

### Developer Questions and Checklist
**Is this a high priority PR? If yes, why and is there a date by which it needs to be merged?**
Yes. 7/13/26.   

**Are there any changes needed to how the code should be run on the server? (Commands, flags, job timings, etc.)**
No changes with the call, but all model control files will need to be deleted and regenerated so they contain the newly matched stations. @apruessner 

**Does this update need to be installed on the server?**
Yes, please! 

**Does this update require front end/web app changes? (If yes, provide documentation to Min)**
No.

**Does this impact code development work on adding SCHISM? (If yes, tag Atieh)**
No.

**Does this impact code development work on adding ADCIRC?**
_No/Yes + tag Jack if yes_
No.

**Does this impact the expected number of output files for integration tests (i.e., will the integration test fail even though code changes result in desired change in the number of outputs?)**
Maybe? There should be more outut for the additional stations.

- [x] Developer's name is removed throughout the code?
- [x] Did you add relevant labels to the PR?
- [x] Have you run pylint and is the code at an acceptable pylint score? (>8.0)
- [x] Jobs contain the appropriate file checking and handle errors for any missing data?
- [x] Is log free of critical ERRORs or WARNINGs? For errors that are not critical and can remain in code, is there sufficient handling and logging?

### Testing Instructions

Do an e2e test run for GOMOFS using station files. Check to see if CO-OPS stations 8419870 (Seavey Island) and 8418150 (Portland) are included in the skill assessment output. They were previously excluded using the smaller 2 km search radius.

### Reminder checklist for PR reviewer:
- [ ] Run PEP8 compliance tests to ensure the code follows best practices
- [ ] Check that documentation in the script is sufficient
- [ ] Validate the output values (if applicable) to make sure the calculations are correct and make scientific/physical sense; include a comment on the pull request including what validation you performed, for replicability.
- [ ] Test code both locally and on the linux server, using several OFS as test cases
- [ ] **Test for all ‘cast’ options: forecast_a, forecast_b, and nowcast**
- [ ] When approving or commenting on a pull request, add information on the calls you use in case they need to be replicated.



