### PR TITLE
Regenerate cached files that don't cover the run window; guard plots against stale data

### DIFF
--- a/bin/visualization/create_1dplot.py
+++ b/bin/visualization/create_1dplot.py
@@ -90,6 +90,7 @@ from ofs_skill.obs_retrieval import parse_arguments_to_list, utils
 from ofs_skill.obs_retrieval.station_ctl_file_extract import station_ctl_file_extract
 from ofs_skill.obs_retrieval.utils import get_parallel_config
 from ofs_skill.skill_assessment.get_skill import get_skill
+from ofs_skill.utils.timeseries_coverage import covers_run_window, parse_run_window
 from ofs_skill.visualization import create_gui, plotting_scalar, plotting_vector, summary_barplots
 
 warnings.filterwarnings('ignore')
@@ -269,6 +270,49 @@ def ofs_ctlfile_read(prop, name_var, logger):
     {name_var} from {prop.control_files_path}')
     return None
 
+def _drop_stale_casts(now_fores_paired, paired_casts, prop, station_id_val,
+                      logger):
+    """Drop casts whose paired series barely intersects the run window.
+
+    ``combine_obs_across_casts`` crops every trace to
+    ``[prop.start_date_full, prop.end_date_full]`` at plot time, so a pair
+    file left over from an earlier run window renders as a one-point plot
+    (adjacent windows share a boundary timestamp) or a blank plot
+    (disjoint windows). Rather than publish a misleading plot, drop any
+    cast with fewer than 2 points inside the window and log an ERROR.
+
+    Mirrors the crop condition in ``combine_obs_across_casts``: when both
+    nowcast and forecast_a are requested, no crop is applied, so no guard
+    is needed either.
+
+    Returns the filtered ``(now_fores_paired, paired_casts)`` lists.
+    """
+    casts_lower = [c.lower() for c in prop.whichcasts]
+    if 'nowcast' in casts_lower and 'forecast_a' in casts_lower:
+        return now_fores_paired, paired_casts
+    run_window = parse_run_window(prop)
+    if run_window is None:
+        return now_fores_paired, paired_casts
+    kept_pairs = []
+    kept_casts = []
+    for paired_data, cast in zip(now_fores_paired, paired_casts):
+        points_in_window = int(
+            ((paired_data['DateTime'] >= run_window[0])
+             & (paired_data['DateTime'] <= run_window[1])).sum())
+        if points_in_window < 2:
+            logger.error(
+                'Paired dataset for station %s cast %s has only %d data '
+                'point(s) inside the run window %s to %s -- the pair file '
+                'is likely stale (left over from an earlier run window). '
+                'Skipping this cast instead of plotting it.',
+                station_id_val, cast, points_in_window,
+                run_window[0], run_window[1])
+        else:
+            kept_pairs.append(paired_data)
+            kept_casts.append(cast)
+    return kept_pairs, kept_casts
+
+
 def _process_station_plot(
         i, read_ofs_ctl_file, read_station_ctl_file, prop, var_info, logger):
     """
@@ -292,6 +336,7 @@ def _process_station_plot(
         return None
 
     now_fores_paired = []
+    paired_casts = []
     deltat = 0
     for cast in station_prop.whichcasts:
         paired_data = None
@@ -331,11 +376,15 @@ def _process_station_plot(
                 serieskey = pd.read_csv(filepath)
                 serieskey['DateTime'] = pd.to_datetime(
                     serieskey['DateTime'])
+                # Left merge: the key only supplies hover-text filenames,
+                # so a stale or partial key must not drop data rows.
                 paired_data = pd.merge(
-                    paired_data, serieskey, on='DateTime', how='inner')
-                if len(paired_data) != len(serieskey):
-                    logger.warning('Filename key and time series have different '
-                                   'lengths!')
+                    paired_data, serieskey, on='DateTime', how='left')
+                if paired_data['filename'].isna().any():
+                    logger.warning(
+                        'Model filename key does not cover all paired '
+                        'timestamps; hover-text model cycles may be '
+                        'incomplete.')
             except FileNotFoundError:
                 logger.error(
                     'No model series filename key found! Skipping')
@@ -361,6 +410,14 @@ def _process_station_plot(
                         ['year', 'month', 'day', 'hour'],
                         observed=True)['minute'].idxmin()]
             now_fores_paired.append(paired_data)
+            paired_casts.append(cast)
+
+    now_fores_paired, paired_casts = _drop_stale_casts(
+        now_fores_paired, paired_casts, station_prop, station_id_val, logger)
+    # Keep cast labels aligned with the series that will be plotted --
+    # the plotting functions index prop.whichcasts positionally against
+    # now_fores_paired.
+    station_prop.whichcasts = paired_casts
 
     if len(now_fores_paired) > 0:
         try:
@@ -483,6 +540,7 @@ def _ensure_paired_data_exists(read_ofs_ctl_file, prop, var_info, logger):
     (prop.whichcast) and creates control files.
     """
     casts_needing_skill = set()
+    run_window = parse_run_window(prop, logger)
     for i in range(len(read_ofs_ctl_file[1])):
         for cast in prop.whichcasts:
             current_cast = cast.lower()
@@ -492,6 +550,19 @@ def _ensure_paired_data_exists(read_ofs_ctl_file, prop, var_info, logger):
                 f'{read_ofs_ctl_file[1][i]}_{current_cast}_'
                 f'{prop.ofsfiletype}_pair.int'
             )
+            # Pair filenames do not encode the run window, so a file left
+            # over from an earlier run would be cropped to 0-1 points at
+            # plot time. Delete it and regenerate instead.
+            if (os.path.isfile(pair_file) and run_window is not None
+                    and not covers_run_window(
+                        pair_file, run_window[0], run_window[1],
+                        logger=logger)):
+                logger.warning(
+                    'Paired dataset %s does not cover the run window '
+                    '%s to %s and is likely left over from an earlier '
+                    'run. Deleting it so it is regenerated.',
+                    pair_file, run_window[0], run_window[1])
+                os.remove(pair_file)
             if not os.path.isfile(pair_file):
                 if (prop.ofsfiletype == 'fields'
                         or read_ofs_ctl_file[1][i] >= 0):

--- a/bin/visualization/create_1dplot.py
+++ b/bin/visualization/create_1dplot.py
@@ -90,7 +90,11 @@ from ofs_skill.obs_retrieval import parse_arguments_to_list, utils
 from ofs_skill.obs_retrieval.station_ctl_file_extract import station_ctl_file_extract
 from ofs_skill.obs_retrieval.utils import get_parallel_config
 from ofs_skill.skill_assessment.get_skill import get_skill
-from ofs_skill.utils.timeseries_coverage import covers_run_window, parse_run_window
+from ofs_skill.utils.timeseries_coverage import (
+    covers_run_window,
+    parse_run_window,
+    remove_stale_artifact,
+)
 from ofs_skill.visualization import create_gui, plotting_scalar, plotting_vector, summary_barplots
 
 warnings.filterwarnings('ignore')
@@ -270,6 +274,13 @@ def ofs_ctlfile_read(prop, name_var, logger):
     {name_var} from {prop.control_files_path}')
     return None
 
+
+# A trace with fewer points than this inside the run window carries no
+# usable information and is the signature of a stale pair file cropped
+# to the window boundary.
+MIN_POINTS_TO_PLOT = 2
+
+
 def _drop_stale_casts(now_fores_paired, paired_casts, prop, station_id_val,
                       logger):
     """Drop casts whose paired series barely intersects the run window.
@@ -279,18 +290,20 @@ def _drop_stale_casts(now_fores_paired, paired_casts, prop, station_id_val,
     file left over from an earlier run window renders as a one-point plot
     (adjacent windows share a boundary timestamp) or a blank plot
     (disjoint windows). Rather than publish a misleading plot, drop any
-    cast with fewer than 2 points inside the window and log an ERROR.
+    cast with fewer than ``MIN_POINTS_TO_PLOT`` points inside the window
+    and log an ERROR.
 
-    Mirrors the crop condition in ``combine_obs_across_casts``: when both
-    nowcast and forecast_a are requested, no crop is applied, so no guard
-    is needed either.
+    Mirrors the crop condition in ``combine_obs_across_casts`` exactly:
+    the crop is skipped only when both ``nowcast`` and ``forecast_a``
+    appear (case-sensitively) in the cast list the plotting layer will
+    actually see -- ``paired_casts``, the casts that have a paired series
+    -- so the exemption is evaluated on that same list.
 
     Returns the filtered ``(now_fores_paired, paired_casts)`` lists.
     """
-    casts_lower = [c.lower() for c in prop.whichcasts]
-    if 'nowcast' in casts_lower and 'forecast_a' in casts_lower:
+    if 'nowcast' in paired_casts and 'forecast_a' in paired_casts:
         return now_fores_paired, paired_casts
-    run_window = parse_run_window(prop)
+    run_window = parse_run_window(prop, logger)
     if run_window is None:
         return now_fores_paired, paired_casts
     kept_pairs = []
@@ -299,18 +312,44 @@ def _drop_stale_casts(now_fores_paired, paired_casts, prop, station_id_val,
         points_in_window = int(
             ((paired_data['DateTime'] >= run_window[0])
              & (paired_data['DateTime'] <= run_window[1])).sum())
-        if points_in_window < 2:
+        if points_in_window < MIN_POINTS_TO_PLOT:
             logger.error(
                 'Paired dataset for station %s cast %s has only %d data '
-                'point(s) inside the run window %s to %s -- the pair file '
-                'is likely stale (left over from an earlier run window). '
-                'Skipping this cast instead of plotting it.',
+                'point(s) inside the run window %s to %s -- either the '
+                'pair file is stale (left over from an earlier run '
+                'window) or the station has too little data in this '
+                'window. Skipping this cast instead of plotting it.',
                 station_id_val, cast, points_in_window,
                 run_window[0], run_window[1])
         else:
             kept_pairs.append(paired_data)
             kept_casts.append(cast)
     return kept_pairs, kept_casts
+
+
+def _remove_superseded_plots(prop, var_info, station_id_val, logger):
+    """Remove previously published plots this run will no longer rewrite.
+
+    Plot filenames embed ``'_'.join(prop.whichcasts)``, so when a cast is
+    dropped (missing or stale pair file) the current run writes under a
+    different name -- or, with every cast dropped, writes nothing -- and
+    the previous run's file under the full-cast name would keep being
+    served with stale data. Delete the full-cast-named plots for this
+    station/variable so the front end cannot show them.
+    """
+    naming_ws = '_'.join(prop.whichcasts)
+    if var_info[1] == 'cu':
+        pattern = (f'{prop.ofs}_{station_id_val}_currents_*_'
+                   f'{naming_ws}_{prop.ofsfiletype}.html')
+    else:
+        pattern = (f'{prop.ofs}_{station_id_val}_{var_info[0]}_timeseries_'
+                   f'{naming_ws}_{prop.ofsfiletype}.html')
+    for path in glob.glob(
+            os.path.join(prop.visuals_1d_station_path, pattern)):
+        logger.warning(
+            'Removing previously published plot %s: its cast list does '
+            'not match the data available for this run window.', path)
+        remove_stale_artifact(path, prop.visuals_1d_station_path, logger)
 
 
 def _process_station_plot(
@@ -418,6 +457,8 @@ def _process_station_plot(
     # the plotting functions index prop.whichcasts positionally against
     # now_fores_paired.
     station_prop.whichcasts = paired_casts
+    if paired_casts != list(prop.whichcasts):
+        _remove_superseded_plots(prop, var_info, station_id_val, logger)
 
     if len(now_fores_paired) > 0:
         try:
@@ -562,7 +603,8 @@ def _ensure_paired_data_exists(read_ofs_ctl_file, prop, var_info, logger):
                     '%s to %s and is likely left over from an earlier '
                     'run. Deleting it so it is regenerated.',
                     pair_file, run_window[0], run_window[1])
-                os.remove(pair_file)
+                remove_stale_artifact(
+                    pair_file, prop.data_skill_1d_pair_path, logger)
             if not os.path.isfile(pair_file):
                 if (prop.ofsfiletype == 'fields'
                         or read_ofs_ctl_file[1][i] >= 0):

--- a/src/ofs_skill/model_processing/get_node_ofs.py
+++ b/src/ofs_skill/model_processing/get_node_ofs.py
@@ -1436,7 +1436,7 @@ def _all_prd_files_complete(prop_local, ofs_ctlfile, name_var,
         try:
             with open(path, encoding='utf-8') as fh:
                 row_count = sum(1 for _ in fh)
-        except OSError as ex:
+        except (OSError, UnicodeDecodeError) as ex:
             logger.warning(
                 'Could not read %s for row-count check (%s); treating '
                 'as incomplete and re-extracting.', path, ex)
@@ -1456,7 +1456,7 @@ def _all_prd_files_complete(prop_local, ofs_ctlfile, name_var,
     # by an earlier run of the same window length (daily operational runs
     # produce identical row counts every day). Check that the files
     # actually cover the requested run window before reusing them.
-    run_window = parse_run_window(prop_local)
+    run_window = parse_run_window(prop_local, logger)
     if run_window is not None:
         for i in range(n_stations):
             path = _prd_path(i)

--- a/src/ofs_skill/model_processing/get_node_ofs.py
+++ b/src/ofs_skill/model_processing/get_node_ofs.py
@@ -36,6 +36,7 @@ from ofs_skill.model_processing.model_source import get_model_source
 from ofs_skill.model_processing.write_ofs_ctlfile import write_ofs_ctlfile
 from ofs_skill.obs_retrieval import scalar, utils, vector
 from ofs_skill.obs_retrieval.utils import get_parallel_config
+from ofs_skill.utils.timeseries_coverage import covers_run_window, parse_run_window
 
 logger = logging.getLogger(__name__)
 
@@ -1450,6 +1451,22 @@ def _all_prd_files_complete(prop_local, ofs_ctlfile, name_var,
                 'previous run likely killed mid-write. Re-extracting.',
                 path, row_count, expected_timesteps)
             return False
+
+    # Row counts alone cannot distinguish a fresh file from one left over
+    # by an earlier run of the same window length (daily operational runs
+    # produce identical row counts every day). Check that the files
+    # actually cover the requested run window before reusing them.
+    run_window = parse_run_window(prop_local)
+    if run_window is not None:
+        for i in range(n_stations):
+            path = _prd_path(i)
+            if not covers_run_window(path, run_window[0], run_window[1],
+                                     logger=logger):
+                logger.warning(
+                    'Resume check: %s does not cover the run window '
+                    '%s to %s — likely left over from an earlier run. '
+                    'Re-extracting.', path, run_window[0], run_window[1])
+                return False
     return True
 
 

--- a/src/ofs_skill/skill_assessment/get_skill.py
+++ b/src/ofs_skill/skill_assessment/get_skill.py
@@ -29,7 +29,11 @@ from ofs_skill.obs_retrieval.utils import get_parallel_config
 from ofs_skill.skill_assessment import format_paired_one_d, metrics_paired_one_d
 from ofs_skill.skill_assessment.make_skill_maps import make_skill_maps
 from ofs_skill.tidal_analysis.extremes import extract_water_level_extrema
-from ofs_skill.utils.timeseries_coverage import covers_run_window, parse_run_window
+from ofs_skill.utils.timeseries_coverage import (
+    covers_run_window,
+    parse_run_window,
+    remove_stale_artifact,
+)
 
 
 def _cache_key(prop):
@@ -744,8 +748,11 @@ def get_skill(prop, logger):
                             'run. Deleting it and re-fetching '
                             'observations.',
                             obs_path, run_window[0], run_window[1])
-                        os.remove(obs_path)
-                        needs_fetch = True
+                        if remove_stale_artifact(
+                                obs_path,
+                                p.data_observations_1d_station_path,
+                                logger_):
+                            needs_fetch = True
                     else:
                         logger_.info('%s found', obs_path)
                 else:
@@ -794,8 +801,9 @@ def get_skill(prop, logger):
                         'is likely left over from an earlier run. '
                         'Deleting it and re-extracting model data.',
                         prd_path, run_window[0], run_window[1])
-                    os.remove(prd_path)
-                    needs_model = True
+                    if remove_stale_artifact(
+                            prd_path, p.data_model_1d_node_path, logger_):
+                        needs_model = True
             else:
                 logger_.info('%s is missing', prd_path)
                 needs_model = True

--- a/src/ofs_skill/skill_assessment/get_skill.py
+++ b/src/ofs_skill/skill_assessment/get_skill.py
@@ -29,6 +29,7 @@ from ofs_skill.obs_retrieval.utils import get_parallel_config
 from ofs_skill.skill_assessment import format_paired_one_d, metrics_paired_one_d
 from ofs_skill.skill_assessment.make_skill_maps import make_skill_maps
 from ofs_skill.tidal_analysis.extremes import extract_water_level_extrema
+from ofs_skill.utils.timeseries_coverage import covers_run_window, parse_run_window
 
 
 def _cache_key(prop):
@@ -717,97 +718,92 @@ def get_skill(prop, logger):
     # USGS, and NDBC based on the station data source
 
     def _ensure_obs_files(read_station_ctl_file, p, name_var, logger_):
-        """Check for missing .obs files, download if needed."""
+        """Check for missing or stale .obs files, download if needed.
+
+        Obs filenames do not encode the run window, and the obs module
+        skips stations whose .obs file already exists -- so a file left
+        over from an earlier run window would be reused verbatim. Delete
+        stale files first, then fetch once so all missing files are
+        recreated for the current window.
+        """
+        run_window = parse_run_window(p, logger_)
+        needs_fetch = False
         for i in range(0, len(read_station_ctl_file[0])):
             obs_path = os.path.join(p.data_observations_1d_station_path,
                     str(read_station_ctl_file[0][i][0]+'_'+p.ofs+'_'+\
                         name_var+'_station.obs'))
             if os.path.isfile(obs_path):
                 if os.path.getsize(obs_path) > 0:
-                    logger_.info(
-                        '%s/%s_%s_%s_station.obs found',
-                        p.data_observations_1d_station_path,
-                        read_station_ctl_file[0][i][0],
-                        p.ofs,
-                        name_var,
-                    )
+                    if (run_window is not None
+                            and not covers_run_window(
+                                obs_path, run_window[0], run_window[1],
+                                logger=logger_)):
+                        logger_.warning(
+                            '%s does not cover the run window %s to %s '
+                            'and is likely left over from an earlier '
+                            'run. Deleting it and re-fetching '
+                            'observations.',
+                            obs_path, run_window[0], run_window[1])
+                        os.remove(obs_path)
+                        needs_fetch = True
+                    else:
+                        logger_.info('%s found', obs_path)
                 else:
-                    logger_.error(
-                        '%s/%s_%s_%s_station.obs is empty',
-                        p.data_observations_1d_station_path,
-                        read_station_ctl_file[0][i][0],
-                        p.ofs,
-                        name_var,
-                    )
+                    logger_.error('%s is empty', obs_path)
             else:
                 logger_.error(
-                    '%s/%s_%s_%s_station.obs is missing, calling Obs Module',
-                    p.data_observations_1d_station_path,
-                    read_station_ctl_file[0][i][0],
-                    p.ofs,
-                    name_var,
-                )
-                get_station_observations(p, logger_)
-                break
+                    '%s is missing, calling Obs Module', obs_path)
+                needs_fetch = True
+        if needs_fetch:
+            get_station_observations(p, logger_)
 
     def _ensure_prd_files(read_ofs_ctl_file, p, name_var, logger_,
                           cached_model=None):
-        """Check for missing .prd files, extract if needed.
-        Returns the (possibly updated) cached model dataset."""
+        """Check for missing or stale .prd files, extract if needed.
+        Returns the (possibly updated) cached model dataset.
+
+        Like the .obs files, .prd filenames do not encode the run
+        window, so files left over from an earlier run would be reused
+        verbatim. Delete stale files first, then extract once so all
+        missing files are recreated for the current window.
+        """
+        run_window = parse_run_window(p, logger_)
+        needs_model = False
         for i in range(0, len(read_ofs_ctl_file[-1])):
             if p.whichcast == 'forecast_a':
-                if os.path.isfile(
+                prd_path = (
                     f'{p.data_model_1d_node_path}/'
                     f'{read_ofs_ctl_file[-1][i]}_{p.ofs}_{name_var}_'
                     f'{read_ofs_ctl_file[1][i]}_{p.whichcast}_'
                     f'{p.forecast_hr}_{p.ofsfiletype}_model.prd'
-                ) is False:
-                    logger_.error(
-                        '%s/%s_%s_%s_%s_%s_%s_%s_model.prd is missing',
-                        p.data_model_1d_node_path,
-                        read_ofs_ctl_file[-1][i],
-                        p.ofs,
-                        name_var,
-                        read_ofs_ctl_file[1][i],
-                        p.whichcast,
-                        p.forecast_hr,
-                        p.ofsfiletype
-                    )
-                    logger_.info(
-                        'Calling OFS module for %s',
-                        p.whichcast,
-                    )
-                    result = get_node_ofs(p, logger_,
-                                          model_dataset=cached_model)
-                    if result is not None:
-                        cached_model = result
-                    break
+                )
             else:
-                if os.path.isfile(
+                prd_path = (
                     f'{p.data_model_1d_node_path}/'
                     f'{read_ofs_ctl_file[-1][i]}_{p.ofs}_{name_var}_'
                     f'{read_ofs_ctl_file[1][i]}_{p.whichcast}_'
                     f'{p.ofsfiletype}_model.prd'
-                ) is False:
-                    logger_.info(
-                        '%s/%s_%s_%s_%s_%s_%s_model.prd is missing',
-                        p.data_model_1d_node_path,
-                        read_ofs_ctl_file[-1][i],
-                        p.ofs,
-                        name_var,
-                        read_ofs_ctl_file[1][i],
-                        p.whichcast,
-                        p.ofsfiletype
-                    )
-                    logger_.info(
-                        'Calling OFS module for %s',
-                        p.whichcast,
-                    )
-                    result = get_node_ofs(p, logger_,
-                                          model_dataset=cached_model)
-                    if result is not None:
-                        cached_model = result
-                    break
+                )
+            if os.path.isfile(prd_path):
+                if (run_window is not None
+                        and not covers_run_window(
+                            prd_path, run_window[0], run_window[1],
+                            logger=logger_)):
+                    logger_.warning(
+                        '%s does not cover the run window %s to %s and '
+                        'is likely left over from an earlier run. '
+                        'Deleting it and re-extracting model data.',
+                        prd_path, run_window[0], run_window[1])
+                    os.remove(prd_path)
+                    needs_model = True
+            else:
+                logger_.info('%s is missing', prd_path)
+                needs_model = True
+        if needs_model:
+            logger_.info('Calling OFS module for %s', p.whichcast)
+            result = get_node_ofs(p, logger_, model_dataset=cached_model)
+            if result is not None:
+                cached_model = result
         return cached_model
 
     parallel_cfg = get_parallel_config(

--- a/src/ofs_skill/utils/__init__.py
+++ b/src/ofs_skill/utils/__init__.py
@@ -1,0 +1,1 @@
+"""Shared utility helpers for the OFS skill-assessment pipeline."""

--- a/src/ofs_skill/utils/timeseries_coverage.py
+++ b/src/ofs_skill/utils/timeseries_coverage.py
@@ -8,42 +8,59 @@ serve files left over from an earlier run window. Downstream, the plotting
 step crops every series to the current window
 (``combine_obs_across_casts``), so a stale artifact renders as a one-point
 plot when the two windows are adjacent (daily operational runs share a
-boundary timestamp) or as a blank plot when they are disjoint.
+boundary timestamp) or as a blank plot when they are disjoint. Rolling
+windows (e.g. a 7-day assessment re-run daily) are subtler: a stale file
+overlaps most of the new window but is missing exactly the newest data.
 
-These helpers let the existence checks in ``get_skill`` and
-``create_1dplot`` detect stale artifacts and trigger regeneration instead.
+These helpers let the existence checks in ``get_skill``, ``get_node_ofs``,
+and ``create_1dplot`` detect stale artifacts and trigger regeneration
+instead. ``remove_stale_artifact`` is the shared deletion path: it refuses
+targets that resolve outside the artifact directory and tolerates a
+concurrent run having already deleted the file.
 """
 
-from datetime import datetime
+import contextlib
+import os
+from datetime import datetime, timedelta, timezone
 
-# An artifact is considered stale when its time range overlaps less than
-# this fraction of the requested run window. Kept deliberately loose so
-# genuine data gaps (late model cycles, short gauge outages) do not force
-# pointless regeneration on every run.
-MIN_OVERLAP_FRACTION = 0.5
+# How far a cached artifact's data may stop short of the reachable run
+# window before the file is declared stale. Sized to absorb the nowcast
+# cycle spacing (up to 6 h between cycles) plus NODD/CO-OPS publication
+# lag, while still catching daily-cadence staleness (a file from
+# yesterday's window ends ~24 h short). Data gaps wider than this at the
+# very start or end of the window will regenerate on every run; gaps in
+# the middle of the window are never penalized.
+STALENESS_TOLERANCE = timedelta(hours=12)
+
+
+def _parse_date(raw):
+    """Parse one pipeline date string in either accepted format."""
+    for fmt in ('%Y-%m-%dT%H:%M:%SZ', '%Y%m%d-%H:%M:%S'):
+        try:
+            return datetime.strptime(raw, fmt)
+        except (TypeError, ValueError):
+            continue
+    return None
 
 
 def parse_run_window(prop, logger=None):
     """Parse ``prop.start_date_full``/``prop.end_date_full`` to datetimes.
 
-    Both date formats used across the pipeline are accepted. Returns a
-    ``(start, end)`` tuple, or ``None`` if the dates cannot be parsed (in
-    which case callers should skip staleness checks).
+    Each date is parsed independently, so a run that has rewritten one of
+    them to the compact format mid-pipeline still yields a window. Returns
+    a ``(start, end)`` tuple, or ``None`` if either date cannot be parsed
+    (in which case callers should skip staleness checks).
     """
     start_raw = getattr(prop, 'start_date_full', None)
     end_raw = getattr(prop, 'end_date_full', None)
-    for fmt in ('%Y-%m-%dT%H:%M:%SZ', '%Y%m%d-%H:%M:%S'):
-        try:
-            return (datetime.strptime(start_raw, fmt),
-                    datetime.strptime(end_raw, fmt))
-        except (TypeError, ValueError):
-            continue
+    start_dt = _parse_date(start_raw)
+    end_dt = _parse_date(end_raw)
+    if start_dt is not None and end_dt is not None:
+        return start_dt, end_dt
     if logger is not None:
         logger.warning(
             'Could not parse run window from start=%s end=%s; '
-            'skipping cached-file staleness checks.',
-            getattr(prop, 'start_date_full', None),
-            getattr(prop, 'end_date_full', None))
+            'skipping cached-file staleness checks.', start_raw, end_raw)
     return None
 
 
@@ -61,15 +78,15 @@ def _row_datetime(line):
         return datetime(int(float(fields[1])), int(float(fields[2])),
                         int(float(fields[3])), int(float(fields[4])),
                         int(float(fields[5])))
-    except ValueError:
+    except (ValueError, OverflowError):
         return None
 
 
 def read_first_last_timestamps(path):
     """Return (first, last) data-row timestamps of a cached artifact.
 
-    Returns ``(None, None)`` when the file cannot be read or contains no
-    parseable data rows.
+    Returns ``(None, None)`` when the file cannot be read or decoded, or
+    contains no parseable data rows.
     """
     first = None
     last = None
@@ -82,18 +99,29 @@ def read_first_last_timestamps(path):
                 if first is None:
                     first = stamp
                 last = stamp
-    except OSError:
+    except (OSError, UnicodeDecodeError):
         return None, None
     return first, last
 
 
-def covers_run_window(path, start_dt, end_dt,
-                      min_fraction=MIN_OVERLAP_FRACTION, logger=None):
-    """True if the file's time range overlaps enough of the run window.
+def covers_run_window(path, start_dt, end_dt, *, logger=None, now=None):
+    """True unless the file's data demonstrably stops short of the window.
+
+    A cached artifact is stale when its first timestamp begins more than
+    ``STALENESS_TOLERANCE`` after the window start, or its last timestamp
+    ends more than that before ``min(end_dt, now)``. Clamping the end to
+    *now* means windows extending into the future (forecast runs) never
+    penalize a fresh file for data that cannot exist yet, and comparing
+    against the window ends rather than an overlap fraction catches
+    rolling-window reuse (a file from yesterday's overlapping window
+    always ends ~24 h short) without deleting files that merely have
+    mid-window gaps.
 
     Fails open (returns True) when the file cannot be parsed, so
     unreadable files keep flowing through the pre-existing error handling
-    instead of being regenerated on every run.
+    instead of being regenerated on every run, and when the reachable part
+    of the window is shorter than the tolerance (too little data can
+    exist to judge either way).
     """
     first, last = read_first_last_timestamps(path)
     if first is None or last is None:
@@ -102,9 +130,46 @@ def covers_run_window(path, start_dt, end_dt,
                 'Could not read timestamps from %s; '
                 'skipping staleness check for this file.', path)
         return True
-    window_seconds = (end_dt - start_dt).total_seconds()
-    if window_seconds <= 0:
+    if now is None:
+        now = datetime.now(timezone.utc).replace(tzinfo=None)
+    effective_end = min(end_dt, now)
+    if effective_end - start_dt <= STALENESS_TOLERANCE:
         return True
-    overlap_seconds = (min(end_dt, last)
-                       - max(start_dt, first)).total_seconds()
-    return overlap_seconds / window_seconds >= min_fraction
+    if first > start_dt + STALENESS_TOLERANCE:
+        return False
+    if last < effective_end - STALENESS_TOLERANCE:
+        return False
+    return True
+
+
+def is_within_directory(path, directory):
+    """True if ``path`` resolves to a location inside ``directory``.
+
+    Cached-artifact paths embed station IDs that originate from external
+    metadata services; a deletion must never follow such an ID outside
+    the artifact directory.
+    """
+    try:
+        base = os.path.realpath(directory)
+        target = os.path.realpath(path)
+        return os.path.commonpath([base, target]) == base
+    except (OSError, ValueError):
+        return False
+
+
+def remove_stale_artifact(path, base_dir, logger=None):
+    """Delete a stale cached artifact; return True if the file is gone.
+
+    Refuses to delete a path that resolves outside ``base_dir`` (returns
+    False so callers do not treat the file as regenerable). A file already
+    deleted by a concurrent run is not an error.
+    """
+    if not is_within_directory(path, base_dir):
+        if logger is not None:
+            logger.warning(
+                'Refusing to delete %s: it resolves outside the artifact '
+                'directory %s.', path, base_dir)
+        return False
+    with contextlib.suppress(FileNotFoundError):
+        os.remove(path)
+    return True

--- a/src/ofs_skill/utils/timeseries_coverage.py
+++ b/src/ofs_skill/utils/timeseries_coverage.py
@@ -1,0 +1,110 @@
+"""
+Helpers to check whether cached time-series artifacts cover the run window.
+
+The 1D pipeline caches its intermediate artifacts (``*_station.obs``,
+``*_model.prd``, ``*_pair.int``) under filenames that do not encode the
+assessment start/end dates. A persistent working directory can therefore
+serve files left over from an earlier run window. Downstream, the plotting
+step crops every series to the current window
+(``combine_obs_across_casts``), so a stale artifact renders as a one-point
+plot when the two windows are adjacent (daily operational runs share a
+boundary timestamp) or as a blank plot when they are disjoint.
+
+These helpers let the existence checks in ``get_skill`` and
+``create_1dplot`` detect stale artifacts and trigger regeneration instead.
+"""
+
+from datetime import datetime
+
+# An artifact is considered stale when its time range overlaps less than
+# this fraction of the requested run window. Kept deliberately loose so
+# genuine data gaps (late model cycles, short gauge outages) do not force
+# pointless regeneration on every run.
+MIN_OVERLAP_FRACTION = 0.5
+
+
+def parse_run_window(prop, logger=None):
+    """Parse ``prop.start_date_full``/``prop.end_date_full`` to datetimes.
+
+    Both date formats used across the pipeline are accepted. Returns a
+    ``(start, end)`` tuple, or ``None`` if the dates cannot be parsed (in
+    which case callers should skip staleness checks).
+    """
+    start_raw = getattr(prop, 'start_date_full', None)
+    end_raw = getattr(prop, 'end_date_full', None)
+    for fmt in ('%Y-%m-%dT%H:%M:%SZ', '%Y%m%d-%H:%M:%S'):
+        try:
+            return (datetime.strptime(start_raw, fmt),
+                    datetime.strptime(end_raw, fmt))
+        except (TypeError, ValueError):
+            continue
+    if logger is not None:
+        logger.warning(
+            'Could not parse run window from start=%s end=%s; '
+            'skipping cached-file staleness checks.',
+            getattr(prop, 'start_date_full', None),
+            getattr(prop, 'end_date_full', None))
+    return None
+
+
+def _row_datetime(line):
+    """Timestamp of one whitespace-separated data row, or None.
+
+    ``.obs``, ``.prd``, and ``*_pair.int`` files all carry
+    ``year month day hour minute`` in columns 1-5 (0-based) after the
+    julian-date column. Header rows and malformed lines return None.
+    """
+    fields = line.split()
+    if len(fields) < 6:
+        return None
+    try:
+        return datetime(int(float(fields[1])), int(float(fields[2])),
+                        int(float(fields[3])), int(float(fields[4])),
+                        int(float(fields[5])))
+    except ValueError:
+        return None
+
+
+def read_first_last_timestamps(path):
+    """Return (first, last) data-row timestamps of a cached artifact.
+
+    Returns ``(None, None)`` when the file cannot be read or contains no
+    parseable data rows.
+    """
+    first = None
+    last = None
+    try:
+        with open(path, encoding='utf-8') as file_handle:
+            for line in file_handle:
+                stamp = _row_datetime(line)
+                if stamp is None:
+                    continue
+                if first is None:
+                    first = stamp
+                last = stamp
+    except OSError:
+        return None, None
+    return first, last
+
+
+def covers_run_window(path, start_dt, end_dt,
+                      min_fraction=MIN_OVERLAP_FRACTION, logger=None):
+    """True if the file's time range overlaps enough of the run window.
+
+    Fails open (returns True) when the file cannot be parsed, so
+    unreadable files keep flowing through the pre-existing error handling
+    instead of being regenerated on every run.
+    """
+    first, last = read_first_last_timestamps(path)
+    if first is None or last is None:
+        if logger is not None:
+            logger.warning(
+                'Could not read timestamps from %s; '
+                'skipping staleness check for this file.', path)
+        return True
+    window_seconds = (end_dt - start_dt).total_seconds()
+    if window_seconds <= 0:
+        return True
+    overlap_seconds = (min(end_dt, last)
+                       - max(start_dt, first)).total_seconds()
+    return overlap_seconds / window_seconds >= min_fraction

--- a/tests/stale_cache_coverage_test.py
+++ b/tests/stale_cache_coverage_test.py
@@ -9,10 +9,21 @@ earlier run. The plotting step crops every series to the current window
 one-point plot when the two windows are adjacent (daily operational runs
 share a boundary timestamp) or a blank plot when they are disjoint.
 
+Staleness is judged against the window ends, not an overlap fraction: a
+file is stale when its data starts too long after the window start or
+stops too long before ``min(end, now)``. That catches rolling-window
+reuse (yesterday's 7-day file overlaps 86% of today's window but misses
+the newest day) while never penalizing forecast windows that extend into
+the future or files with mid-window gaps.
+
 Covers:
 - ``ofs_skill.utils.timeseries_coverage`` helpers,
+- the guarded deletion path ``remove_stale_artifact``,
 - stale-pair detection/regeneration in ``_ensure_paired_data_exists``,
-- the plot-time guard ``_drop_stale_casts``,
+- the plot-time guard ``_drop_stale_casts`` (exemption evaluated on the
+  cast list the crop will actually see),
+- removal of previously published plots whose cast naming this run no
+  longer writes,
 - the left merge with the model filename key (a stale/partial key must
   not drop data rows).
 """
@@ -30,6 +41,7 @@ from ofs_skill.utils.timeseries_coverage import (
     covers_run_window,
     parse_run_window,
     read_first_last_timestamps,
+    remove_stale_artifact,
 )
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -102,6 +114,14 @@ class TestTimeseriesCoverage:
             _WindowProp('20260328-18:00:00', '20260329-18:00:00'))
         assert window == (WINDOW_START, WINDOW_END)
 
+    def test_parse_run_window_mixed_formats(self):
+        """One ISO date and one compact date still yield a window --
+        the pipeline rewrites start/end to the compact format mid-run,
+        and a mixed state must not silently disable the checks."""
+        window = parse_run_window(
+            _WindowProp('2026-03-28T18:00:00Z', '20260329-18:00:00'))
+        assert window == (WINDOW_START, WINDOW_END)
+
     def test_parse_run_window_unparseable_returns_none(self):
         """Unparseable date strings yield None, not an exception."""
         assert parse_run_window(_WindowProp('garbage', 'garbage')) is None
@@ -154,6 +174,109 @@ class TestTimeseriesCoverage:
         pair = tmp_path / 'pair.int'
         pair.write_text('not a data row\nstill not one\n', encoding='utf-8')
         assert covers_run_window(pair, WINDOW_START, WINDOW_END)
+
+    def test_undecodable_binary_file_fails_open(self, tmp_path):
+        """A binary/corrupt cached file must fail open, not raise
+        UnicodeDecodeError out of the check on every run."""
+        pair = tmp_path / 'pair.int'
+        pair.write_bytes(b'\x00\xff\xfe\x93 not utf-8 \x81\x82')
+        assert covers_run_window(pair, WINDOW_START, WINDOW_END)
+
+    def test_overflowing_date_field_fails_open(self, tmp_path):
+        """A corrupt row whose date field parses to inf must be skipped,
+        not raise OverflowError."""
+        pair = tmp_path / 'pair.int'
+        pair.write_text('2461127.25 1e999 3 28 18 0 7.4 5.3 -2.1\n',
+                        encoding='utf-8')
+        assert covers_run_window(pair, WINDOW_START, WINDOW_END)
+
+    def test_rolling_window_stale_file_fails(self, tmp_path):
+        """Yesterday's 7-day file overlaps ~86% of today's 7-day window
+        but is missing the newest day -- it must be flagged stale (the
+        old overlap-fraction test reused it forever)."""
+        start = WINDOW_START
+        end = start + timedelta(days=7)
+        pair = tmp_path / 'pair.int'
+        _write_pair_file(pair, start - timedelta(days=1), hours=7 * 24 + 1)
+        assert not covers_run_window(
+            pair, start, end, now=end + timedelta(days=1))
+
+    def test_two_day_window_advanced_one_day_fails(self, tmp_path):
+        """A 2-day window advanced by one day leaves exactly 50% overlap;
+        the stale file must still be regenerated."""
+        start = WINDOW_START
+        end = start + timedelta(days=2)
+        pair = tmp_path / 'pair.int'
+        _write_pair_file(pair, start - timedelta(days=1), hours=2 * 24 + 1)
+        assert not covers_run_window(
+            pair, start, end, now=end + timedelta(days=1))
+
+    def test_future_window_fresh_file_passes(self, tmp_path):
+        """forecast windows extend past *now*; a fresh file reaching now
+        must not be regenerated (no per-run churn, no CO-OPS hammering)."""
+        start = WINDOW_START
+        end = start + timedelta(hours=48)
+        pair = tmp_path / 'pair.int'
+        _write_pair_file(pair, start, hours=20)
+        assert covers_run_window(
+            pair, start, end, now=start + timedelta(hours=20))
+
+    def test_future_window_stale_file_fails(self, tmp_path):
+        """A leftover file ending at the forecast window's start is stale
+        even though the window extends into the future."""
+        start = WINDOW_START
+        end = start + timedelta(hours=48)
+        pair = tmp_path / 'pair.int'
+        _write_pair_file(pair, start - timedelta(hours=24), hours=25)
+        assert not covers_run_window(
+            pair, start, end, now=start + timedelta(hours=30))
+
+    def test_window_entirely_in_future_fails_open(self, tmp_path):
+        """When no data can exist yet for the window, the check cannot
+        judge staleness and must fail open."""
+        pair = tmp_path / 'pair.int'
+        _write_pair_file(pair, WINDOW_START - timedelta(days=2), hours=25)
+        assert covers_run_window(
+            pair, WINDOW_START, WINDOW_END,
+            now=WINDOW_START - timedelta(hours=1))
+
+    def test_late_starting_file_fails(self, tmp_path):
+        """A file whose data begins well after the window start (e.g. a
+        cache from a newer, later window) must be regenerated."""
+        start = WINDOW_START
+        end = start + timedelta(days=1)
+        pair = tmp_path / 'pair.int'
+        _write_pair_file(pair, start + timedelta(hours=18), hours=25)
+        assert not covers_run_window(
+            pair, start, end, now=end + timedelta(days=1))
+
+
+class TestRemoveStaleArtifact:
+    """Guarded deletion of cached artifacts."""
+
+    def test_removes_file_inside_directory(self, tmp_path):
+        """A normal artifact inside the cache directory is deleted."""
+        target = tmp_path / 'cbofs_temp_x_pair.int'
+        target.write_text('x', encoding='utf-8')
+        assert remove_stale_artifact(str(target), str(tmp_path))
+        assert not target.exists()
+
+    def test_refuses_path_outside_directory(self, tmp_path):
+        """A path that resolves outside the artifact directory (e.g. via
+        a hostile station ID) is never deleted."""
+        outside = tmp_path / 'outside.txt'
+        outside.write_text('x', encoding='utf-8')
+        base = tmp_path / 'cache'
+        base.mkdir()
+        target = base / '..' / 'outside.txt'
+        assert not remove_stale_artifact(
+            str(target), str(base), _make_logger())
+        assert outside.exists()
+
+    def test_already_deleted_file_is_not_an_error(self, tmp_path):
+        """A concurrent run deleting the file first must not raise."""
+        assert remove_stale_artifact(
+            str(tmp_path / 'gone_pair.int'), str(tmp_path))
 
 
 class _PairCheckProp:
@@ -254,6 +377,31 @@ class TestDropStaleCasts:
         assert casts == ['nowcast', 'forecast_a']
         assert len(pairs) == 2
 
+    def test_exemption_requires_paired_forecast_a(self, create_1dplot_mod):
+        """nowcast+forecast_a was requested but the forecast_a pair is
+        missing: the crop in combine_obs_across_casts acts on the
+        realigned cast list and WILL fire, so the guard must fire too --
+        otherwise the one-point plot renders anyway."""
+        prop = _WindowProp()
+        prop.whichcasts = ['nowcast', 'forecast_a']
+        stale = _paired_df(WINDOW_START - timedelta(hours=24), 25)
+        pairs, casts = create_1dplot_mod._drop_stale_casts(
+            [stale], ['nowcast'], prop, '8571421', _make_logger())
+        assert not casts and not pairs
+
+    def test_exemption_is_case_sensitive_like_the_crop(
+            self, create_1dplot_mod):
+        """combine_obs_across_casts matches cast names case-sensitively;
+        the guard's exemption must agree, or a differently-cased combo
+        would be exempted while the crop still fires."""
+        prop = _WindowProp()
+        prop.whichcasts = ['Nowcast', 'Forecast_A']
+        stale = _paired_df(WINDOW_START - timedelta(hours=24), 25)
+        _, casts = create_1dplot_mod._drop_stale_casts(
+            [stale, stale], ['Nowcast', 'Forecast_A'], prop, '8571421',
+            _make_logger())
+        assert casts == []
+
     def test_unparseable_window_keeps_everything(self, create_1dplot_mod):
         """Without a parseable window the guard is skipped entirely."""
         prop = _WindowProp('garbage', 'garbage')
@@ -345,3 +493,33 @@ class TestFilenameKeyLeftMerge:
         assert not calls, (
             'a stale pair file must be dropped by the plot-time guard, '
             'not rendered as a one-point plot')
+
+    def test_superseded_plot_is_removed(
+            self, create_1dplot_mod, tmp_path, monkeypatch):
+        """When every cast is dropped, the previous run's plot under the
+        full-cast filename must be deleted -- otherwise the front end
+        keeps serving the stale plot that this run refused to rewrite."""
+        pair_dir = tmp_path / 'pair'
+        node_dir = tmp_path / 'node'
+        visual_dir = tmp_path / 'visual'
+        for directory in (pair_dir, node_dir, visual_dir):
+            directory.mkdir()
+
+        pair = pair_dir / 'cbofs_temp_8571421_29_nowcast_stations_pair.int'
+        _write_pair_file(pair, WINDOW_START - timedelta(hours=24), hours=25)
+        old_plot = visual_dir / (
+            'cbofs_8571421_water_temperature_timeseries_'
+            'nowcast_stations.html')
+        old_plot.write_text('<html>stale</html>', encoding='utf-8')
+
+        monkeypatch.setattr(
+            create_1dplot_mod.plotting_scalar, 'oned_scalar_plot',
+            lambda *a, **k: None)
+
+        prop = _PlotProp(pair_dir, node_dir, visual_dir)
+        create_1dplot_mod._process_station_plot(
+            0, OFS_CTL, STATION_CTL, prop, VAR_INFO, _make_logger())
+
+        assert not old_plot.exists(), (
+            'the previously published full-cast plot must be retired '
+            'when its cast is dropped for this run window')

--- a/tests/stale_cache_coverage_test.py
+++ b/tests/stale_cache_coverage_test.py
@@ -1,0 +1,322 @@
+"""
+Regression tests for the stale-cache one-point-plot bug.
+
+Cached pipeline artifacts (``*_station.obs``, ``*_model.prd``,
+``*_pair.int``) are keyed by filenames that do not encode the run window,
+so a persistent working directory can serve files left over from an
+earlier run. The plotting step crops every series to the current window
+(``combine_obs_across_casts``), so a stale pair file renders as a
+one-point plot when the two windows are adjacent (daily operational runs
+share a boundary timestamp) or a blank plot when they are disjoint.
+
+Covers:
+- ``ofs_skill.utils.timeseries_coverage`` helpers,
+- stale-pair detection/regeneration in ``_ensure_paired_data_exists``,
+- the plot-time guard ``_drop_stale_casts``,
+- the left merge with the model filename key (a stale/partial key must
+  not drop data rows).
+"""
+
+import importlib.util
+import sys
+from datetime import datetime, timedelta
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from ofs_skill.utils.timeseries_coverage import (
+    covers_run_window,
+    parse_run_window,
+    read_first_last_timestamps,
+)
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+CREATE_1DPLOT_PATH = REPO_ROOT / 'bin' / 'visualization' / 'create_1dplot.py'
+
+WINDOW_START = datetime(2026, 3, 28, 18, 0)
+WINDOW_END = datetime(2026, 3, 29, 18, 0)
+
+
+@pytest.fixture(scope='module')
+def create_1dplot_mod():
+    spec = importlib.util.spec_from_file_location(
+        'create_1dplot_stale_cache_under_test', CREATE_1DPLOT_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules['create_1dplot_stale_cache_under_test'] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _write_pair_file(path, start, hours, header=True):
+    """Write a minimal pair.int-shaped file with hourly rows."""
+    lines = []
+    if header:
+        lines.append('DNUM_JAN1 YEAR MONTH DAY HOUR MINUTE OBS OFS BIAS')
+    for i in range(hours):
+        stamp = start + timedelta(hours=i)
+        lines.append(
+            f'2461127.25 {stamp.year} {stamp.month} {stamp.day} '
+            f'{stamp.hour} {stamp.minute} 7.4 5.3 -2.1')
+    path.write_text('\n'.join(lines) + '\n', encoding='utf-8')
+
+
+class _WindowProp:
+    """Minimum prop surface for the run-window helpers."""
+
+    def __init__(self, start='2026-03-28T18:00:00Z',
+                 end='2026-03-29T18:00:00Z'):
+        self.start_date_full = start
+        self.end_date_full = end
+
+
+class TestTimeseriesCoverage:
+
+    def test_parse_run_window_iso_format(self):
+        window = parse_run_window(_WindowProp())
+        assert window == (WINDOW_START, WINDOW_END)
+
+    def test_parse_run_window_compact_format(self):
+        window = parse_run_window(
+            _WindowProp('20260328-18:00:00', '20260329-18:00:00'))
+        assert window == (WINDOW_START, WINDOW_END)
+
+    def test_parse_run_window_unparseable_returns_none(self):
+        assert parse_run_window(_WindowProp('garbage', 'garbage')) is None
+
+    def test_parse_run_window_missing_attributes_returns_none(self):
+        # Some callers (and test stubs) hand in prop objects without the
+        # date attributes; staleness checks must be skipped, not crash.
+        assert parse_run_window(object()) is None
+
+    def test_read_first_last_skips_header(self, tmp_path):
+        pair = tmp_path / 'pair.int'
+        _write_pair_file(pair, WINDOW_START, hours=25)
+        first, last = read_first_last_timestamps(pair)
+        assert first == WINDOW_START
+        assert last == WINDOW_START + timedelta(hours=24)
+
+    def test_fresh_file_covers_window(self, tmp_path):
+        pair = tmp_path / 'pair.int'
+        _write_pair_file(pair, WINDOW_START, hours=25)
+        assert covers_run_window(pair, WINDOW_START, WINDOW_END)
+
+    def test_adjacent_stale_file_fails(self, tmp_path):
+        # Yesterday's file: ends exactly at the new window's start -- the
+        # daily-operations signature that produced one-point plots.
+        pair = tmp_path / 'pair.int'
+        _write_pair_file(pair, WINDOW_START - timedelta(hours=24), hours=25)
+        assert not covers_run_window(pair, WINDOW_START, WINDOW_END)
+
+    def test_disjoint_stale_file_fails(self, tmp_path):
+        pair = tmp_path / 'pair.int'
+        _write_pair_file(pair, WINDOW_START - timedelta(days=5), hours=25)
+        assert not covers_run_window(pair, WINDOW_START, WINDOW_END)
+
+    def test_partial_coverage_from_data_gap_is_tolerated(self, tmp_path):
+        # A file that covers most of the window (e.g. the last model cycle
+        # not yet available) must NOT trigger regeneration churn.
+        pair = tmp_path / 'pair.int'
+        _write_pair_file(pair, WINDOW_START, hours=19)
+        assert covers_run_window(pair, WINDOW_START, WINDOW_END)
+
+    def test_unparseable_file_fails_open(self, tmp_path):
+        pair = tmp_path / 'pair.int'
+        pair.write_text('not a data row\nstill not one\n', encoding='utf-8')
+        assert covers_run_window(pair, WINDOW_START, WINDOW_END)
+
+
+class _PairCheckProp:
+    """Minimum prop surface for _ensure_paired_data_exists."""
+
+    def __init__(self, pair_dir):
+        self.ofs = 'cbofs'
+        self.whichcasts = ['nowcast']
+        self.whichcast = 'nowcast'
+        self.ofsfiletype = 'stations'
+        self.data_skill_1d_pair_path = str(pair_dir)
+        self.start_date_full = '2026-03-28T18:00:00Z'
+        self.end_date_full = '2026-03-29T18:00:00Z'
+        self.start_date_full_before = self.start_date_full
+        self.end_date_full_before = self.end_date_full
+
+
+VAR_INFO = ['water_temperature', 'temp',
+            ['Julian', 'year', 'month', 'day', 'hour', 'minute',
+             'OBS', 'OFS', 'BIAS']]
+
+# [lines, nodes, depths, shifts, ids] -- only [1] and [-1] are used here.
+OFS_CTL = [None, [29], None, None, ['8571421']]
+
+
+class TestEnsurePairedDataStaleness:
+
+    def test_stale_pair_is_deleted_and_regenerated(
+            self, create_1dplot_mod, tmp_path, monkeypatch):
+        pair = tmp_path / 'cbofs_temp_8571421_29_nowcast_stations_pair.int'
+        _write_pair_file(pair, WINDOW_START - timedelta(hours=24), hours=25)
+
+        calls = []
+        monkeypatch.setattr(create_1dplot_mod, 'get_skill',
+                            lambda p, lg: calls.append(p.whichcast))
+        prop = _PairCheckProp(tmp_path)
+        create_1dplot_mod._ensure_paired_data_exists(
+            OFS_CTL, prop, VAR_INFO, _make_logger())
+
+        assert not pair.exists(), 'stale pair file should be deleted'
+        assert calls == ['nowcast'], 'get_skill should regenerate the cast'
+
+    def test_fresh_pair_is_left_alone(
+            self, create_1dplot_mod, tmp_path, monkeypatch):
+        pair = tmp_path / 'cbofs_temp_8571421_29_nowcast_stations_pair.int'
+        _write_pair_file(pair, WINDOW_START, hours=25)
+
+        calls = []
+        monkeypatch.setattr(create_1dplot_mod, 'get_skill',
+                            lambda p, lg: calls.append(p.whichcast))
+        prop = _PairCheckProp(tmp_path)
+        create_1dplot_mod._ensure_paired_data_exists(
+            OFS_CTL, prop, VAR_INFO, _make_logger())
+
+        assert pair.exists()
+        assert calls == []
+
+
+def _make_logger():
+    import logging
+    return logging.getLogger('stale_cache_test')
+
+
+def _paired_df(start, hours):
+    stamps = [start + timedelta(hours=i) for i in range(hours)]
+    return pd.DataFrame({
+        'DateTime': stamps,
+        'OBS': [7.4] * hours,
+        'OFS': [5.3] * hours,
+    })
+
+
+class TestDropStaleCasts:
+
+    def test_stale_cast_dropped_fresh_cast_kept(self, create_1dplot_mod):
+        prop = _WindowProp()
+        prop.whichcasts = ['nowcast', 'forecast_b']
+        fresh = _paired_df(WINDOW_START, 25)
+        # Adjacent-window stale series: only the boundary stamp survives
+        # the plot-time crop -- the one-point-plot signature.
+        stale = _paired_df(WINDOW_START - timedelta(hours=24), 25)
+        pairs, casts = create_1dplot_mod._drop_stale_casts(
+            [stale, fresh], ['nowcast', 'forecast_b'], prop, '8571421',
+            _make_logger())
+        assert casts == ['forecast_b']
+        assert len(pairs) == 1 and pairs[0] is fresh
+
+    def test_all_stale_returns_empty(self, create_1dplot_mod):
+        prop = _WindowProp()
+        prop.whichcasts = ['nowcast']
+        stale = _paired_df(WINDOW_START - timedelta(days=3), 25)
+        pairs, casts = create_1dplot_mod._drop_stale_casts(
+            [stale], ['nowcast'], prop, '8571421', _make_logger())
+        assert pairs == [] and casts == []
+
+    def test_nowcast_forecast_a_combo_is_exempt(self, create_1dplot_mod):
+        # combine_obs_across_casts applies no crop for this combo, so the
+        # guard must not drop anything either.
+        prop = _WindowProp()
+        prop.whichcasts = ['nowcast', 'forecast_a']
+        stale = _paired_df(WINDOW_START - timedelta(days=3), 25)
+        pairs, casts = create_1dplot_mod._drop_stale_casts(
+            [stale, stale], ['nowcast', 'forecast_a'], prop, '8571421',
+            _make_logger())
+        assert casts == ['nowcast', 'forecast_a']
+        assert len(pairs) == 2
+
+    def test_unparseable_window_keeps_everything(self, create_1dplot_mod):
+        prop = _WindowProp('garbage', 'garbage')
+        prop.whichcasts = ['nowcast']
+        stale = _paired_df(WINDOW_START - timedelta(days=3), 25)
+        pairs, casts = create_1dplot_mod._drop_stale_casts(
+            [stale], ['nowcast'], prop, '8571421', _make_logger())
+        assert casts == ['nowcast']
+
+
+class _PlotProp(_PairCheckProp):
+    """Minimum prop surface for _process_station_plot."""
+
+    def __init__(self, pair_dir, node_dir, visual_dir):
+        super().__init__(pair_dir)
+        self.data_model_1d_node_path = str(node_dir)
+        self.visuals_1d_station_path = str(visual_dir)
+
+
+# [0]: obs rows [id, name, source]; [1]: rows whose [2] is the datum.
+STATION_CTL = [[['8571421', 'name_Solomons', 'CO-OPS']],
+               [[0.0, 0.0, 'MLLW']]]
+
+
+class TestFilenameKeyLeftMerge:
+
+    def test_partial_key_does_not_drop_rows(
+            self, create_1dplot_mod, tmp_path, monkeypatch):
+        """A filename key covering only part of the series must not prune
+        data rows from the plot (regression: how='inner' collapsed the
+        series to the key's coverage)."""
+        pair_dir = tmp_path / 'pair'
+        node_dir = tmp_path / 'node'
+        visual_dir = tmp_path / 'visual'
+        for d in (pair_dir, node_dir, visual_dir):
+            d.mkdir()
+
+        pair = pair_dir / 'cbofs_temp_8571421_29_nowcast_stations_pair.int'
+        _write_pair_file(pair, WINDOW_START, hours=25)
+        # Key covers only the first 5 hours of the series.
+        key = pd.DataFrame({
+            'DateTime': [WINDOW_START + timedelta(hours=i)
+                         for i in range(5)],
+            'filename': ['cbofs.t00z.20260328.stations.nowcast.nc'] * 5,
+        })
+        key.to_csv(node_dir / 'cbofs_nowcast_filename_key.csv', index=False)
+
+        captured = {}
+
+        def _capture_plot(now_fores_paired, *args, **kwargs):
+            captured['pairs'] = now_fores_paired
+
+        monkeypatch.setattr(
+            create_1dplot_mod.plotting_scalar, 'oned_scalar_plot',
+            _capture_plot)
+
+        prop = _PlotProp(pair_dir, node_dir, visual_dir)
+        result = create_1dplot_mod._process_station_plot(
+            0, OFS_CTL, STATION_CTL, prop, VAR_INFO, _make_logger())
+
+        assert result == '8571421'
+        assert len(captured['pairs']) == 1
+        assert len(captured['pairs'][0]) == 25, (
+            'left merge with the filename key must keep all data rows')
+
+    def test_stale_pair_reaches_no_plot(
+            self, create_1dplot_mod, tmp_path, monkeypatch):
+        """End-to-end through _process_station_plot: a stale pair file must
+        not produce a plot call at all."""
+        pair_dir = tmp_path / 'pair'
+        node_dir = tmp_path / 'node'
+        visual_dir = tmp_path / 'visual'
+        for d in (pair_dir, node_dir, visual_dir):
+            d.mkdir()
+
+        pair = pair_dir / 'cbofs_temp_8571421_29_nowcast_stations_pair.int'
+        _write_pair_file(pair, WINDOW_START - timedelta(hours=24), hours=25)
+
+        calls = []
+        monkeypatch.setattr(
+            create_1dplot_mod.plotting_scalar, 'oned_scalar_plot',
+            lambda *a, **k: calls.append(a))
+
+        prop = _PlotProp(pair_dir, node_dir, visual_dir)
+        create_1dplot_mod._process_station_plot(
+            0, OFS_CTL, STATION_CTL, prop, VAR_INFO, _make_logger())
+
+        assert calls == [], (
+            'a stale pair file must be dropped by the plot-time guard, '
+            'not rendered as a one-point plot')

--- a/tests/stale_cache_coverage_test.py
+++ b/tests/stale_cache_coverage_test.py
@@ -18,6 +18,7 @@ Covers:
 """
 
 import importlib.util
+import logging
 import sys
 from datetime import datetime, timedelta
 from pathlib import Path
@@ -38,8 +39,9 @@ WINDOW_START = datetime(2026, 3, 28, 18, 0)
 WINDOW_END = datetime(2026, 3, 29, 18, 0)
 
 
-@pytest.fixture(scope='module')
-def create_1dplot_mod():
+@pytest.fixture(scope='module', name='create_1dplot_mod')
+def fixture_create_1dplot_mod():
+    """Import bin/visualization/create_1dplot.py as a module."""
     spec = importlib.util.spec_from_file_location(
         'create_1dplot_stale_cache_under_test', CREATE_1DPLOT_PATH)
     mod = importlib.util.module_from_spec(spec)
@@ -61,6 +63,21 @@ def _write_pair_file(path, start, hours, header=True):
     path.write_text('\n'.join(lines) + '\n', encoding='utf-8')
 
 
+def _make_logger():
+    """Return a plain logger for functions that require one."""
+    return logging.getLogger('stale_cache_test')
+
+
+def _paired_df(start, hours):
+    """Build a paired-data-shaped DataFrame with hourly timestamps."""
+    stamps = [start + timedelta(hours=i) for i in range(hours)]
+    return pd.DataFrame({
+        'DateTime': stamps,
+        'OBS': [7.4] * hours,
+        'OFS': [5.3] * hours,
+    })
+
+
 class _WindowProp:
     """Minimum prop surface for the run-window helpers."""
 
@@ -68,28 +85,37 @@ class _WindowProp:
                  end='2026-03-29T18:00:00Z'):
         self.start_date_full = start
         self.end_date_full = end
+        self.whichcasts = []
 
 
 class TestTimeseriesCoverage:
+    """Unit tests for the timeseries_coverage helper module."""
 
     def test_parse_run_window_iso_format(self):
+        """ISO-format dates parse to the expected window."""
         window = parse_run_window(_WindowProp())
         assert window == (WINDOW_START, WINDOW_END)
 
     def test_parse_run_window_compact_format(self):
+        """Compact YYYYMMDD-HH:MM:SS dates parse identically."""
         window = parse_run_window(
             _WindowProp('20260328-18:00:00', '20260329-18:00:00'))
         assert window == (WINDOW_START, WINDOW_END)
 
     def test_parse_run_window_unparseable_returns_none(self):
+        """Unparseable date strings yield None, not an exception."""
         assert parse_run_window(_WindowProp('garbage', 'garbage')) is None
 
     def test_parse_run_window_missing_attributes_returns_none(self):
-        # Some callers (and test stubs) hand in prop objects without the
-        # date attributes; staleness checks must be skipped, not crash.
+        """Prop objects without the date attributes yield None.
+
+        Some callers (and test stubs) hand in prop objects without the
+        date attributes; staleness checks must be skipped, not crash.
+        """
         assert parse_run_window(object()) is None
 
     def test_read_first_last_skips_header(self, tmp_path):
+        """The header row is skipped when reading first/last stamps."""
         pair = tmp_path / 'pair.int'
         _write_pair_file(pair, WINDOW_START, hours=25)
         first, last = read_first_last_timestamps(pair)
@@ -97,30 +123,34 @@ class TestTimeseriesCoverage:
         assert last == WINDOW_START + timedelta(hours=24)
 
     def test_fresh_file_covers_window(self, tmp_path):
+        """A file spanning the full window passes the coverage check."""
         pair = tmp_path / 'pair.int'
         _write_pair_file(pair, WINDOW_START, hours=25)
         assert covers_run_window(pair, WINDOW_START, WINDOW_END)
 
     def test_adjacent_stale_file_fails(self, tmp_path):
-        # Yesterday's file: ends exactly at the new window's start -- the
-        # daily-operations signature that produced one-point plots.
+        """Yesterday's file, ending exactly at the new window's start,
+        fails the check -- the daily-operations signature that produced
+        one-point plots."""
         pair = tmp_path / 'pair.int'
         _write_pair_file(pair, WINDOW_START - timedelta(hours=24), hours=25)
         assert not covers_run_window(pair, WINDOW_START, WINDOW_END)
 
     def test_disjoint_stale_file_fails(self, tmp_path):
+        """A file from a disjoint window fails the check."""
         pair = tmp_path / 'pair.int'
         _write_pair_file(pair, WINDOW_START - timedelta(days=5), hours=25)
         assert not covers_run_window(pair, WINDOW_START, WINDOW_END)
 
     def test_partial_coverage_from_data_gap_is_tolerated(self, tmp_path):
-        # A file that covers most of the window (e.g. the last model cycle
-        # not yet available) must NOT trigger regeneration churn.
+        """A file covering most of the window (e.g. the last model cycle
+        not yet available) must NOT trigger regeneration churn."""
         pair = tmp_path / 'pair.int'
         _write_pair_file(pair, WINDOW_START, hours=19)
         assert covers_run_window(pair, WINDOW_START, WINDOW_END)
 
     def test_unparseable_file_fails_open(self, tmp_path):
+        """A file with no parseable data rows is treated as covering."""
         pair = tmp_path / 'pair.int'
         pair.write_text('not a data row\nstill not one\n', encoding='utf-8')
         assert covers_run_window(pair, WINDOW_START, WINDOW_END)
@@ -150,9 +180,12 @@ OFS_CTL = [None, [29], None, None, ['8571421']]
 
 
 class TestEnsurePairedDataStaleness:
+    """Stale-pair handling in _ensure_paired_data_exists."""
 
     def test_stale_pair_is_deleted_and_regenerated(
             self, create_1dplot_mod, tmp_path, monkeypatch):
+        """A pair file from the previous window is deleted and its cast
+        queued for regeneration through get_skill."""
         pair = tmp_path / 'cbofs_temp_8571421_29_nowcast_stations_pair.int'
         _write_pair_file(pair, WINDOW_START - timedelta(hours=24), hours=25)
 
@@ -168,6 +201,7 @@ class TestEnsurePairedDataStaleness:
 
     def test_fresh_pair_is_left_alone(
             self, create_1dplot_mod, tmp_path, monkeypatch):
+        """A pair file covering the current window is reused as-is."""
         pair = tmp_path / 'cbofs_temp_8571421_29_nowcast_stations_pair.int'
         _write_pair_file(pair, WINDOW_START, hours=25)
 
@@ -179,26 +213,14 @@ class TestEnsurePairedDataStaleness:
             OFS_CTL, prop, VAR_INFO, _make_logger())
 
         assert pair.exists()
-        assert calls == []
-
-
-def _make_logger():
-    import logging
-    return logging.getLogger('stale_cache_test')
-
-
-def _paired_df(start, hours):
-    stamps = [start + timedelta(hours=i) for i in range(hours)]
-    return pd.DataFrame({
-        'DateTime': stamps,
-        'OBS': [7.4] * hours,
-        'OFS': [5.3] * hours,
-    })
+        assert not calls
 
 
 class TestDropStaleCasts:
+    """Plot-time guard against stale paired series."""
 
     def test_stale_cast_dropped_fresh_cast_kept(self, create_1dplot_mod):
+        """Only the cast whose series intersects the window survives."""
         prop = _WindowProp()
         prop.whichcasts = ['nowcast', 'forecast_b']
         fresh = _paired_df(WINDOW_START, 25)
@@ -212,16 +234,17 @@ class TestDropStaleCasts:
         assert len(pairs) == 1 and pairs[0] is fresh
 
     def test_all_stale_returns_empty(self, create_1dplot_mod):
+        """When every cast is stale, nothing is left to plot."""
         prop = _WindowProp()
         prop.whichcasts = ['nowcast']
         stale = _paired_df(WINDOW_START - timedelta(days=3), 25)
         pairs, casts = create_1dplot_mod._drop_stale_casts(
             [stale], ['nowcast'], prop, '8571421', _make_logger())
-        assert pairs == [] and casts == []
+        assert not pairs and not casts
 
     def test_nowcast_forecast_a_combo_is_exempt(self, create_1dplot_mod):
-        # combine_obs_across_casts applies no crop for this combo, so the
-        # guard must not drop anything either.
+        """combine_obs_across_casts applies no crop for this combo, so
+        the guard must not drop anything either."""
         prop = _WindowProp()
         prop.whichcasts = ['nowcast', 'forecast_a']
         stale = _paired_df(WINDOW_START - timedelta(days=3), 25)
@@ -232,10 +255,11 @@ class TestDropStaleCasts:
         assert len(pairs) == 2
 
     def test_unparseable_window_keeps_everything(self, create_1dplot_mod):
+        """Without a parseable window the guard is skipped entirely."""
         prop = _WindowProp('garbage', 'garbage')
         prop.whichcasts = ['nowcast']
         stale = _paired_df(WINDOW_START - timedelta(days=3), 25)
-        pairs, casts = create_1dplot_mod._drop_stale_casts(
+        _, casts = create_1dplot_mod._drop_stale_casts(
             [stale], ['nowcast'], prop, '8571421', _make_logger())
         assert casts == ['nowcast']
 
@@ -255,6 +279,7 @@ STATION_CTL = [[['8571421', 'name_Solomons', 'CO-OPS']],
 
 
 class TestFilenameKeyLeftMerge:
+    """Integration through _process_station_plot."""
 
     def test_partial_key_does_not_drop_rows(
             self, create_1dplot_mod, tmp_path, monkeypatch):
@@ -264,8 +289,8 @@ class TestFilenameKeyLeftMerge:
         pair_dir = tmp_path / 'pair'
         node_dir = tmp_path / 'node'
         visual_dir = tmp_path / 'visual'
-        for d in (pair_dir, node_dir, visual_dir):
-            d.mkdir()
+        for directory in (pair_dir, node_dir, visual_dir):
+            directory.mkdir()
 
         pair = pair_dir / 'cbofs_temp_8571421_29_nowcast_stations_pair.int'
         _write_pair_file(pair, WINDOW_START, hours=25)
@@ -279,7 +304,7 @@ class TestFilenameKeyLeftMerge:
 
         captured = {}
 
-        def _capture_plot(now_fores_paired, *args, **kwargs):
+        def _capture_plot(now_fores_paired, *_args, **_kwargs):
             captured['pairs'] = now_fores_paired
 
         monkeypatch.setattr(
@@ -297,13 +322,13 @@ class TestFilenameKeyLeftMerge:
 
     def test_stale_pair_reaches_no_plot(
             self, create_1dplot_mod, tmp_path, monkeypatch):
-        """End-to-end through _process_station_plot: a stale pair file must
-        not produce a plot call at all."""
+        """End-to-end through _process_station_plot: a stale pair file
+        must not produce a plot call at all."""
         pair_dir = tmp_path / 'pair'
         node_dir = tmp_path / 'node'
         visual_dir = tmp_path / 'visual'
-        for d in (pair_dir, node_dir, visual_dir):
-            d.mkdir()
+        for directory in (pair_dir, node_dir, visual_dir):
+            directory.mkdir()
 
         pair = pair_dir / 'cbofs_temp_8571421_29_nowcast_stations_pair.int'
         _write_pair_file(pair, WINDOW_START - timedelta(hours=24), hours=25)
@@ -317,6 +342,6 @@ class TestFilenameKeyLeftMerge:
         create_1dplot_mod._process_station_plot(
             0, OFS_CTL, STATION_CTL, prop, VAR_INFO, _make_logger())
 
-        assert calls == [], (
+        assert not calls, (
             'a stale pair file must be dropped by the plot-time guard, '
             'not rendered as a one-point plot')


### PR DESCRIPTION
### Description of Changes

Closes #202.

Operational front-end users have been seeing 1D timeseries plots with **only one data point**. We fixed a NECOFS-specific trigger of this symptom in #104 / PR #169 (a threading race in the parallel plot dispatch), but the symptom returned on other OFS — and the remaining cause is the pipeline's file caching, not the race.

Every cached artifact (`*_station.obs`, `*_model.prd`, `*_pair.int`, `{ofs}_{cast}_filename_key.csv`) is keyed by a filename that does **not encode the assessment start/end dates**, and every existence check reuses those files without checking what dates they contain. At plot time, `combine_obs_across_casts` crops every trace to `[start_date, end_date]`. Crop a stale series to the current window and you get exactly one point when the stale file's window is adjacent to the current one (daily operational runs share a boundary timestamp), or a blank plot — written silently, with no warning — when the windows are disjoint. Rolling windows (e.g. a 7-day assessment re-run daily) are subtler: the stale file overlaps most of the new window but is missing exactly the newest data.

Reproduced on cbofs (with the PR #169 fix in place): re-running `create_1dplot.py` with the window shifted one day over existing pair files collapsed every water-temperature trace from 181 points to **1 point**; shifted two days, to **0 points**. Full analysis in #202.

Self-review of the first draft (`ba667ec`/`cb9aceb`) surfaced design gaps in the original overlap-fraction staleness test and some robustness holes in the deletion paths; all are fixed in `756c848`, and the description below reflects the final state.

Labels: `bug`

### Summary of changes

**Correctness — coverage-aware cache reuse**
- New `src/ofs_skill/utils/timeseries_coverage.py`: reads a cached artifact's first/last data-row timestamps and flags the file stale when its data starts more than `STALENESS_TOLERANCE` (12 h) after the window start, or ends more than that before `min(end_date, now)`. Judging against the window ends rather than an overlap fraction catches **both** stale directions — adjacent/disjoint windows *and* rolling windows (a file from yesterday's 7-day window overlaps ~86% of today's but always ends ~24 h short) — while never penalizing what isn't stale: clamping the end to *now* exempts forecast windows that extend into the future (fresh forecast_a artifacts cannot contain data that doesn't exist yet), and mid-window data gaps (gauge outages, late model cycles) are never penalized, so genuine gaps don't cause regeneration churn. Unparseable files — including binary/corrupt ones — fail open into the existing error handling.
- Applied at all four reuse points, deleting stale files so the existing missing-file paths regenerate them:
  - `_ensure_paired_data_exists` (`bin/visualization/create_1dplot.py`) — pair files;
  - `_ensure_obs_files` (`src/ofs_skill/skill_assessment/get_skill.py`) — `.obs` files. Deletion is required here: the obs module skips stations whose `.obs` file already exists, so a stale obs file otherwise never refreshes;
  - `_ensure_prd_files` (same file) — `.prd` files;
  - `_all_prd_files_complete` (`src/ofs_skill/model_processing/get_node_ofs.py`) — the `.prd` resume short-circuit validates by row count, and adjacent daily windows produce identical row counts, so stale model series passed that check too.
- The obs/prd ensure loops now scan all stations (deleting every stale file) before triggering one fetch/extraction, instead of breaking on the first missing file.
- All deletions go through a single guarded path, `remove_stale_artifact`: it refuses any target that resolves outside the artifact directory (station IDs embedded in these paths originate from external metadata services) and tolerates a concurrent run having already deleted the file.
- `parse_run_window` parses the start and end dates independently, so a run that has rewritten one of them to the compact format mid-pipeline still gets staleness checks (previously a mixed-format state silently disabled them), and every call site now passes the logger so a disabled check is always visible in the log.

**Correctness — plot-time guard**
- New `_drop_stale_casts` in `create_1dplot.py`: any cast whose paired series has fewer than `MIN_POINTS_TO_PLOT` (2) points inside the run window is dropped from the plot with an ERROR in the log, instead of being rendered as a one-point/blank plot. This is defense-in-depth behind the cache fix — no misleading plot can be published even if stale data reaches the plot step by some other route.
- The guard's nowcast+forecast_a exemption is evaluated on the cast list the plot-time crop will actually see (the casts that have a paired series, matched case-sensitively exactly as `combine_obs_across_casts` matches them). This closes a route where a nowcast+forecast_a run that lost its forecast_a pair skipped the guard while the crop still fired.
- The cast labels are kept positionally aligned with the series actually plotted. This also fixes a latent misalignment: when a pair file was missing for one cast but not another, the plotting functions (which index `prop.whichcasts` positionally against `now_fores_paired`) mislabeled the remaining traces.
- When a cast is dropped, the output filename changes (plot names embed `'_'.join(whichcasts)`), so the previous run's plot under the full-cast name would have kept being served with stale data. `_remove_superseded_plots` now deletes those files for the affected station/variable.

**Correctness — filename-key merge**
- The merge that attaches hover-text model cycles from `{ofs}_{cast}_filename_key.csv` is now `how='left'` instead of `how='inner'`. The key only supplies hover text, so a stale or partial key now yields incomplete hover labels (with a warning) instead of silently pruning data rows. This retires the long-standing `Filename key and time series have different lengths!` warning noted as a follow-up in PR #169.

**Tests**
- New `tests/stale_cache_coverage_test.py` (33 tests): the coverage helper (fresh/adjacent-stale/disjoint/rolling-window/exact-50%-advance/future-window fresh and stale/mid-gap tolerated/late-start/unparseable/binary/overflow-row), the guarded deletion path (inside-dir delete, outside-dir refusal, concurrent-delete tolerance), stale-pair deletion + regeneration in `_ensure_paired_data_exists`, the plot-time guard (including the adjacent-window one-point signature, the nowcast+forecast_a exemption, the missing-forecast_a and case-sensitivity alignment with the crop), and three integration tests through `_process_station_plot` (partial key must not drop rows — verified to fail against the previous inner merge; stale pair must produce no plot call; a superseded full-cast plot must be removed).

**Known, accepted limitation**
- A station whose data genuinely stops more than 12 h before the window end (e.g. an extended buoy outage) is deleted and re-fetched once per run. The churn is bounded (one fetch per run per affected station) and only affects stations that would not plot for the window anyway; a per-window marker file could eliminate it if it ever matters in operations.

### Expected Outcome of Changes

- Runs over a persistent working directory whose cached files are from an earlier date window — adjacent, disjoint, **or overlapping/rolling** — now **regenerate** those files for the current window instead of plotting them cropped or frozen at old data.
- Forecast-mode runs (windows extending past *now*) reuse their caches normally: fresh artifacts are never flagged stale for data that cannot exist yet.
- A station whose data genuinely cannot be regenerated (obs outage, model files unavailable) produces **no plot and a clear ERROR/WARNING trail**, rather than a silently misleading one-point or blank HTML — and any previously published plot under a cast naming this run no longer writes is removed rather than left to be served.
- Fresh single-window runs are unaffected: pair/obs/prd files produced by the current run always cover the window and are reused exactly as before.
- No change to `.prd` / `.int` / `.obs` schemas or output paths. Regeneration cost is only incurred when a stale file is detected.

### Developer Questions and Checklist

**Is this a high priority PR? If yes, why and is there a date by which it needs to be merged?**
Yes — this is the cause of the one-point timeseries plots currently visible in the operational front end, and the blank-plot variant is worse because it looks like a data problem rather than a pipeline bug.

**Are there any changes needed to how the code should be run for operational runs? (Commands, flags, job timings, etc.)**
No. Existing commands and configs work unchanged. Operational setups that clear the data directories between runs as a workaround can stop doing so once this is deployed.

**Does this update need to be deployed for operational runs?**
Yes — without it, any operational workspace that persists between daily runs can serve one-point, blank, or silently frozen plots for stations whose data failed to regenerate.

**Does this update require front end/web app changes? (If yes, provide documentation to Min)**
No. The front end simply stops receiving one-point/blank/stale HTMLs.

**Does this impact code development work on adding SCHISM?**
No. The coverage checks are format-agnostic (they parse the shared year/month/day/hour/minute row layout used by all model sources).

**Does this impact code development work on adding ADCIRC?**
No, same reason.

**Does this impact the expected number of output files for integration tests (i.e., will the integration test fail even though code changes result in desired change in outputs?)**
Only in the intended case: a plot that would previously have been written with 0–1 points is now skipped with an ERROR (and a stale-named leftover plot may be deleted). Fresh-run integration tests produce the same file counts as before.

- [x] Developer's name is removed throughout the code
- [x] Did you add relevant labels to the PR? — `bug`
- [x] Have you run pylint and is the code at an acceptable pylint score (>8)? — `timeseries_coverage.py` **10.00**, `create_1dplot.py` **9.05**, `get_skill.py` **9.43**, `get_node_ofs.py` **8.59**, `stale_cache_coverage_test.py` **9.42**
- [x] Jobs contain the appropriate file checking and handle errors for any missing data — stale files are deleted through a guarded path and flow through the existing missing-file handling; unparseable or corrupt files fail open into the existing error paths
- [x] Is log free of critical ERRORs or WARNINGs? — new WARNINGs/ERRORs only fire when stale files are detected, a cast is dropped, or a superseded plot is removed, which is exactly when the operator needs to see them

### Testing Instructions

**Setup**

```bash
git fetch origin
git checkout fix-stale-cache-one-point-plots
eval "$(~/miniforge3/bin/conda shell.bash hook)" && conda activate ofs_dps
pip install -e .
```

**Unit tests**

```bash
python -m pytest tests/ --no-cov -q --ignore=tests/manual
```

Expected: full suite passes (859 passed, 1 xfailed on my machine — no regressions). The new tests are in `tests/stale_cache_coverage_test.py` (33 tests).

To prove the merge test is a real regression guard, revert `how='left'` back to `how='inner'` at the filename-key merge in `bin/visualization/create_1dplot.py` and re-run `tests/stale_cache_coverage_test.py::TestFilenameKeyLeftMerge::test_partial_key_does_not_drop_rows` — it fails.

**Integration: reproduce the stale-cache collapse (the bug this PR fixes)**

1. Run any OFS end-to-end for a 1-day window, e.g.:
   ```bash
   python ./bin/visualization/create_1dplot.py -o cbofs -p ./ \
     -s <dayN>T18:00:00Z -e <dayN+1>T18:00:00Z \
     -d MLLW -ws nowcast -t stations -vs water_temperature
   ```
2. Re-run the same command with the window shifted forward one day (`dayN+1` → `dayN+2`) **without clearing the data directories**.

**Before this PR:** step 2 silently produces HTMLs where every trace has exactly one data point (the boundary timestamp).
**After this PR:** step 2 logs `does not cover the run window ... Deleting it so it is regenerated` for each stale file and regenerates obs/model/pair data for the new window; the resulting plots contain the full series. (Verified on cbofs at `756c848`: the shifted rerun fired 63 stale detections — 26 `.obs`, 19 `.prd`, 18 `.int` — and every plot trace had the full 241 points spanning exactly the new window.) If data for the new window is genuinely unavailable, no plot is written and the log says why.

**Integration: fresh-run regression check**

Run step 1 twice in a row with the same window — the second run should reuse all cached files (no `does not cover` warnings, unchanged file mtimes) and produce identical plots.

### Reminder checklist for PR reviewer

- [ ] Run PEP8 / pylint compliance — all touched files score ≥ 8.5 (see checklist above)
- [ ] Check that documentation in the script is sufficient — the coverage module docstring explains both failure modes (adjacent/disjoint and rolling windows) and the fail-open contract; each reuse site has a comment pointing at the stale-file hazard
- [ ] Validate output values — easiest check is the integration repro above; also diff `.prd`/`.int` files between two identical-window runs (should be unchanged)
- [ ] Test code on Windows and Linux. Tested on Linux locally; file handling uses `os.path`/`pathlib` throughout, no platform-specific paths (`remove_stale_artifact` containment check handles cross-drive paths on Windows)
- [ ] **Test for all 'cast' options: forecast_a, forecast_b, and nowcast** — the guard exempts nowcast+forecast_a combos exactly where `combine_obs_across_casts` skips its crop (evaluated on the casts actually paired); forecast windows extending past *now* never flag fresh artifacts stale; forecast_a `.prd` filenames (with cycle hour) are handled in `_ensure_prd_files`
- [ ] Add the call you used to the PR comments when reviewing
