### PR TITLE
Retire the netcdf_dir config setting and report NODD download failures honestly (#213)

### DIFF
--- a/bin/skill_assessment/do_iceskill.py
+++ b/bin/skill_assessment/do_iceskill.py
@@ -93,6 +93,7 @@ from bin.model_processing import get_icecover_model
 from bin.obs_retrieval import get_icecover_observations
 from bin.visualization import create_1dplot_ice
 from ofs_skill.model_processing import (
+    local_model_dir,
     model_properties,
     model_source,
 )
@@ -455,8 +456,8 @@ def do_iceskill(prop, logger):
     )
     os.makedirs(prop.data_model_ice_path, exist_ok=True)
     # Example (local) ice data
-    prop.model_path = os.path.join(
-        dir_params['model_historical_dir'], prop.ofs, dir_params['netcdf_dir'],
+    prop.model_path = local_model_dir(
+        dir_params['model_historical_dir'], prop.ofs, logger,
     )
 
     # Parse whichcasts argument

--- a/bin/utils/get_model_data.py
+++ b/bin/utils/get_model_data.py
@@ -338,7 +338,17 @@ def make_file_list(prop, dates, dir_list, logger):
                                 file_list.append(file_name)
 
         elif prop.ofsfiletype == 'stations':
-            if prop.ofs in ('stofs_2d_glo'):
+            if prop.ofs in ('stofs_3d_atl', 'stofs_3d_pac'):
+                for i, datei in enumerate(dates):
+                    for cycle in fcstcycles:
+                        # STOFS-3D writes one points (station) file per cycle
+                        # containing both the nowcast and forecast periods.
+                        file_name = f'{prop.ofs}.t{cycle}z.' \
+                            'points.cwl.temp.salt.vel.nc'
+                        file_list.append(
+                            os.path.join(dir_list[i], file_name).replace('\\', '/')
+                        )
+            elif prop.ofs in ('stofs_2d_glo'):
                 for i, datei in enumerate(dates):
                     for cycle in fcstcycles:
                         # For now we're just doing the combined water level ("cwl").
@@ -419,7 +429,17 @@ def make_file_list(prop, dates, dir_list, logger):
                                 file_list.append(file_name)
 
         elif prop.ofsfiletype == 'stations':
-            if prop.ofs in ('stofs_2d_glo'):
+            if prop.ofs in ('stofs_3d_atl', 'stofs_3d_pac'):
+                for i, datei in enumerate(dates):
+                    for cycle in fcstcycles:
+                        # STOFS-3D writes one points (station) file per cycle
+                        # containing both the nowcast and forecast periods.
+                        file_name = f'{prop.ofs}.t{cycle}z.' \
+                            'points.cwl.temp.salt.vel.nc'
+                        file_list.append(
+                            os.path.join(dir_list[i], file_name).replace('\\', '/')
+                        )
+            elif prop.ofs in ('stofs_2d_glo'):
                 for i, datei in enumerate(dates):
                     for cycle in fcstcycles:
                         # For now we're just doing the combined water level ("cwl").
@@ -459,6 +479,32 @@ def make_file_list(prop, dates, dir_list, logger):
     return file_list
 
 
+def get_nodd_prefix_map(prop, logger):
+    """
+    Return (local_prefix, bucket_prefix) for translating file paths between
+    the local directory layout ({ofs}/{netcdf_dir}/) and the layout of the
+    NODD S3 bucket for the OFS.
+
+    The STOFS buckets have no netcdf subdirectory: STOFS-3D buckets use
+    capitalized top-level prefixes (STOFS-3D-Atl/, STOFS-3D-Pac/), and the
+    STOFS-2D-Global bucket stores date directories at the bucket root. For
+    all other OFS the bucket layout matches the local layout, so both
+    prefixes are identical and translation is a no-op.
+    """
+    _conf = getattr(prop, 'config_file', None)
+    dir_params = utils.Utils(_conf).read_config_section('directories', logger)
+    local_prefix = Path(
+        os.path.join(prop.ofs, dir_params['netcdf_dir'])
+    ).as_posix() + '/'
+    bucket_prefixes = {
+        'stofs_3d_atl': 'STOFS-3D-Atl/',
+        'stofs_3d_pac': 'STOFS-3D-Pac/',
+        'stofs_2d_glo': '',
+    }
+    bucket_prefix = bucket_prefixes.get(prop.ofs, local_prefix)
+    return local_prefix, bucket_prefix
+
+
 def list_of_urls(file_list, prop, logger):
     """
     This function take a file list and builds the URLs for all downloads.
@@ -467,6 +513,7 @@ def list_of_urls(file_list, prop, logger):
     # Retrieve urls from config file
     _conf = getattr(prop, 'config_file', None)
     url_params = utils.Utils(_conf).read_config_section('urls', logger)
+    local_prefix, bucket_prefix = get_nodd_prefix_map(prop, logger)
     if prop.ofs not in ('stofs_3d_atl', 'stofs_3d_pac', 'stofs_2d_glo'):
         url_root = url_params['nodd_s3']
         url_list = []
@@ -482,7 +529,7 @@ def list_of_urls(file_list, prop, logger):
         for file in file_list:
             url = (
                 f'{url_root}'
-                f"{file.replace('stofs_3d_atl/', 'STOFS-3D-Atl/')}"
+                f'{file.replace(local_prefix, bucket_prefix)}'
             )
             url_list.append(url)
     elif prop.ofs == 'stofs_2d_glo':
@@ -491,7 +538,7 @@ def list_of_urls(file_list, prop, logger):
         for file in file_list:
             url = (
                 f'{url_root}'
-                f"{file.replace('stofs_2d_glo/', '')}"
+                f'{file.replace(local_prefix, bucket_prefix)}'
             )
             url_list.append(url)
     logger.info(f'Starting URL building for {url_root}...')
@@ -500,7 +547,8 @@ def list_of_urls(file_list, prop, logger):
     return url_list
 
 
-def _download_single_file(mod_dat, savepath, ofs, logger):
+def _download_single_file(mod_dat, savepath, ofs, logger,
+                          bucket_prefix='', local_prefix=''):
     """
     Download a single model output file from the NODD.
 
@@ -518,6 +566,11 @@ def _download_single_file(mod_dat, savepath, ofs, logger):
         OFS name (e.g. 'cbofs', 'stofs_3d_atl').
     logger : logging.Logger
         Logger instance.
+    bucket_prefix : str
+        S3 bucket path prefix for the OFS (e.g. 'STOFS-3D-Atl/'), swapped
+        for local_prefix when building the local file path.
+    local_prefix : str
+        Local directory layout prefix (e.g. 'stofs_3d_atl/netcdf/').
 
     Returns
     -------
@@ -529,18 +582,15 @@ def _download_single_file(mod_dat, savepath, ofs, logger):
 
     try:
         # Build the local file path based on OFS type
-        if ofs not in ('stofs_3d_atl', 'stofs_3d_pac', 'stofs_2d_global'):
-            local_path = (
-                savepath + mod_dat.split('.com')[-1]
-            ).replace('//', '/')
-        elif ofs in ('stofs_3d_atl', 'stofs_3d_pac'):
+        if ofs in ('stofs_3d_atl', 'stofs_3d_pac') and bucket_prefix:
             local_path = (
                 savepath + mod_dat.split('.com')[-1]
             ).replace('//', '/').replace(
-                'STOFS-3D-Atl/', 'stofs_3d_atl/',
+                bucket_prefix, local_prefix,
             )
         else:
-            # stofs_2d_global or other future stofs variants
+            # Non-stofs OFS (bucket layout matches the local layout) and
+            # stofs_2d_glo (savepath already carries the local prefix).
             local_path = (
                 savepath + mod_dat.split('.com')[-1]
             ).replace('//', '/')
@@ -581,36 +631,35 @@ def download_data(prop, list_of_urls1, dir_list, logger):
     """
     # Set up save path
     savepath = dir_list[0][:].split(prop.ofs)[0]
-    # Need to add a "stofs_2d_glo" to the savepath for stofs_2d_glo files
+    # Prefixes for translating bucket paths back to the local layout
+    local_prefix, bucket_prefix = get_nodd_prefix_map(prop, logger)
+    # Need to add the local prefix to the savepath for stofs_2d_glo files
     # because the NODD S3 bucket doesn't contain it (unlike other models).
     if prop.ofs == 'stofs_2d_glo':
-        savepath = savepath + 'stofs_2d_glo/'
+        savepath = savepath + local_prefix
     # First try the NODD and see if it's responding
     try:
         logger.info('Try NODD S3 download...')
-        if prop.ofs not in ('stofs_3d_atl', 'stofs_3d_pac', 'stofs_2d_glo'):
+        if prop.ofs in ('stofs_3d_atl', 'stofs_3d_pac'):
+            urllib.request.urlretrieve(
+                list_of_urls1[0].replace('\\', '/'), (
+                    savepath +
+                    list_of_urls1[0].split('.com')[-1]
+                ).replace('//', '/').replace(bucket_prefix, local_prefix),
+            )
+        else:
             urllib.request.urlretrieve(
                 list_of_urls1[0].replace('\\', '/'), (
                     savepath +
                     list_of_urls1[0].split('.com')[-1]
                 ).replace('//', '/'),
             )
-        elif prop.ofs in ('stofs_3d_atl', 'stofs_3d_pac'):
-            urllib.request.urlretrieve(
-                list_of_urls1[0].replace('\\', '/'), (
-                    savepath +
-                    list_of_urls1[0].split('.com')[-1]
-                ).replace('//', '/').replace('STOFS-3D-Atl/', 'stofs_3d_atl/'),
-            )
-        elif prop.ofs in ('stofs_2d_glo'):
-            urllib.request.urlretrieve(
-                list_of_urls1[0].replace('\\', '/'),
-                (savepath + list_of_urls1[0].split('.com')[-1]).replace('//', '/'),
-            )
         logger.info('NODD is responding! Keep going -->')
         list_of_urls_main = list_of_urls1
     except (ValueError, HTTPError, Exception) as e_x:
         logger.info("NODD S3 is not responding! I'm out.")
+        logger.error('First download failed for URL: %s',
+                     list_of_urls1[0].replace('\\', '/'))
         logger.error(f'Exception: {e_x}')
         sys.exit(-1)
         # list_of_urls = list_of_urls2
@@ -623,6 +672,7 @@ def download_data(prop, list_of_urls1, dir_list, logger):
         futures = {
             executor.submit(
                 _download_single_file, mod_dat, savepath, prop.ofs, logger,
+                bucket_prefix, local_prefix,
             ): mod_dat
             for mod_dat in list_of_urls_main
         }

--- a/bin/utils/get_model_data.py
+++ b/bin/utils/get_model_data.py
@@ -16,6 +16,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime, timedelta
 from pathlib import Path
 from urllib.error import HTTPError
+from urllib.parse import urlparse
 
 import numpy as np
 
@@ -149,7 +150,9 @@ def get_ofs_cycle(prop, logger):
         ).astype(int).astype(str)
     return fcstcycles, hrstrings
 
-def dates_range(start_date, end_date, ofs, whichcast,logger):
+# pylint: disable-next=too-many-arguments
+def dates_range(start_date, end_date, ofs, whichcast, logger, *,
+                ofsfiletype=None):
     """
     This function uses the start and end date and returns
     all the dates between start and end.
@@ -160,6 +163,14 @@ def dates_range(start_date, end_date, ofs, whichcast,logger):
 
     # For WCOFS nowcast, we need to look an extra day ahead
     if ofs == 'wcofs' and whichcast == 'nowcast':
+        offset = 2
+    # Same for STOFS-3D stations nowcast: the t12z points file covers the
+    # preceding 24 hours, so the post-12Z hours of the window's last day
+    # live in the NEXT day's file. The read side already looks a day ahead
+    # (list_of_files.dates_range); mirror it here so pre-provisioned runs
+    # (use_s3_fallback=False) have the file the reader asks for.
+    elif (ofs in ('stofs_3d_atl', 'stofs_3d_pac')
+          and whichcast == 'nowcast' and ofsfiletype == 'stations'):
         offset = 2
     else:
         offset = 1
@@ -199,12 +210,14 @@ def list_of_dir(prop, basepath, logger):
     """
 
     dir_list = []
+    ofsfiletype = getattr(prop, 'ofsfiletype', None)
     if prop.whichcast != 'forecast_a':
         dates = dates_range(prop.start_date_full, prop.end_date_full, prop.ofs,
-                            prop.whichcast, logger)
+                            prop.whichcast, logger, ofsfiletype=ofsfiletype)
     else:
         dates = dates_range(prop.start_date_full, prop.start_date_full,
-                            prop.ofs, prop.whichcast, logger)
+                            prop.ofs, prop.whichcast, logger,
+                            ofsfiletype=ofsfiletype)
     dates_len = len(dates)
     # After 12/31/24, directory structure changes! Now we need to sort
     # a dir list that might have two different formats.
@@ -531,11 +544,37 @@ def _url_to_local_path(url, savepath, prefix_map):
         The local file path.
     """
     local_prefix, bucket_prefix = prefix_map
-    key = url.split('.com')[-1].lstrip('/')
+    # urlparse().path is exactly the bucket key regardless of the endpoint
+    # host (a '.com' substring split breaks for non-.com endpoints and for
+    # keys that themselves contain '.com').
+    key = urlparse(url).path.lstrip('/')
     # No-op for non-STOFS OFS (identical prefixes) and for stofs_2d_glo
     # (empty bucket prefix; savepath already carries the local prefix).
     key = swap_path_prefix(key, bucket_prefix, local_prefix)
     return f'{savepath}/{key}'.replace('//', '/')
+
+
+def _retrieve_atomic(url, local_path):
+    """
+    Download url to local_path via a temporary '.part' name.
+
+    urllib.request.urlretrieve writes directly to its destination, so an
+    interrupted transfer would leave a truncated file at the final path
+    that later runs treat as complete (same defect class as issues
+    #176/#193, fixed for the S3 cache path in intake_scisa.py). Download
+    to '<name>.part' and promote with os.replace() only after the
+    transfer finishes; on failure the partial '.part' file is removed.
+    """
+    part_path = f'{local_path}.part'
+    try:
+        urllib.request.urlretrieve(url, part_path)
+        os.replace(part_path, local_path)
+    except BaseException:
+        try:
+            os.remove(part_path)
+        except OSError:
+            pass
+        raise
 
 
 def _download_single_file(mod_dat, savepath, logger, prefix_map=('', '')):
@@ -570,7 +609,15 @@ def _download_single_file(mod_dat, savepath, logger, prefix_map=('', '')):
     try:
         local_path = _url_to_local_path(mod_dat, savepath, prefix_map)
 
-        # Skip if file already exists
+        # Remove any stale partial file left by an interrupted run
+        part_path = f'{local_path}.part'
+        if os.path.isfile(part_path):
+            logger.warning('Removing stale partial download: %s', part_path)
+            os.remove(part_path)
+
+        # Skip if file already exists. Safe because downloads are promoted
+        # to the final name only after they finish (_retrieve_atomic), so
+        # a truncated transfer can never land at the final path.
         if os.path.isfile(local_path):
             logger.info('File already exists, skipping: %s', local_path)
             return local_path
@@ -581,7 +628,7 @@ def _download_single_file(mod_dat, savepath, logger, prefix_map=('', '')):
         # Retry loop for transient HTTP errors
         for attempt in range(max_retries):
             try:
-                urllib.request.urlretrieve(url, local_path)
+                _retrieve_atomic(url, local_path)
                 return local_path
             except HTTPError as e:
                 if e.code == 503 and attempt < max_retries - 1:
@@ -600,15 +647,55 @@ def _download_single_file(mod_dat, savepath, logger, prefix_map=('', '')):
     return None
 
 
+def _derive_savepath(dir_list, local_prefix):
+    """
+    Derive the local base path (everything above {ofs}/{netcdf_dir}/)
+    from the first save directory.
+
+    Splitting on the first occurrence of the OFS name anywhere in the
+    string breaks for working directories that happen to contain the OFS
+    name (e.g. /home/user/cbofs_runs/). Instead, locate the trailing,
+    path-anchored {ofs}/{netcdf_dir}/ layout component from
+    get_nodd_prefix_map and keep everything before it.
+
+    Parameters
+    ----------
+    dir_list : list of str
+        Save directories ({base}/{ofs}/{netcdf_dir}/{date_dir} layout).
+    local_prefix : str
+        The '{ofs}/{netcdf_dir}/' local prefix from get_nodd_prefix_map.
+
+    Returns
+    -------
+    str
+        The base path, with a trailing '/' when non-empty.
+    """
+    first_dir = f'{Path(dir_list[0]).as_posix()}/'
+    if first_dir.startswith(local_prefix):
+        # Relative layout rooted directly at {ofs}/{netcdf_dir}/
+        return ''
+    anchor = f'/{local_prefix}'
+    idx = first_dir.rfind(anchor)
+    if idx < 0:
+        raise ValueError(
+            f"Cannot find layout component '{local_prefix}' in save "
+            f"directory '{dir_list[0]}'."
+        )
+    return first_dir[:idx + 1]
+
+
 def download_data(prop, list_of_urls1, dir_list, logger):
     """
     This function gets the model output files from the NODD using the list
     of URLs.
     """
-    # Set up save path
-    savepath = dir_list[0][:].split(prop.ofs)[0]
     # Prefixes for translating bucket paths back to the local layout
     prefix_map = get_nodd_prefix_map(prop, logger)
+    # Set up save path: strip the {ofs}/{netcdf_dir}/{date_dir} layout
+    # from the first save directory, anchored at the trailing path
+    # component (not the first occurrence of the OFS name, which may also
+    # appear in the working directory path).
+    savepath = _derive_savepath(dir_list, prefix_map[0])
     # Need to add the local prefix to the savepath for stofs_2d_glo files
     # because the NODD S3 bucket doesn't contain it (unlike other models).
     if prop.ofs == 'stofs_2d_glo':
@@ -616,7 +703,7 @@ def download_data(prop, list_of_urls1, dir_list, logger):
     # First try the NODD and see if it's responding
     try:
         logger.info('Try NODD S3 download...')
-        urllib.request.urlretrieve(
+        _retrieve_atomic(
             list_of_urls1[0].replace('\\', '/'),
             _url_to_local_path(list_of_urls1[0], savepath, prefix_map),
         )

--- a/bin/utils/get_model_data.py
+++ b/bin/utils/get_model_data.py
@@ -15,13 +15,14 @@ import urllib.request
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime, timedelta
 from pathlib import Path
-from urllib.error import HTTPError
+from urllib.error import ContentTooShortError, HTTPError, URLError
 from urllib.parse import urlparse
 
 import numpy as np
 
 from ofs_skill.model_processing import get_fcst_cycle, model_properties
 from ofs_skill.model_processing.list_of_files import (
+    NETCDF_SUBDIR,
     get_nodd_prefix_map,
     swap_path_prefix,
 )
@@ -641,10 +642,47 @@ def _download_single_file(mod_dat, savepath, logger, prefix_map=('', '')):
                 else:
                     raise
 
-    except Exception as ex:
-        logger.error('Error: %s. Download failed %s!', ex, mod_dat)
+    except Exception as ex:  # pylint: disable=broad-exception-caught
+        _log_download_failure(mod_dat, ex, logger)
     # Reached only on failure (the retry loop either returns or raises)
     return None
+
+
+def _log_download_failure(url, exc, logger):
+    """
+    Log a failed NODD download with an accurate cause classification.
+
+    The old catch-all message ("NODD S3 is not responding!") presented
+    every failure as an outage, which sent users chasing AWS status
+    pages when the real problem was a bad URL (issue #213: HTTP 404s
+    from a wrong path layout). An HTTP error status means the NODD *is*
+    responding, so say what it said; reserve the unreachable wording
+    for actual connection failures.
+    """
+    if isinstance(exc, HTTPError):
+        if exc.code == 404:
+            logger.error(
+                'HTTP 404 Not Found for %s -- the NODD is reachable, but '
+                'no file exists at this URL. This is not a NODD outage. '
+                'Likely causes: the requested dates are not available on '
+                'the bucket, or the file name/path layout is wrong for '
+                'this OFS.', url)
+        else:
+            logger.error(
+                'The NODD responded with HTTP %s (%s) for %s.',
+                exc.code, exc.reason, url)
+    elif isinstance(exc, ContentTooShortError):
+        logger.error(
+            'Download of %s was interrupted before it completed (%s) -- '
+            'connection dropped mid-transfer; the partial file was '
+            'discarded.', url, exc.reason)
+    elif isinstance(exc, (URLError, TimeoutError, ConnectionError)):
+        reason = getattr(exc, 'reason', exc)
+        logger.error(
+            'Could not reach the NODD S3 endpoint for %s (%s) -- '
+            'network problem or NODD outage.', url, reason)
+    else:
+        logger.error('Download failed for %s: %s', url, exc)
 
 
 def _derive_savepath(dir_list, local_prefix):
@@ -709,13 +747,13 @@ def download_data(prop, list_of_urls1, dir_list, logger):
         )
         logger.info('NODD is responding! Keep going -->')
         list_of_urls_main = list_of_urls1
-    except (ValueError, HTTPError, Exception) as e_x:
-        logger.info("NODD S3 is not responding! I'm out.")
-        logger.error('First download failed for URL: %s',
-                     list_of_urls1[0].replace('\\', '/'))
-        logger.error(f'Exception: {e_x}')
+    except Exception as e_x:  # pylint: disable=broad-exception-caught
+        logger.error(
+            'Could not download the first model file from the NODD; '
+            'stopping before trying the rest.')
+        _log_download_failure(
+            list_of_urls1[0].replace('\\', '/'), e_x, logger)
         sys.exit(-1)
-        # list_of_urls = list_of_urls2
 
     # Download remaining files in parallel
     parallel_config = get_parallel_config(logger)
@@ -792,14 +830,11 @@ def get_model_data(prop, logger):
     # Directory & path set-up -->
     # Root path for saving files
     prop.model_save_path = os.path.join(
-        dir_params['model_historical_dir'], prop.ofs, dir_params['netcdf_dir'],
+        dir_params['model_historical_dir'], prop.ofs, NETCDF_SUBDIR,
     )
     prop.model_save_path = Path(prop.model_save_path).as_posix()
     # Path to files on the NODD
-    prop.model_nodd_path = os.path.join(
-        prop.ofs, dir_params['netcdf_dir'],
-    )
-    prop.model_nodd_path = Path(prop.model_nodd_path).as_posix()
+    prop.model_nodd_path = f'{prop.ofs}/{NETCDF_SUBDIR}'
     logger.info('Successfully set up paths.')
 
     # Directories, file lists, and URLs -- oh my

--- a/bin/utils/get_model_data.py
+++ b/bin/utils/get_model_data.py
@@ -20,11 +20,19 @@ from urllib.error import HTTPError
 import numpy as np
 
 from ofs_skill.model_processing import get_fcst_cycle, model_properties
+from ofs_skill.model_processing.list_of_files import (
+    get_nodd_prefix_map,
+    swap_path_prefix,
+)
 from ofs_skill.obs_retrieval import utils
 from ofs_skill.obs_retrieval.utils import get_parallel_config
 
 TIMEOUT_SEC = 60  # default API timeout in seconds
 socket.setdefaulttimeout(TIMEOUT_SEC)
+
+# STOFS-3D writes one points (station) file per cycle containing both the
+# nowcast and forecast periods.
+STOFS_3D_POINTS_FILENAME = 'points.cwl.temp.salt.vel.nc'
 
 
 def parameter_validation(argu_list, logger):
@@ -308,7 +316,7 @@ def make_file_list(prop, dates, dir_list, logger):
                                 file_name = os.path.join(dir_list[i], file_name). \
                                     replace('\\', '/')
                                 file_list.append(file_name)
-            elif prop.ofs in ('stofs_2d_glo'):
+            elif prop.ofs == 'stofs_2d_glo':
                 for i, datei in enumerate(dates):
                     for cycle in fcstcycles:
                         # For now we're just doing the combined water level ("cwl").
@@ -341,14 +349,13 @@ def make_file_list(prop, dates, dir_list, logger):
             if prop.ofs in ('stofs_3d_atl', 'stofs_3d_pac'):
                 for i, datei in enumerate(dates):
                     for cycle in fcstcycles:
-                        # STOFS-3D writes one points (station) file per cycle
-                        # containing both the nowcast and forecast periods.
-                        file_name = f'{prop.ofs}.t{cycle}z.' \
-                            'points.cwl.temp.salt.vel.nc'
+                        file_name = (
+                            f'{prop.ofs}.t{cycle}z.{STOFS_3D_POINTS_FILENAME}'
+                        )
                         file_list.append(
                             os.path.join(dir_list[i], file_name).replace('\\', '/')
                         )
-            elif prop.ofs in ('stofs_2d_glo'):
+            elif prop.ofs == 'stofs_2d_glo':
                 for i, datei in enumerate(dates):
                     for cycle in fcstcycles:
                         # For now we're just doing the combined water level ("cwl").
@@ -400,7 +407,7 @@ def make_file_list(prop, dates, dir_list, logger):
                                 file_name = os.path.join(dir_list[i], file_name). \
                                     replace('\\', '/')
                                 file_list.append(file_name)
-            elif prop.ofs in ('stofs_2d_glo'):
+            elif prop.ofs == 'stofs_2d_glo':
                 for i, datei in enumerate(dates):
                     for cycle in fcstcycles:
                         # For now we're just doing the combined water level ("cwl").
@@ -432,14 +439,13 @@ def make_file_list(prop, dates, dir_list, logger):
             if prop.ofs in ('stofs_3d_atl', 'stofs_3d_pac'):
                 for i, datei in enumerate(dates):
                     for cycle in fcstcycles:
-                        # STOFS-3D writes one points (station) file per cycle
-                        # containing both the nowcast and forecast periods.
-                        file_name = f'{prop.ofs}.t{cycle}z.' \
-                            'points.cwl.temp.salt.vel.nc'
+                        file_name = (
+                            f'{prop.ofs}.t{cycle}z.{STOFS_3D_POINTS_FILENAME}'
+                        )
                         file_list.append(
                             os.path.join(dir_list[i], file_name).replace('\\', '/')
                         )
-            elif prop.ofs in ('stofs_2d_glo'):
+            elif prop.ofs == 'stofs_2d_glo':
                 for i, datei in enumerate(dates):
                     for cycle in fcstcycles:
                         # For now we're just doing the combined water level ("cwl").
@@ -479,32 +485,6 @@ def make_file_list(prop, dates, dir_list, logger):
     return file_list
 
 
-def get_nodd_prefix_map(prop, logger):
-    """
-    Return (local_prefix, bucket_prefix) for translating file paths between
-    the local directory layout ({ofs}/{netcdf_dir}/) and the layout of the
-    NODD S3 bucket for the OFS.
-
-    The STOFS buckets have no netcdf subdirectory: STOFS-3D buckets use
-    capitalized top-level prefixes (STOFS-3D-Atl/, STOFS-3D-Pac/), and the
-    STOFS-2D-Global bucket stores date directories at the bucket root. For
-    all other OFS the bucket layout matches the local layout, so both
-    prefixes are identical and translation is a no-op.
-    """
-    _conf = getattr(prop, 'config_file', None)
-    dir_params = utils.Utils(_conf).read_config_section('directories', logger)
-    local_prefix = Path(
-        os.path.join(prop.ofs, dir_params['netcdf_dir'])
-    ).as_posix() + '/'
-    bucket_prefixes = {
-        'stofs_3d_atl': 'STOFS-3D-Atl/',
-        'stofs_3d_pac': 'STOFS-3D-Pac/',
-        'stofs_2d_glo': '',
-    }
-    bucket_prefix = bucket_prefixes.get(prop.ofs, local_prefix)
-    return local_prefix, bucket_prefix
-
-
 def list_of_urls(file_list, prop, logger):
     """
     This function take a file list and builds the URLs for all downloads.
@@ -514,41 +494,51 @@ def list_of_urls(file_list, prop, logger):
     _conf = getattr(prop, 'config_file', None)
     url_params = utils.Utils(_conf).read_config_section('urls', logger)
     local_prefix, bucket_prefix = get_nodd_prefix_map(prop, logger)
-    if prop.ofs not in ('stofs_3d_atl', 'stofs_3d_pac', 'stofs_2d_glo'):
-        url_root = url_params['nodd_s3']
-        url_list = []
-        for file in file_list:
-            url = (
-                f'{url_root}'
-                f'{file}'
-            )
-            url_list.append(url)
-    elif prop.ofs in ('stofs_3d_atl', 'stofs_3d_pac'):
-        url_root = url_params['nodd_s3_stofs3d']
-        url_list = []
-        for file in file_list:
-            url = (
-                f'{url_root}'
-                f'{file.replace(local_prefix, bucket_prefix)}'
-            )
-            url_list.append(url)
-    elif prop.ofs == 'stofs_2d_glo':
-        url_root = url_params['nodd_s3_stofs2d']
-        url_list = []
-        for file in file_list:
-            url = (
-                f'{url_root}'
-                f'{file.replace(local_prefix, bucket_prefix)}'
-            )
-            url_list.append(url)
+    url_root = url_params[get_fcst_cycle.get_s3_bucket(prop.ofs)]
     logger.info(f'Starting URL building for {url_root}...')
-    # url_list_backup.append(url_backup)
+    # Swap each file's local {ofs}/{netcdf_dir}/ prefix (anchored at the
+    # start of the path) for the bucket prefix. This is a no-op for
+    # non-STOFS OFS, whose buckets match the local layout.
+    url_list = [
+        f'{url_root}{swap_path_prefix(file, local_prefix, bucket_prefix)}'
+        for file in file_list
+    ]
     logger.info('Completed URL building!')
     return url_list
 
 
-def _download_single_file(mod_dat, savepath, ofs, logger,
-                          bucket_prefix='', local_prefix=''):
+def _url_to_local_path(url, savepath, prefix_map):
+    """
+    Map a NODD URL to the local path where the file should be saved.
+
+    Only the bucket key (the part of the URL after the bucket host) is
+    translated from the bucket layout back to the local layout, anchored
+    at the start of the key. The savepath itself is never rewritten, even
+    if it happens to contain a bucket prefix such as 'STOFS-3D-Atl/'.
+
+    Parameters
+    ----------
+    url : str
+        Full URL of the file to download.
+    savepath : str
+        Local base path for saving downloaded files.
+    prefix_map : tuple of str
+        (local_prefix, bucket_prefix) pair from get_nodd_prefix_map.
+
+    Returns
+    -------
+    str
+        The local file path.
+    """
+    local_prefix, bucket_prefix = prefix_map
+    key = url.split('.com')[-1].lstrip('/')
+    # No-op for non-STOFS OFS (identical prefixes) and for stofs_2d_glo
+    # (empty bucket prefix; savepath already carries the local prefix).
+    key = swap_path_prefix(key, bucket_prefix, local_prefix)
+    return f'{savepath}/{key}'.replace('//', '/')
+
+
+def _download_single_file(mod_dat, savepath, logger, prefix_map=('', '')):
     """
     Download a single model output file from the NODD.
 
@@ -562,15 +552,12 @@ def _download_single_file(mod_dat, savepath, ofs, logger,
         Full URL of the file to download.
     savepath : str
         Local base path for saving downloaded files.
-    ofs : str
-        OFS name (e.g. 'cbofs', 'stofs_3d_atl').
     logger : logging.Logger
         Logger instance.
-    bucket_prefix : str
-        S3 bucket path prefix for the OFS (e.g. 'STOFS-3D-Atl/'), swapped
-        for local_prefix when building the local file path.
-    local_prefix : str
-        Local directory layout prefix (e.g. 'stofs_3d_atl/netcdf/').
+    prefix_map : tuple of str
+        (local_prefix, bucket_prefix) pair from get_nodd_prefix_map, used
+        to translate the bucket key back to the local directory layout
+        (e.g. 'STOFS-3D-Atl/...' -> 'stofs_3d_atl/netcdf/...').
 
     Returns
     -------
@@ -581,19 +568,7 @@ def _download_single_file(mod_dat, savepath, ofs, logger,
     backoff_seconds = 1
 
     try:
-        # Build the local file path based on OFS type
-        if ofs in ('stofs_3d_atl', 'stofs_3d_pac') and bucket_prefix:
-            local_path = (
-                savepath + mod_dat.split('.com')[-1]
-            ).replace('//', '/').replace(
-                bucket_prefix, local_prefix,
-            )
-        else:
-            # Non-stofs OFS (bucket layout matches the local layout) and
-            # stofs_2d_glo (savepath already carries the local prefix).
-            local_path = (
-                savepath + mod_dat.split('.com')[-1]
-            ).replace('//', '/')
+        local_path = _url_to_local_path(mod_dat, savepath, prefix_map)
 
         # Skip if file already exists
         if os.path.isfile(local_path):
@@ -621,7 +596,8 @@ def _download_single_file(mod_dat, savepath, ofs, logger,
 
     except Exception as ex:
         logger.error('Error: %s. Download failed %s!', ex, mod_dat)
-        return None
+    # Reached only on failure (the retry loop either returns or raises)
+    return None
 
 
 def download_data(prop, list_of_urls1, dir_list, logger):
@@ -632,28 +608,18 @@ def download_data(prop, list_of_urls1, dir_list, logger):
     # Set up save path
     savepath = dir_list[0][:].split(prop.ofs)[0]
     # Prefixes for translating bucket paths back to the local layout
-    local_prefix, bucket_prefix = get_nodd_prefix_map(prop, logger)
+    prefix_map = get_nodd_prefix_map(prop, logger)
     # Need to add the local prefix to the savepath for stofs_2d_glo files
     # because the NODD S3 bucket doesn't contain it (unlike other models).
     if prop.ofs == 'stofs_2d_glo':
-        savepath = savepath + local_prefix
+        savepath = savepath + prefix_map[0]
     # First try the NODD and see if it's responding
     try:
         logger.info('Try NODD S3 download...')
-        if prop.ofs in ('stofs_3d_atl', 'stofs_3d_pac'):
-            urllib.request.urlretrieve(
-                list_of_urls1[0].replace('\\', '/'), (
-                    savepath +
-                    list_of_urls1[0].split('.com')[-1]
-                ).replace('//', '/').replace(bucket_prefix, local_prefix),
-            )
-        else:
-            urllib.request.urlretrieve(
-                list_of_urls1[0].replace('\\', '/'), (
-                    savepath +
-                    list_of_urls1[0].split('.com')[-1]
-                ).replace('//', '/'),
-            )
+        urllib.request.urlretrieve(
+            list_of_urls1[0].replace('\\', '/'),
+            _url_to_local_path(list_of_urls1[0], savepath, prefix_map),
+        )
         logger.info('NODD is responding! Keep going -->')
         list_of_urls_main = list_of_urls1
     except (ValueError, HTTPError, Exception) as e_x:
@@ -671,8 +637,7 @@ def download_data(prop, list_of_urls1, dir_list, logger):
     with ThreadPoolExecutor(max_workers=max_workers) as executor:
         futures = {
             executor.submit(
-                _download_single_file, mod_dat, savepath, prop.ofs, logger,
-                bucket_prefix, local_prefix,
+                _download_single_file, mod_dat, savepath, logger, prefix_map,
             ): mod_dat
             for mod_dat in list_of_urls_main
         }

--- a/bin/utils/ofs_climatology.py
+++ b/bin/utils/ofs_climatology.py
@@ -884,8 +884,8 @@ if __name__ == '__main__':
 
     dir_params = utils.Utils(_conf).read_config_section('directories', logger)
 
-    prop1.model_path = os.path.join(
-        dir_params['model_historical_dir'], prop1.ofs, dir_params['netcdf_dir'],
+    prop1.model_path = list_of_files.local_model_dir(
+        dir_params['model_historical_dir'], prop1.ofs, logger,
     )
     prop1.model_path = Path(prop1.model_path).as_posix()
 

--- a/bin/utils/process_schism_stations_cli.py
+++ b/bin/utils/process_schism_stations_cli.py
@@ -23,6 +23,7 @@ from netCDF4 import Dataset, date2num
 from pyproj import Transformer
 
 from ofs_skill.model_processing import model_properties
+from ofs_skill.model_processing.list_of_files import local_model_dir
 from ofs_skill.model_processing.model_source import get_model_source
 from ofs_skill.obs_retrieval import utils
 
@@ -390,8 +391,8 @@ def process_schism_stations(prop, logger):
     parameter_validation(prop, dir_params, logger)
 
     # Path for saving netcdfs
-    prop.model_path = os.path.join(
-        dir_params['model_historical_dir'], prop.ofs, dir_params['netcdf_dir']
+    prop.model_path = local_model_dir(
+        dir_params['model_historical_dir'], prop.ofs, logger
     )
     prop.model_path = Path(prop.model_path).as_posix()
 

--- a/bin/visualization/create_2dplot.py
+++ b/bin/visualization/create_2dplot.py
@@ -61,6 +61,7 @@ from ofs_skill.model_processing import (
     intake_model,
     list_of_dir,
     list_of_files,
+    local_model_dir,
     model_properties,
 )
 from ofs_skill.obs_retrieval import utils
@@ -181,8 +182,8 @@ def validate_and_initialize_parameters(prop):
         os.makedirs(directory, exist_ok=True)
 
     # Additional formatting for model path and date fields
-    prop.model_path = os.path.join(
-        dir_params['model_historical_dir'], prop.ofs, dir_params['netcdf_dir']
+    prop.model_path = local_model_dir(
+        dir_params['model_historical_dir'], prop.ofs, logger
     )
     prop.model_path = Path(prop.model_path).as_posix()
 

--- a/conf/ofs_dps.conf.example
+++ b/conf/ofs_dps.conf.example
@@ -36,7 +36,6 @@ model_dir=model
 skill_dir=skill
 model_historical_dir=%(home)s/example_data
 model_obc_dir=%(home)s/example_data
-netcdf_dir=netcdf
 1d_node_dir=1d_node
 horizon_model_dir=horizon_model
 model_icesave_dir=2D_ice_cover

--- a/src/ofs_skill/model_processing/__init__.py
+++ b/src/ofs_skill/model_processing/__init__.py
@@ -51,11 +51,13 @@ from ofs_skill.model_processing.intake_scisa import (
 
 # File listing and discovery
 from ofs_skill.model_processing.list_of_files import (
+    NETCDF_SUBDIR,
     construct_expected_files,
     construct_s3_url,
     dates_range,
     list_of_dir,
     list_of_files,
+    local_model_dir,
 )
 from ofs_skill.model_processing.model_format_properties import ModelFormatProperties
 from ofs_skill.model_processing.model_properties import ModelProperties
@@ -101,6 +103,8 @@ __all__ = [
     'construct_expected_files',
     'list_of_dir',
     'list_of_files',
+    'local_model_dir',
+    'NETCDF_SUBDIR',
     'get_s3_bucket',
     # File validation
     'check_model_files',

--- a/src/ofs_skill/model_processing/check_model_files.py
+++ b/src/ofs_skill/model_processing/check_model_files.py
@@ -35,7 +35,8 @@ from typing import Any
 from urllib.error import HTTPError, URLError
 
 from bin.utils import get_model_data
-from ofs_skill.model_processing.list_of_files import list_of_dir, list_of_files
+from ofs_skill.model_processing.list_of_files import (
+    NETCDF_SUBDIR, list_of_dir, list_of_files, local_model_dir)
 from ofs_skill.obs_retrieval import utils
 
 
@@ -231,7 +232,7 @@ def check_model_files(prop: Any, logger: Logger) -> None:
         _conf = getattr(prop, 'config_file', None)
         dir_params = utils.Utils(_conf).read_config_section('directories', logger)
         prop.model_save_path = os.path.join(dir_params['model_historical_dir'],
-                                            prop.ofs, dir_params['netcdf_dir'])
+                                            prop.ofs, NETCDF_SUBDIR)
 
         # First make list of what files SHOULD be in the directories
         try:
@@ -273,8 +274,8 @@ def check_model_files(prop: Any, logger: Logger) -> None:
             logger.error('Unable to check if model files are present.')
             return
 
-        prop.model_path = os.path.join(dir_params['model_historical_dir'],
-                                       prop.ofs, dir_params['netcdf_dir'])
+        prop.model_path = local_model_dir(dir_params['model_historical_dir'],
+                                          prop.ofs, logger)
         prop.model_path = Path(prop.model_path).as_posix()
         dir_list = list_of_dir(prop, logger)
         try:

--- a/src/ofs_skill/model_processing/get_node_ofs.py
+++ b/src/ofs_skill/model_processing/get_node_ofs.py
@@ -29,7 +29,7 @@ from ofs_skill.model_processing import do_horizon_skill_utils
 from ofs_skill.model_processing.get_datum_offset import get_datum_offset as get_datum_offset_func
 from ofs_skill.model_processing.get_datum_offset import report_datums
 from ofs_skill.model_processing.intake_scisa import intake_model
-from ofs_skill.model_processing.list_of_files import list_of_dir
+from ofs_skill.model_processing.list_of_files import list_of_dir, local_model_dir
 from ofs_skill.model_processing.list_of_files import list_of_files as list_of_files_func
 from ofs_skill.model_processing.model_format_properties import ModelFormatProperties
 from ofs_skill.model_processing.model_source import get_model_source
@@ -1509,8 +1509,8 @@ def get_node_ofs(prop, logger, model_dataset=None):
     # Parameter validation
     parameter_validation(prop, dir_params, logger)
 
-    prop.model_path = os.path.join(
-        dir_params['model_historical_dir'], prop.ofs, dir_params['netcdf_dir']
+    prop.model_path = local_model_dir(
+        dir_params['model_historical_dir'], prop.ofs, logger
     )
     prop.model_path = Path(prop.model_path).as_posix()
 

--- a/src/ofs_skill/model_processing/indexing.py
+++ b/src/ofs_skill/model_processing/indexing.py
@@ -787,13 +787,17 @@ def index_nearest_depth(
                     raise NotImplementedError('ADCIRC depth indexing not yet implemented for models other than STOFS-2D-Global.')
 
     elif prop.ofsfiletype == 'stations':
-        if prop.ofs in ['stofs']:
-            return [], []
         index_min_depth = []  # type: ignore[no-redef]
         depth_value = []  # type: ignore[no-redef]
         length = len(index_min_dist)
-        if name_var == 'wl':
-            # Water level (zeta) is a 2D surface variable — no depth indexing needed
+        if name_var == 'wl' or prop.ofs in ('stofs_3d_atl', 'stofs_3d_pac'):
+            # Water level (zeta) is a 2D surface variable — no depth
+            # indexing needed. The STOFS-3D points (stations) files are
+            # surface-only for every variable: temperature/salinity are
+            # sampled 'at water surface' and u/v are surface velocities,
+            # all on (time, station) with no vertical coordinate — so
+            # there is nothing to depth-index there either. Report the
+            # surface (layer 0, depth 0.0) for each matched station.
             for idx in range(length):
                 if ~np.isnan(index_min_dist[idx]):
                     index_min_depth.append(0)
@@ -837,6 +841,16 @@ def index_nearest_depth(
                     logger.warning('SECOFS station file does not have depth '
                                    'info! Taking surface value...')
                     depth_tracker = 1
+            else:
+                # Fail loudly instead of leaving model_depths unbound in
+                # the per-station loop below (UnboundLocalError). The
+                # surface-only STOFS-3D OFS return above and never get
+                # here; any new SCHISM OFS needs its depth layout wired
+                # in explicitly.
+                raise NotImplementedError(
+                    f'SCHISM stations depth indexing not implemented '
+                    f'for {prop.ofs}'
+                )
 
         for idx in range(0, length):
             if ~np.isnan(index_min_dist[idx]):

--- a/src/ofs_skill/model_processing/intake_scisa.py
+++ b/src/ofs_skill/model_processing/intake_scisa.py
@@ -544,6 +544,12 @@ def intake_model(file_list: list[str], prop: Any, logger: Logger) -> xr.Dataset:
     # Note that this needs to be done before removal of duplicate times.
     if prop.model_source == 'adcirc':
         ds = fix_adcirc_dataset(prop, ds, urlpaths, logger)
+    # STOFS-3D (SCHISM) points files have the same per-cycle
+    # nowcast+forecast concatenated layout as ADCIRC and need the same
+    # per-cast subsetting; without it, the duplicate-time removal below
+    # silently substitutes other casts for the requested one.
+    elif needs_schism_points_cast_subsetting(prop):
+        ds = fix_schism_points_dataset(prop, ds, logger)
 
     # Round all times to nearest minute
     try:
@@ -1017,6 +1023,283 @@ def fix_adcirc_dataset(
                        'This may cause issues with downstream processing. Continuing...')
     #
     return data_set
+
+
+def needs_schism_points_cast_subsetting(prop: Any) -> bool:
+    """
+    Decide whether a dataset needs SCHISM points-file cast subsetting.
+
+    Only the STOFS-3D points (stations) products bundle the nowcast and
+    forecast periods in a single per-cycle file; the other SCHISM-based
+    OFS (loofs2, secofs) publish separate per-cast stations files, and
+    SCHISM fields files are per-cast too. Those must not be touched.
+
+    Parameters
+    ----------
+    prop : ModelProperties
+        ModelProperties object containing model_source, ofs, and
+        ofsfiletype.
+
+    Returns
+    -------
+    bool
+        True if fix_schism_points_dataset should run on the dataset.
+    """
+    return (getattr(prop, 'model_source', None) == 'schism'
+            and getattr(prop, 'ofsfiletype', None) == 'stations'
+            and getattr(prop, 'ofs', None) in ('stofs_3d_atl',
+                                               'stofs_3d_pac'))
+
+
+def fix_schism_points_dataset(
+    prop: Any,
+    data_set: xr.Dataset,
+    logger: Logger
+) -> xr.Dataset:
+    """
+    Subset concatenated SCHISM points files to the requested whichcast.
+
+    STOFS-3D points (stations) files have the same structure as the
+    ADCIRC / STOFS-2D-Global ones handled by ``fix_adcirc_dataset``:
+    each per-cycle file contains the nowcast and forecast periods
+    concatenated on a single time axis. Verified against operational
+    NODD output (STOFS-3D-Atl ``stofs_3d_atl.t12z.points.*.nc``): 1200
+    timesteps at 6-minute spacing spanning ``cycle - 24 h + dt``
+    through ``cycle + 96 h``; the first 240 steps (times <= cycle
+    time) are the nowcast segment and the remaining 960 (times > cycle
+    time) are the forecast segment.
+
+    Without this subsetting the only whichcast discrimination applied
+    to SCHISM points files is the downstream duplicate-time removal,
+    which silently substitutes later cycles' nowcast output for the
+    requested forecast (forecast_b) or an older initialization for the
+    requested one (forecast_a), biasing the reported forecast skill.
+
+    Parameters
+    ----------
+    prop : ModelProperties
+        ModelProperties object containing:
+        - ofs : str
+            OFS model name ('stofs_3d_atl' or 'stofs_3d_pac')
+        - ofsfiletype : str
+            Must be 'stations'
+        - whichcast : str
+            'nowcast', 'forecast_a', 'forecast_b'
+        - startdate : str
+            'YYYYMMDDHH' assessment start (forecast_a only)
+        - forecast_hr : str
+            Requested forecast cycle, e.g. '12z' (forecast_a only)
+    data_set : xr.Dataset
+        SCHISM points dataset (one or more concatenated cycles)
+    logger : Logger
+        Logger instance for logging messages
+
+    Returns
+    -------
+    xr.Dataset
+        Dataset with timesteps only for the appropriate whichcast.
+
+    Notes
+    -----
+    Unlike ``fix_adcirc_dataset`` this works from the actual time
+    coordinate instead of hard-coded timestep counts: file blocks are
+    the maximal runs of uniformly spaced times, and each block's cycle
+    time is its first time minus one timestep plus the nowcast length
+    (24 h / cycles-per-day from ``get_fcst_hours``). Selection per
+    whichcast:
+
+    - nowcast: keep each block's times <= its cycle time. Blocks never
+      overlap there, and the later dedup (keep='last') is a no-op.
+    - forecast_b: keep each block's times > its cycle time. Consecutive
+      cycles' forecasts overlap; the later dedup (keep='last') then
+      stitches them preferring the most recent cycle, mirroring what
+      forecast_b means for every other OFS.
+    - forecast_a: keep times > cycle time for the single requested
+      initialization (prop.startdate at prop.forecast_hr) only.
+    """
+    if prop.model_source != 'schism' or prop.ofsfiletype != 'stations':
+        raise ValueError('Function fix_schism_points_dataset should only '
+                         'be used with SCHISM points (stations) data!')
+
+    time_vals = data_set['time'].values
+    if time_vals.size < 2:
+        logger.warning('SCHISM points temporal subsetting: dataset has '
+                       f'{time_vals.size} timesteps; nothing to subset.')
+        return data_set
+
+    keep_t_s = _schism_points_keep_mask(prop, time_vals, logger)
+    if keep_t_s is None:
+        logger.warning('SCHISM points temporal subsetting: time axis has '
+                       'no increasing spacing; skipping subsetting.')
+        return data_set
+
+    if not keep_t_s.any():
+        raise ValueError(
+            'SCHISM points temporal subsetting: no timesteps matched '
+            f'whichcast {prop.whichcast}. The requested cycle file may '
+            'be missing from the run.')
+
+    logger.info('SCHISM points temporal subsetting: keeping '
+                f'{int(keep_t_s.sum())} of {time_vals.size} timesteps '
+                f'for whichcast {prop.whichcast}.')
+
+    # Positional selection: the concatenated axis has repeated labels,
+    # so label-based selection is not safe here.
+    return data_set.isel(time=keep_t_s)
+
+
+def _split_uniform_time_blocks(time_vals: np.ndarray) -> Any:
+    """
+    Partition a concatenated time axis into per-file blocks.
+
+    File blocks are maximal runs of uniformly spaced times: the
+    timestep is inferred as the most common positive spacing (6
+    minutes in operational STOFS-3D points files), and any other
+    spacing is the seam between two files (each new cycle rewinds the
+    axis to its own nowcast start).
+
+    Parameters
+    ----------
+    time_vals : np.ndarray
+        datetime64 time coordinate of the concatenated dataset.
+
+    Returns
+    -------
+    tuple of (list of (int, int), np.timedelta64) or None
+        Half-open (start, end) index spans, one per file block, and
+        the inferred timestep. None if the axis never increases.
+    """
+    diffs = np.diff(time_vals)
+    positive = diffs[diffs > np.timedelta64(0)]
+    if positive.size == 0:
+        return None
+    spacings, counts = np.unique(positive, return_counts=True)
+    delta_t = spacings[np.argmax(counts)]
+    seams = np.flatnonzero(diffs != delta_t) + 1
+    starts = np.concatenate(([0], seams))
+    ends = np.concatenate((seams, [time_vals.size]))
+    return list(zip(starts, ends)), delta_t
+
+
+def _forecast_a_requested_cycle(prop: Any) -> np.datetime64:
+    """
+    Resolve the single model cycle a forecast_a run assesses.
+
+    The forecast_a file list holds the requested cycle plus the
+    previous day's cycle (dates_range looks one day behind for STOFS
+    forecasts), so the requested initialization must be identified
+    from prop.startdate ('YYYYMMDDHH', hour stripped upstream) and
+    prop.forecast_hr (e.g. '12z').
+
+    Returns
+    -------
+    np.datetime64
+        The requested cycle time.
+
+    Raises
+    ------
+    ValueError
+        If startdate/forecast_hr are missing or unparseable.
+    """
+    try:
+        cycle_hour = int(str(prop.forecast_hr).lower().rstrip('z'))
+        start_str = str(prop.startdate)[:8]
+        return (np.datetime64(
+                    f'{start_str[:4]}-{start_str[4:6]}-{start_str[6:8]}')
+                + np.timedelta64(cycle_hour, 'h'))
+    except (AttributeError, TypeError, ValueError) as ex:
+        raise ValueError(
+            'SCHISM points temporal subsetting: forecast_a requires '
+            'prop.startdate (YYYYMMDDHH) and prop.forecast_hr (e.g. '
+            f"'12z') to identify the requested cycle; got "
+            f'startdate={getattr(prop, "startdate", None)!r}, '
+            f'forecast_hr={getattr(prop, "forecast_hr", None)!r}'
+        ) from ex
+
+
+def _warn_on_odd_block(n_block: int, expected_len: int,
+                       cycle_time: np.datetime64, fcstcycles: Any,
+                       logger: Logger) -> None:
+    """Warn when a file block deviates from the expected layout."""
+    if n_block != expected_len:
+        logger.warning('SCHISM points temporal subsetting: file block '
+                       f'has {n_block} timesteps, expected '
+                       f'{expected_len}. Continuing with the time-based '
+                       'boundary...')
+    cycle_hour = int((cycle_time - cycle_time.astype('datetime64[D]'))
+                     / np.timedelta64(1, 'h'))
+    if cycle_hour not in fcstcycles:
+        logger.warning('SCHISM points temporal subsetting: inferred '
+                       f'cycle time {cycle_time} is not on a known '
+                       f'forecast cycle hour ({list(fcstcycles)}Z). '
+                       'The file may be truncated at the start. '
+                       'Continuing...')
+
+
+def _block_cast_mask(block: np.ndarray, cycle_time: np.datetime64,
+                     whichcast: str, requested_cycle: Any,
+                     logger: Logger) -> np.ndarray:
+    """
+    Boolean keep-mask for one file block and one whichcast.
+
+    Times at or before the block's cycle time are its nowcast segment;
+    times after it are its forecast segment. forecast_a keeps the
+    forecast segment of the requested initialization only.
+    """
+    if whichcast == 'nowcast':
+        return block <= cycle_time
+    if whichcast == 'forecast_b':
+        return block > cycle_time
+    if whichcast == 'forecast_a':
+        if cycle_time == requested_cycle:
+            return block > cycle_time
+        logger.info('SCHISM points temporal subsetting: dropping '
+                    f'cycle {cycle_time} (forecast_a requested '
+                    f'{requested_cycle}).')
+        return np.zeros(block.size, dtype=bool)
+    raise ValueError(f'whichcast {whichcast} not recognized.')
+
+
+def _schism_points_keep_mask(prop: Any, time_vals: np.ndarray,
+                             logger: Logger) -> Any:
+    """
+    Build the whichcast keep-mask for a concatenated points time axis.
+
+    Splits the axis into per-file blocks, infers each block's cycle
+    time from its first timestep (first time = cycle - nowcast length
+    + one timestep), and masks each block per the requested whichcast.
+
+    Returns
+    -------
+    np.ndarray or None
+        Boolean mask over time_vals, or None if the axis is degenerate
+        (never increases) and subsetting should be skipped.
+    """
+    blocks = _split_uniform_time_blocks(time_vals)
+    if blocks is None:
+        return None
+    block_spans, delta_t = blocks
+
+    fcst_len_hours, fcstcycles = get_fcst_hours(prop.ofs)
+    nowcast_td = np.timedelta64(int(24 / len(fcstcycles) * 3600), 's')
+    expected_len = round(
+        (nowcast_td + np.timedelta64(int(fcst_len_hours * 3600), 's'))
+        / delta_t)
+
+    requested_cycle = None
+    if prop.whichcast == 'forecast_a':
+        requested_cycle = _forecast_a_requested_cycle(prop)
+
+    keep_t_s = np.zeros(time_vals.size, dtype=bool)
+    for start, end in block_spans:
+        # First block time is cycle - nowcast length + delta_t, so:
+        cycle_time = time_vals[start] - delta_t + nowcast_td
+        _warn_on_odd_block(end - start, expected_len, cycle_time,
+                           fcstcycles, logger)
+        keep_t_s[start:end] = _block_cast_mask(
+            time_vals[start:end], cycle_time, prop.whichcast,
+            requested_cycle, logger)
+    return keep_t_s
 
 
 def get_station_dim(engine: str, urlpaths: list[str],

--- a/src/ofs_skill/model_processing/list_of_files.py
+++ b/src/ofs_skill/model_processing/list_of_files.py
@@ -95,6 +95,7 @@ def construct_s3_url(local_path: str, prop: Any, logger: Logger) -> Optional[str
         if prop.ofs in ('stofs_3d_atl', 'stofs_3d_pac'):
             # STOFS uses different path structure - no 'netcdf' subdirectory
             # Bucket structure: STOFS-3D-Atl/stofs_3d_atl.YYYYMMDD/filename.nc
+            ofs_relative_path = ofs_relative_path.replace(f'{prop.ofs}/netcdf/', f'{prop.ofs}/')
             ofs_relative_path = ofs_relative_path.replace('stofs_3d_atl/', 'STOFS-3D-Atl/')
             ofs_relative_path = ofs_relative_path.replace('stofs_3d_pac/', 'STOFS-3D-Pac/')
         elif prop.ofs == 'stofs_2d_glo':
@@ -102,6 +103,7 @@ def construct_s3_url(local_path: str, prop: Any, logger: Logger) -> Optional[str
             # STOFS-2D-Global uses different path structure - no 'netcdf' subdirectory
             # Bucket structure: stofs_2d_glo.YYYYMMDD/<filename>.nc
             # Note no <ofs> subdirectory in bucket, so we need to remove 'stofs_2d_glo/' from the path
+            ofs_relative_path = ofs_relative_path.replace(f'{prop.ofs}/netcdf/', f'{prop.ofs}/')
             ofs_relative_path = ofs_relative_path.replace('stofs_2d_glo/', '')
         else:
             url_root = url_params['nodd_s3']

--- a/src/ofs_skill/model_processing/list_of_files.py
+++ b/src/ofs_skill/model_processing/list_of_files.py
@@ -28,7 +28,7 @@ import os
 from datetime import datetime, timedelta
 from logging import Logger
 from os import listdir
-from pathlib import Path, PurePosixPath, PureWindowsPath
+from pathlib import Path
 from typing import Any, Optional
 
 import boto3
@@ -41,41 +41,70 @@ from ofs_skill.obs_retrieval import utils
 from ofs_skill.model_processing import get_fcst_cycle
 
 
+# Fixed name of the model-file subdirectory in the local data layout
+# ({model_historical_dir}/{ofs}/netcdf/...). This mirrors the layout of
+# the regular NODD bucket and is not configurable: the retired
+# 'netcdf_dir' config setting existed only as a workaround for STOFS
+# bucket URLs, which are now translated explicitly (see
+# get_nodd_prefix_map), and a configurable value only created ways to
+# build URLs and local trees that nothing else could find (issue #213).
+NETCDF_SUBDIR = 'netcdf'
+
+# One-time flag for the retired-setting notice in get_nodd_prefix_map.
+_NETCDF_DIR_NOTICE_DONE = False
+
+
+def _notice_retired_netcdf_dir(config_file: Any, logger: Logger) -> None:
+    """
+    Log a one-time notice if the retired netcdf_dir setting is present.
+
+    The [directories] netcdf_dir config setting is no longer read: the
+    local layout always uses NETCDF_SUBDIR. Configs that still carry the
+    setting keep working, but users who had customized it (typically the
+    old blank-value STOFS workaround) should know it no longer has any
+    effect.
+    """
+    global _NETCDF_DIR_NOTICE_DONE  # pylint: disable=global-statement
+    if _NETCDF_DIR_NOTICE_DONE:
+        return
+    _NETCDF_DIR_NOTICE_DONE = True
+    try:
+        dir_params = utils.Utils(config_file).read_config_section(
+            'directories', logger)
+        legacy_value = dir_params.get('netcdf_dir')
+    except Exception:  # pylint: disable=broad-exception-caught
+        return
+    if legacy_value is None:
+        return
+    if legacy_value == NETCDF_SUBDIR:
+        logger.info(
+            "The [directories] netcdf_dir config setting is deprecated "
+            'and no longer read; the line can be removed from the config '
+            'file.')
+    else:
+        logger.warning(
+            "The [directories] netcdf_dir config setting is deprecated "
+            f"and no longer read: the value '{legacy_value}' is ignored "
+            f"and model files always use the '{NETCDF_SUBDIR}' "
+            'subdirectory. The setting existed as a workaround for STOFS '
+            'NODD paths, which are now handled automatically; the line '
+            'can be removed from the config file.')
+
+
 def get_nodd_prefix_map(prop: Any, logger: Logger) -> tuple[str, str]:
     """
     Return (local_prefix, bucket_prefix) for translating file paths between
-    the local directory layout ({ofs}/{netcdf_dir}/) and the layout of the
-    NODD S3 bucket for the OFS.
+    the local directory layout ({ofs}/netcdf/) and the layout of the NODD
+    S3 bucket for the OFS.
 
     The STOFS buckets have no netcdf subdirectory: STOFS-3D buckets use
     capitalized top-level prefixes (STOFS-3D-Atl/, STOFS-3D-Pac/), and the
     STOFS-2D-Global bucket stores date directories at the bucket root. For
     all other OFS the bucket layout matches the local layout, so both
     prefixes are identical and translation is a no-op.
-
-    Raises
-    ------
-    ValueError
-        If the configured netcdf_dir is an absolute path or contains a
-        '..' component, either of which would relocate downloads outside
-        the data directory tree.
     """
-    _conf = getattr(prop, 'config_file', None)
-    dir_params = utils.Utils(_conf).read_config_section('directories', logger)
-    netcdf_dir = dir_params['netcdf_dir']
-    posix_dir = PurePosixPath(netcdf_dir)
-    windows_dir = PureWindowsPath(netcdf_dir)
-    if (posix_dir.is_absolute() or windows_dir.is_absolute()
-            or windows_dir.drive
-            or '..' in posix_dir.parts or '..' in windows_dir.parts):
-        raise ValueError(
-            f"Invalid netcdf_dir '{netcdf_dir}' in the [directories] config "
-            "section: it must be a relative subdirectory with no '..' "
-            'components.'
-        )
-    local_prefix = Path(
-        os.path.join(prop.ofs, netcdf_dir)
-    ).as_posix() + '/'
+    _notice_retired_netcdf_dir(getattr(prop, 'config_file', None), logger)
+    local_prefix = f'{prop.ofs}/{NETCDF_SUBDIR}/'
     bucket_prefixes = {
         'stofs_3d_atl': 'STOFS-3D-Atl/',
         'stofs_3d_pac': 'STOFS-3D-Pac/',
@@ -83,6 +112,40 @@ def get_nodd_prefix_map(prop: Any, logger: Logger) -> tuple[str, str]:
     }
     bucket_prefix = bucket_prefixes.get(prop.ofs, local_prefix)
     return local_prefix, bucket_prefix
+
+
+def local_model_dir(model_historical_dir: str, ofs: str,
+                    logger: Logger) -> str:
+    """
+    Return the local directory that holds model files for an OFS.
+
+    The canonical layout is {model_historical_dir}/{ofs}/netcdf/. Before
+    the netcdf_dir config setting was retired (issue #213), a blank value
+    (the old STOFS workaround) placed files directly under
+    {model_historical_dir}/{ofs}/ instead. So that existing archives keep
+    working without a re-download, this falls back to the legacy layout
+    when the canonical directory does not exist but the legacy one does
+    and is non-empty.
+
+    Downloads always write the canonical layout (get_model_data joins
+    NETCDF_SUBDIR directly), so a fresh tree resolves to canonical.
+    """
+    canonical = os.path.join(model_historical_dir, ofs, NETCDF_SUBDIR)
+    if os.path.isdir(canonical):
+        return canonical
+    legacy = os.path.join(model_historical_dir, ofs)
+    try:
+        legacy_entries = [e for e in os.listdir(legacy)
+                          if e != NETCDF_SUBDIR]
+    except OSError:
+        legacy_entries = []
+    if legacy_entries:
+        logger.info(
+            f'Model files for {ofs} found in the legacy layout {legacy} '
+            f'(no {NETCDF_SUBDIR}/ subdirectory); using it. New downloads '
+            f'are stored under {canonical}.')
+        return legacy
+    return canonical
 
 
 def swap_path_prefix(path: str, old_prefix: str, new_prefix: str) -> str:
@@ -129,35 +192,32 @@ def construct_s3_url(local_path: str, prop: Any, logger: Logger) -> Optional[str
         _conf = getattr(prop, 'config_file', None)
         url_params = utils.Utils(_conf).read_config_section('urls', logger)
 
-        # Prefix pair for translating the local {ofs}/{netcdf_dir}/ layout
-        # to the bucket layout (the two are identical for non-STOFS OFS).
+        # Prefix pair for translating the local {ofs}/netcdf/ layout to
+        # the bucket layout (the two are identical for non-STOFS OFS).
         local_prefix, bucket_prefix = get_nodd_prefix_map(prop, logger)
-        netcdf_dir = local_prefix[len(prop.ofs):].strip('/')
 
         # Normalize path separators
         local_path = Path(local_path).as_posix()
 
         # Extract the OFS-relative path (everything after the OFS name)
-        # Format: {base_path}/{ofs}/{netcdf_dir}/{rest_of_path}
+        # Format: {base_path}/{ofs}/netcdf/{rest_of_path}
         path_parts = local_path.split('/')
-
-        # Find where the configured netcdf subdirectory appears in the path
-        if netcdf_dir and netcdf_dir in path_parts:
-            netcdf_idx = path_parts.index(netcdf_dir)
-            # Reconstruct from OFS name onwards
-            ofs_relative_path = '/'.join(
-                [prop.ofs, netcdf_dir] + path_parts[netcdf_idx + 1:])
-        elif prop.ofs in path_parts:
-            # Fallback: find the OFS name in the path
-            ofs_relative_path = '/'.join(
-                path_parts[path_parts.index(prop.ofs):])
-        else:
+        if prop.ofs not in path_parts:
             logger.error(f'Cannot determine OFS-relative path from: {local_path}')
             return None
+        ofs_relative_path = '/'.join(
+            path_parts[path_parts.index(prop.ofs):])
+
+        # Normalize legacy-layout paths ({ofs}/ directly containing date
+        # directories, from the retired blank-netcdf_dir workaround; see
+        # local_model_dir) to the canonical local layout first.
+        if not ofs_relative_path.startswith(local_prefix):
+            ofs_relative_path = swap_path_prefix(
+                ofs_relative_path, f'{prop.ofs}/', local_prefix)
 
         # Select appropriate S3 bucket URL based on OFS
         url_root = url_params[get_s3_bucket(prop.ofs)]
-        # Swap the local {ofs}/{netcdf_dir}/ prefix for the bucket prefix.
+        # Swap the local {ofs}/netcdf/ prefix for the bucket prefix.
         # The STOFS buckets have no netcdf subdirectory (STOFS-3D buckets
         # use STOFS-3D-Atl/ or STOFS-3D-Pac/, STOFS-2D-Global stores date
         # directories at the bucket root); for all other OFS the bucket
@@ -619,9 +679,8 @@ def list_of_dir(prop: Any, logger: Logger) -> list[str]:
             logger.info('Trying backup dir...')
             dir_params = utils.Utils(_conf).read_config_section(
                 'directories', logger)
-            backup_model_path = os.path.join(
-                dir_params['model_historical_dir_backup'],
-                prop.ofs, dir_params['netcdf_dir'])
+            backup_model_path = local_model_dir(
+                dir_params['model_historical_dir_backup'], prop.ofs, logger)
 
             # Construct backup directory path based on OFS type and date
             if prop.ofs in ('stofs_3d_atl', 'stofs_3d_pac', 'stofs_2d_glo'):

--- a/src/ofs_skill/model_processing/list_of_files.py
+++ b/src/ofs_skill/model_processing/list_of_files.py
@@ -14,6 +14,8 @@ for WCOFS to help stitch together more complete time series and avoid gaps.
 
 Functions
 ---------
+get_nodd_prefix_map : Returns the local-vs-bucket path prefix pair for an OFS
+swap_path_prefix : Swaps a path prefix anchored at the start of the string
 construct_s3_url : Converts local file paths to S3 URLs for NODD bucket access
 dates_range : Creates a date range between start and end dates
 construct_expected_files : Generates expected file names when files are not available locally
@@ -26,7 +28,7 @@ import os
 from datetime import datetime, timedelta
 from logging import Logger
 from os import listdir
-from pathlib import Path
+from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import Any, Optional
 
 import boto3
@@ -37,6 +39,64 @@ from botocore.exceptions import ClientError
 from ofs_skill.model_processing.get_fcst_cycle import get_fcst_hours, get_s3_bucket
 from ofs_skill.obs_retrieval import utils
 from ofs_skill.model_processing import get_fcst_cycle
+
+
+def get_nodd_prefix_map(prop: Any, logger: Logger) -> tuple[str, str]:
+    """
+    Return (local_prefix, bucket_prefix) for translating file paths between
+    the local directory layout ({ofs}/{netcdf_dir}/) and the layout of the
+    NODD S3 bucket for the OFS.
+
+    The STOFS buckets have no netcdf subdirectory: STOFS-3D buckets use
+    capitalized top-level prefixes (STOFS-3D-Atl/, STOFS-3D-Pac/), and the
+    STOFS-2D-Global bucket stores date directories at the bucket root. For
+    all other OFS the bucket layout matches the local layout, so both
+    prefixes are identical and translation is a no-op.
+
+    Raises
+    ------
+    ValueError
+        If the configured netcdf_dir is an absolute path or contains a
+        '..' component, either of which would relocate downloads outside
+        the data directory tree.
+    """
+    _conf = getattr(prop, 'config_file', None)
+    dir_params = utils.Utils(_conf).read_config_section('directories', logger)
+    netcdf_dir = dir_params['netcdf_dir']
+    posix_dir = PurePosixPath(netcdf_dir)
+    windows_dir = PureWindowsPath(netcdf_dir)
+    if (posix_dir.is_absolute() or windows_dir.is_absolute()
+            or windows_dir.drive
+            or '..' in posix_dir.parts or '..' in windows_dir.parts):
+        raise ValueError(
+            f"Invalid netcdf_dir '{netcdf_dir}' in the [directories] config "
+            "section: it must be a relative subdirectory with no '..' "
+            'components.'
+        )
+    local_prefix = Path(
+        os.path.join(prop.ofs, netcdf_dir)
+    ).as_posix() + '/'
+    bucket_prefixes = {
+        'stofs_3d_atl': 'STOFS-3D-Atl/',
+        'stofs_3d_pac': 'STOFS-3D-Pac/',
+        'stofs_2d_glo': '',
+    }
+    bucket_prefix = bucket_prefixes.get(prop.ofs, local_prefix)
+    return local_prefix, bucket_prefix
+
+
+def swap_path_prefix(path: str, old_prefix: str, new_prefix: str) -> str:
+    """
+    Swap old_prefix for new_prefix at the start of path.
+
+    Unlike whole-string str.replace, this rewrites only an anchored prefix
+    match, so path components that happen to repeat the prefix deeper in
+    the string are never touched. The path is returned unchanged if it
+    does not start with old_prefix, or if old_prefix is empty.
+    """
+    if old_prefix and path.startswith(old_prefix):
+        return new_prefix + path[len(old_prefix):]
+    return path
 
 
 def construct_s3_url(local_path: str, prop: Any, logger: Logger) -> Optional[str]:
@@ -69,44 +129,41 @@ def construct_s3_url(local_path: str, prop: Any, logger: Logger) -> Optional[str
         _conf = getattr(prop, 'config_file', None)
         url_params = utils.Utils(_conf).read_config_section('urls', logger)
 
+        # Prefix pair for translating the local {ofs}/{netcdf_dir}/ layout
+        # to the bucket layout (the two are identical for non-STOFS OFS).
+        local_prefix, bucket_prefix = get_nodd_prefix_map(prop, logger)
+        netcdf_dir = local_prefix[len(prop.ofs):].strip('/')
+
         # Normalize path separators
         local_path = Path(local_path).as_posix()
 
         # Extract the OFS-relative path (everything after the OFS name)
-        # Format: {base_path}/{ofs}/netcdf/{rest_of_path}
+        # Format: {base_path}/{ofs}/{netcdf_dir}/{rest_of_path}
         path_parts = local_path.split('/')
 
-        # Find where 'netcdf' appears in the path
-        try:
-            netcdf_idx = path_parts.index('netcdf')
+        # Find where the configured netcdf subdirectory appears in the path
+        if netcdf_dir and netcdf_dir in path_parts:
+            netcdf_idx = path_parts.index(netcdf_dir)
             # Reconstruct from OFS name onwards
-            ofs_relative_path = '/'.join([prop.ofs, 'netcdf'] + path_parts[netcdf_idx + 1:])
-        except ValueError:
-            # Fallback: try to find OFS name in path
-            try:
-                ofs_idx = path_parts.index(prop.ofs)
-                ofs_relative_path = '/'.join(path_parts[ofs_idx:])
-            except ValueError:
-                logger.error(f'Cannot determine OFS-relative path from: {local_path}')
-                return None
+            ofs_relative_path = '/'.join(
+                [prop.ofs, netcdf_dir] + path_parts[netcdf_idx + 1:])
+        elif prop.ofs in path_parts:
+            # Fallback: find the OFS name in the path
+            ofs_relative_path = '/'.join(
+                path_parts[path_parts.index(prop.ofs):])
+        else:
+            logger.error(f'Cannot determine OFS-relative path from: {local_path}')
+            return None
 
         # Select appropriate S3 bucket URL based on OFS
         url_root = url_params[get_s3_bucket(prop.ofs)]
-        if prop.ofs in ('stofs_3d_atl', 'stofs_3d_pac'):
-            # STOFS uses different path structure - no 'netcdf' subdirectory
-            # Bucket structure: STOFS-3D-Atl/stofs_3d_atl.YYYYMMDD/filename.nc
-            ofs_relative_path = ofs_relative_path.replace(f'{prop.ofs}/netcdf/', f'{prop.ofs}/')
-            ofs_relative_path = ofs_relative_path.replace('stofs_3d_atl/', 'STOFS-3D-Atl/')
-            ofs_relative_path = ofs_relative_path.replace('stofs_3d_pac/', 'STOFS-3D-Pac/')
-        elif prop.ofs == 'stofs_2d_glo':
-            url_root = url_params['nodd_s3_stofs2d']
-            # STOFS-2D-Global uses different path structure - no 'netcdf' subdirectory
-            # Bucket structure: stofs_2d_glo.YYYYMMDD/<filename>.nc
-            # Note no <ofs> subdirectory in bucket, so we need to remove 'stofs_2d_glo/' from the path
-            ofs_relative_path = ofs_relative_path.replace(f'{prop.ofs}/netcdf/', f'{prop.ofs}/')
-            ofs_relative_path = ofs_relative_path.replace('stofs_2d_glo/', '')
-        else:
-            url_root = url_params['nodd_s3']
+        # Swap the local {ofs}/{netcdf_dir}/ prefix for the bucket prefix.
+        # The STOFS buckets have no netcdf subdirectory (STOFS-3D buckets
+        # use STOFS-3D-Atl/ or STOFS-3D-Pac/, STOFS-2D-Global stores date
+        # directories at the bucket root); for all other OFS the bucket
+        # layout matches the local layout and this is a no-op.
+        ofs_relative_path = swap_path_prefix(
+            ofs_relative_path, local_prefix, bucket_prefix)
 
         # Construct full S3 URL
         s3_url = f'{url_root}{ofs_relative_path}'

--- a/src/ofs_skill/model_processing/list_of_files.py
+++ b/src/ofs_skill/model_processing/list_of_files.py
@@ -834,7 +834,8 @@ def list_of_files(prop: Any, dir_list: list[str], logger: Logger) -> list[str]:
                                     hr_cyc_day.append(checkstr)
                                     files.append(af_name)
                             elif prop.ofs in ('stofs_3d_atl', 'stofs_3d_pac'):  # add stofs filename format
-                                if 'n0' in af_name and 'fields' in af_name:  # skiping filed2d post process
+                                if ('n0' in af_name and 'fields' in af_name
+                                        and prop.ofsfiletype == 'fields'):  # skiping filed2d post process
                                     # Split the string based on underscores and periods
                                     spltstr = af_name.split('_')
                                     # Extract the values
@@ -845,17 +846,17 @@ def list_of_files(prop: Any, dir_list: list[str], logger: Logger) -> list[str]:
                                         ):
                                         files.append(af_name)
                                         hr_cyc_day.append(checkstr1)
-                                elif prop.ofsfiletype == 'stations':
-                                    # Split the string based on underscores and periods
-                                    spltstr = af_name.split('_')
-                                    # Extract the values
-                                    checkstr1 = spltstr[-2][-2:]
-                                    checkstr2 = spltstr[-1].split('.')[0][1:3]
-                                    if ((int(checkstr2) - 1 >= int(prop.startdate[-2:]))
-                                        and (int(checkstr1) - 1 <= int(prop.enddate[-2:]))
-                                        ):
-                                        files.append(af_name)
-                                        hr_cyc_day.append(checkstr1)
+                                elif (prop.ofsfiletype == 'stations'
+                                      and 'points' in af_name
+                                      and af_name.endswith('.nc')):
+                                    # STOFS-3D points files carry the full
+                                    # timeseries for the directory's date
+                                    # (e.g. stofs_3d_atl.t12z.points.cwl.temp.salt.vel.nc),
+                                    # so key the sort string off the model
+                                    # cycle, same as the stofs_2d_glo branch.
+                                    files.append(af_name)
+                                    hr_cyc_day.append(
+                                        '000' + af_name.split('.')[1][1:3] + '00')
                             elif prop.ofs in ('stofs_2d_glo'):
                                 # STOFS-2D-Global files each contain the full timeseries,
                                 # so we filter only on:
@@ -1048,7 +1049,8 @@ def list_of_files(prop: Any, dir_list: list[str], logger: Logger) -> list[str]:
                                     hr_cyc_day.append(checkstr)
                                     files.append(af_name)
                             elif prop.ofs in ('stofs_3d_atl', 'stofs_3d_pac'):   # add stofs filename format
-                                if 'f0' in af_name and 'fields' in af_name:  # skiping filed2d post process
+                                if ('f0' in af_name and 'fields' in af_name
+                                        and prop.ofsfiletype == 'fields'):  # skiping filed2d post process
                                     # Split the string based on underscores and periods
                                     spltstr = af_name.split('_')
                                     # Extract the values
@@ -1059,16 +1061,17 @@ def list_of_files(prop: Any, dir_list: list[str], logger: Logger) -> list[str]:
                                         files.append(af_name)
                                         hr_cyc_day.append(checkstr1)
 
-                                elif prop.ofsfiletype == 'stations':
-                                    # Split the string based on underscores and periods
-                                    spltstr = af_name.split('_')
-                                    # Extract the values
-                                    checkstr1 = spltstr[-2][-2:]
-                                    checkstr2 = spltstr[-1].split('.')[0][1:3]
-
-                                    if (int(checkstr2) - 1 >= int(a_start[-2:])):
-                                        files.append(af_name)
-                                        hr_cyc_day.append(checkstr1)
+                                elif (prop.ofsfiletype == 'stations'
+                                      and 'points' in af_name
+                                      and af_name.endswith('.nc')
+                                      and cycle_z in af_name):
+                                    # STOFS-3D points files carry the full
+                                    # timeseries for the directory's date
+                                    # (e.g. stofs_3d_atl.t12z.points.cwl.temp.salt.vel.nc),
+                                    # so filter on the requested cycle only,
+                                    # same as the stofs_2d_glo branch.
+                                    files.append(af_name)
+                                    hr_cyc_day.append('0000000')
                             elif prop.ofs in ('stofs_2d_glo'):
                                 # STOFS-2D-Global files each contain the full timeseries,
                                 # so we filter on:
@@ -1217,7 +1220,8 @@ def list_of_files(prop: Any, dir_list: list[str], logger: Logger) -> list[str]:
                                     hr_cyc_day.append(checkstr)
                                     files.append(af_name)
                             elif prop.ofs in ('stofs_3d_atl', 'stofs_3d_pac'):    # add stofs filename format
-                                if 'f0' in af_name and 'fields' in af_name:  # skiping filed2d post process:
+                                if ('f0' in af_name and 'fields' in af_name
+                                        and prop.ofsfiletype == 'fields'):  # skiping filed2d post process:
                                     # Split the string based on underscores and periods
                                     spltstr = af_name.split('_')
                                     # Extract the values
@@ -1229,18 +1233,17 @@ def list_of_files(prop: Any, dir_list: list[str], logger: Logger) -> list[str]:
                                         ):
                                         files.append(af_name)
                                         hr_cyc_day.append(checkstr1)
-                                elif prop.ofsfiletype == 'stations':
-                                    # Split the string based on underscores and periods
-                                    spltstr = af_name.split('_')
-                                    # Extract the values
-                                    checkstr1 = spltstr[-2][-2:]
-                                    checkstr2 = spltstr[-1].split('.')[0][1:3]
-
-                                    if ((int(checkstr2) - 1 >= int(prop.startdate[-2:]))
-                                        and (int(checkstr1) - 1 <= int(prop.enddate[-2:]))
-                                        ):
-                                        files.append(af_name)
-                                        hr_cyc_day.append(checkstr1)
+                                elif (prop.ofsfiletype == 'stations'
+                                      and 'points' in af_name
+                                      and af_name.endswith('.nc')):
+                                    # STOFS-3D points files carry the full
+                                    # timeseries for the directory's date
+                                    # (e.g. stofs_3d_atl.t12z.points.cwl.temp.salt.vel.nc),
+                                    # so key the sort string off the model
+                                    # cycle, same as the stofs_2d_glo branch.
+                                    files.append(af_name)
+                                    hr_cyc_day.append(
+                                        '000' + af_name.split('.')[1][1:3] + '00')
                             elif prop.ofs in ['stofs_2d_glo']:
                                 # STOFS-2D-Global files each contain the full timeseries,
                                 # so we filter only on:

--- a/src/ofs_skill/model_processing/write_ofs_ctlfile.py
+++ b/src/ofs_skill/model_processing/write_ofs_ctlfile.py
@@ -35,6 +35,7 @@ from typing import Any
 import numpy as np
 
 import ofs_skill.model_processing.indexing as indexing
+from ofs_skill.model_processing.list_of_files import local_model_dir
 from ofs_skill.obs_retrieval import utils
 from ofs_skill.obs_retrieval.station_ctl_file_extract import station_ctl_file_extract
 
@@ -380,8 +381,8 @@ def write_ofs_ctlfile(prop: Any, model: Any, logger: Logger) -> Any:
     _conf = getattr(prop, 'config_file', None)
     dir_params = utils.Utils(_conf).read_config_section('directories', logger)
 
-    prop.model_path = os.path.join(
-        dir_params['model_historical_dir'], prop.ofs, dir_params['netcdf_dir']
+    prop.model_path = local_model_dir(
+        dir_params['model_historical_dir'], prop.ofs, logger
     )
     prop.model_path = Path(prop.model_path).as_posix()
 

--- a/tests/list_of_files_stofs_points_test.py
+++ b/tests/list_of_files_stofs_points_test.py
@@ -1,0 +1,230 @@
+"""
+Unit tests for STOFS-3D points-file parsing in list_of_files().
+
+Regression protection for the bug where the local directory-listing
+parsers could not parse the STOFS-3D points filename
+(e.g. ``stofs_3d_atl.t12z.points.cwl.temp.salt.vel.nc``): the
+underscore-split logic written for the fields names ended up doing
+``int('tl')`` -> ValueError, so every locally present points file was
+skipped as unparseable. With ``use_s3_fallback=False`` a run over fully
+pre-downloaded station files exited with "No model files found" even
+though the files were on disk.
+
+Also covers the companion fix: the STOFS-3D *fields* sub-branches never
+checked ``prop.ofsfiletype``, so fields files could leak into a stations
+listing.
+
+All tests are in-process (no subprocesses) and use real temp
+directories/config files so the exact production code path is exercised
+with the S3 fallback disabled.
+"""
+
+import pytest
+
+from ofs_skill.model_processing.list_of_files import list_of_files
+
+POINTS_FILE = 'stofs_3d_atl.t12z.points.cwl.temp.salt.vel.nc'
+FIELDS_FILES = [
+    'stofs_3d_atl.t12z.fields.temperature_n001_012.nc',
+    'stofs_3d_atl.t12z.fields.temperature_n013_024.nc',
+]
+FORECAST_FIELDS_FILES = [
+    'stofs_3d_atl.t12z.fields.temperature_f001_012.nc',
+    'stofs_3d_atl.t12z.fields.temperature_f013_024.nc',
+]
+
+
+class MockLogger:
+    """Minimal logger capturing messages per level for assertions."""
+
+    def __init__(self):
+        """Create empty per-level message buffers."""
+        self.infos = []
+        self.warnings = []
+        self.errors = []
+        self.debugs = []
+
+    def info(self, msg, *args, **_kwargs):
+        """Record an info message."""
+        self.infos.append(msg % args if args else msg)
+
+    def warning(self, msg, *args, **_kwargs):
+        """Record a warning message."""
+        self.warnings.append(msg % args if args else msg)
+
+    def error(self, msg, *args, **_kwargs):
+        """Record an error message."""
+        self.errors.append(msg % args if args else msg)
+
+    def debug(self, msg, *args, **_kwargs):
+        """Record a debug message."""
+        self.debugs.append(msg % args if args else msg)
+
+
+class MockProps:  # pylint: disable=too-few-public-methods
+    """Minimal ModelProperties stand-in for list_of_files()."""
+
+    def __init__(self, config_file, **overrides):
+        """Store the attributes list_of_files() reads."""
+        self.ofs = 'stofs_3d_atl'
+        self.whichcast = 'nowcast'
+        self.ofsfiletype = 'stations'
+        self.forecast_hr = '12z'
+        self.startdate = '2025070100'
+        self.enddate = '2025070223'
+        self.config_file = config_file
+        for key, value in overrides.items():
+            setattr(self, key, value)
+
+
+@pytest.fixture(name='logger')
+def logger_fixture():
+    """Provide a fresh MockLogger per test."""
+    return MockLogger()
+
+
+@pytest.fixture(name='no_fallback_conf')
+def no_fallback_conf_fixture(tmp_path):
+    """Write a real config file with the S3 fallback disabled."""
+    conf = tmp_path / 'ofs_dps.conf'
+    conf.write_text('[settings]\nuse_s3_fallback = False\n',
+                    encoding='utf-8')
+    return str(conf)
+
+
+def make_stofs_dir(tmp_path, date_str, filenames):
+    """Create a STOFS-style dated directory populated with dummy files."""
+    stofs_dir = tmp_path / f'stofs_3d_atl.{date_str}'
+    stofs_dir.mkdir()
+    for name in filenames:
+        (stofs_dir / name).write_bytes(b'')
+    return stofs_dir
+
+
+def basenames(result):
+    """Reduce list_of_files() output to plain file names."""
+    return [f.replace('\\', '/').split('/')[-1] for f in result]
+
+
+@pytest.mark.parametrize('whichcast', ['nowcast', 'forecast_a', 'forecast_b'])
+def test_stations_run_lists_points_file(tmp_path, no_fallback_conf, logger,
+                                        whichcast):
+    """Points files must be listed for stations runs in all whichcasts.
+
+    Pre-fix, the underscore-split parse raised ValueError (int('tl')) and
+    the file was skipped, leaving the listing empty and the run dead with
+    SystemExit(1) when the S3 fallback is off.
+    """
+    stofs_dir = make_stofs_dir(tmp_path, '20250701', [POINTS_FILE])
+    props = MockProps(no_fallback_conf, whichcast=whichcast)
+
+    result = list_of_files(props, [str(stofs_dir)], logger)
+
+    assert basenames(result) == [POINTS_FILE]
+    assert not any('unparseable' in w for w in logger.warnings), (
+        f'points file still hit the unparseable path: {logger.warnings}'
+    )
+
+
+@pytest.mark.parametrize(
+    'whichcast,fields_names',
+    [('nowcast', FIELDS_FILES),
+     ('forecast_a', FORECAST_FIELDS_FILES),
+     ('forecast_b', FORECAST_FIELDS_FILES)])
+def test_stations_run_excludes_fields_files(tmp_path, no_fallback_conf,
+                                            logger, whichcast, fields_names):
+    """Fields files in the same directory must not leak into stations runs.
+
+    Pre-fix, the fields sub-branch had no ofsfiletype guard, so fields
+    files were appended to stations listings whenever they parsed.
+    """
+    stofs_dir = make_stofs_dir(tmp_path, '20250701',
+                               [POINTS_FILE] + fields_names)
+    props = MockProps(no_fallback_conf, whichcast=whichcast)
+
+    result = list_of_files(props, [str(stofs_dir)], logger)
+
+    assert basenames(result) == [POINTS_FILE]
+
+
+def test_stations_run_with_only_fields_files_exits(tmp_path,
+                                                   no_fallback_conf, logger):
+    """A stations run over a fields-only directory must find nothing.
+
+    Pre-fix, the missing ofsfiletype guard let the fields files through;
+    post-fix the listing is empty and, with the fallback off, the run
+    exits via SystemExit.
+    """
+    stofs_dir = make_stofs_dir(tmp_path, '20250701', FIELDS_FILES)
+    props = MockProps(no_fallback_conf, whichcast='nowcast')
+
+    with pytest.raises(SystemExit):
+        list_of_files(props, [str(stofs_dir)], logger)
+
+
+@pytest.mark.parametrize('whichcast', ['nowcast', 'forecast_a', 'forecast_b'])
+def test_fields_run_excludes_points_files(tmp_path, no_fallback_conf, logger,
+                                          whichcast):
+    """Fields runs keep listing fields files and never the points file."""
+    fields_names = (FIELDS_FILES if whichcast == 'nowcast'
+                    else FORECAST_FIELDS_FILES)
+    stofs_dir = make_stofs_dir(tmp_path, '20250701',
+                               [POINTS_FILE] + fields_names)
+    props = MockProps(no_fallback_conf, whichcast=whichcast,
+                      ofsfiletype='fields')
+
+    result = list_of_files(props, [str(stofs_dir)], logger)
+
+    assert sorted(basenames(result)) == sorted(fields_names)
+
+
+def test_forecast_a_points_filtered_by_cycle(tmp_path, no_fallback_conf,
+                                             logger):
+    """forecast_a must keep only the requested cycle's points file."""
+    stofs_dir = make_stofs_dir(
+        tmp_path, '20250701',
+        [POINTS_FILE, 'stofs_3d_atl.t00z.points.cwl.temp.salt.vel.nc'])
+    props = MockProps(no_fallback_conf, whichcast='forecast_a',
+                      forecast_hr='12z')
+
+    result = list_of_files(props, [str(stofs_dir)], logger)
+
+    assert basenames(result) == [POINTS_FILE]
+
+
+def test_multi_day_points_files_listed_in_directory_order(
+        tmp_path, no_fallback_conf, logger):
+    """One points file per dated directory, in dir_list (date) order.
+
+    This matches the ordering construct_expected_files() produces when
+    the S3 fallback resolves the same window.
+    """
+    dir1 = make_stofs_dir(tmp_path, '20250701', [POINTS_FILE])
+    dir2 = make_stofs_dir(tmp_path, '20250702', [POINTS_FILE])
+    props = MockProps(no_fallback_conf, whichcast='nowcast')
+
+    result = list_of_files(props, [str(dir1), str(dir2)], logger)
+
+    assert len(result) == 2
+    assert '20250701' in result[0].replace('\\', '/')
+    assert '20250702' in result[1].replace('\\', '/')
+
+
+@pytest.mark.parametrize('whichcast,cast_names', [
+    ('nowcast', ['cbofs.t00z.20250701.stations.n001.nc',
+                 'cbofs.t06z.20250701.stations.n001.nc']),
+    ('forecast_b', ['cbofs.t00z.20250701.stations.f001.nc',
+                    'cbofs.t06z.20250701.stations.f001.nc']),
+])
+def test_cbofs_style_names_unchanged(tmp_path, no_fallback_conf, logger,
+                                     whichcast, cast_names):
+    """Non-STOFS naming conventions must parse exactly as before."""
+    cbofs_dir = tmp_path / 'cbofs' / '2025' / '07' / '01'
+    cbofs_dir.mkdir(parents=True)
+    for name in cast_names:
+        (cbofs_dir / name).write_bytes(b'')
+    props = MockProps(no_fallback_conf, whichcast=whichcast, ofs='cbofs')
+
+    result = list_of_files(props, [str(cbofs_dir)], logger)
+
+    assert sorted(basenames(result)) == sorted(cast_names)

--- a/tests/netcdf_dir_retirement_test.py
+++ b/tests/netcdf_dir_retirement_test.py
@@ -1,0 +1,124 @@
+"""
+Tests for the retirement of the netcdf_dir config setting (issue #213).
+
+Covers local_model_dir (canonical {ofs}/netcdf/ layout with a fallback
+to the legacy no-subdirectory layout left behind by the retired blank
+netcdf_dir workaround) and the download-failure log classification that
+replaced the misleading "NODD S3 is not responding!" catch-all.
+"""
+
+from urllib.error import ContentTooShortError, HTTPError, URLError
+
+from bin.utils import get_model_data
+from ofs_skill.model_processing.list_of_files import (
+    NETCDF_SUBDIR,
+    local_model_dir,
+)
+
+
+class MockLogger:  # pylint: disable=too-few-public-methods
+    """Capture log calls by level."""
+
+    def __init__(self):
+        self.infos = []
+        self.warnings = []
+        self.errors = []
+
+    def info(self, msg, *args, **_kwargs):
+        """Record an info message."""
+        self.infos.append(msg % args if args else msg)
+
+    def warning(self, msg, *args, **_kwargs):
+        """Record a warning message."""
+        self.warnings.append(msg % args if args else msg)
+
+    def error(self, msg, *args, **_kwargs):
+        """Record an error message."""
+        self.errors.append(msg % args if args else msg)
+
+
+# ---------------------------------------------------------------------------
+# local_model_dir: canonical layout with legacy fallback
+# ---------------------------------------------------------------------------
+
+def test_local_model_dir_canonical(tmp_path):
+    """The canonical {ofs}/netcdf/ directory wins when it exists."""
+    canonical = tmp_path / 'cbofs' / NETCDF_SUBDIR
+    canonical.mkdir(parents=True)
+    logger = MockLogger()
+    result = local_model_dir(str(tmp_path), 'cbofs', logger)
+    assert result == str(canonical)
+    assert not logger.infos
+
+
+def test_local_model_dir_legacy_fallback(tmp_path):
+    """A populated legacy tree (no netcdf/ level) is used with a notice."""
+    legacy = tmp_path / 'cbofs'
+    (legacy / '2025' / '07' / '01').mkdir(parents=True)
+    logger = MockLogger()
+    result = local_model_dir(str(tmp_path), 'cbofs', logger)
+    assert result == str(legacy)
+    assert any('legacy layout' in msg for msg in logger.infos)
+
+
+def test_local_model_dir_fresh_tree(tmp_path):
+    """With nothing on disk, the canonical path is returned for creation."""
+    logger = MockLogger()
+    result = local_model_dir(str(tmp_path), 'cbofs', logger)
+    assert result == str(tmp_path / 'cbofs' / NETCDF_SUBDIR)
+    assert not logger.infos
+
+
+def test_local_model_dir_empty_legacy_dir(tmp_path):
+    """An empty {ofs}/ directory does not trigger the legacy fallback."""
+    (tmp_path / 'cbofs').mkdir()
+    logger = MockLogger()
+    result = local_model_dir(str(tmp_path), 'cbofs', logger)
+    assert result == str(tmp_path / 'cbofs' / NETCDF_SUBDIR)
+    assert not logger.infos
+
+
+# ---------------------------------------------------------------------------
+# _log_download_failure: honest cause classification (issue #213)
+# ---------------------------------------------------------------------------
+
+def _classify(exc):
+    """Run the classifier and return the logged error messages."""
+    logger = MockLogger()
+    # pylint: disable-next=protected-access
+    get_model_data._log_download_failure(
+        'https://noaa-nos-ofs-pds.s3.amazonaws.com/cbofs/x.nc', exc, logger)
+    return logger.errors
+
+
+def test_classify_http_404_is_not_an_outage():
+    """A 404 names the URL and says the NODD is reachable."""
+    errors = _classify(
+        HTTPError('http://x', 404, 'Not Found', None, None))
+    assert any('404' in msg and 'not a NODD outage' in msg for msg in errors)
+    assert not any('not responding' in msg for msg in errors)
+
+
+def test_classify_http_other_status():
+    """Non-404 HTTP errors report the actual status code."""
+    errors = _classify(
+        HTTPError('http://x', 403, 'Forbidden', None, None))
+    assert any('403' in msg and 'responded' in msg for msg in errors)
+
+
+def test_classify_unreachable():
+    """Connection-level failures keep the outage wording."""
+    errors = _classify(URLError('connection refused'))
+    assert any('Could not reach' in msg for msg in errors)
+
+
+def test_classify_interrupted_transfer():
+    """A transfer that dies mid-download is reported as interrupted."""
+    errors = _classify(ContentTooShortError('connection dropped', b''))
+    assert any('interrupted' in msg for msg in errors)
+
+
+def test_classify_generic_exception():
+    """Anything unrecognized still logs the URL and the exception."""
+    errors = _classify(RuntimeError('boom'))
+    assert any('boom' in msg for msg in errors)

--- a/tests/nodd_download_robustness_test.py
+++ b/tests/nodd_download_robustness_test.py
@@ -112,7 +112,7 @@ def test_truncated_download_never_promoted(tmp_path):
     assert local_path is None
     assert not final.exists(), 'truncated file must not reach the final path'
     assert not part.exists(), 'failed .part file must be cleaned up'
-    assert any(lvl == 'error' and 'Download failed' in msg
+    assert any(lvl == 'error' and 'interrupted' in msg
                for lvl, msg in logged)
 
 

--- a/tests/nodd_download_robustness_test.py
+++ b/tests/nodd_download_robustness_test.py
@@ -1,0 +1,283 @@
+"""
+Unit tests for NODD downloader robustness in `bin/utils/get_model_data.py`.
+
+Covers four defects found while verifying the STOFS station download path:
+
+(a) `urlretrieve` wrote directly to the final path, so an interrupted
+    transfer left a truncated file that the skip-if-exists check treated
+    as complete on every later run. Downloads now go to a '.part' name
+    and are promoted with os.replace() only on success (same pattern as
+    the S3 cache path in intake_scisa.py, issues #176/#193).
+
+(b) The bucket key was extracted with `url.split('.com')[-1]`, which
+    breaks for endpoints whose host has no '.com'. Now urlparse().path.
+
+(c) `savepath` was derived by splitting the first save directory on the
+    FIRST occurrence of the OFS name anywhere in the string, which broke
+    for working directories containing the OFS name (e.g.
+    /home/user/cbofs_runs/). Now anchored on the trailing
+    {ofs}/{netcdf_dir}/ layout component.
+
+(d) For STOFS-3D stations nowcast, the read side lists the day-(end+1)
+    12Z points file (the t12z segment covers the PRECEDING 24 hours) but
+    the downloader never fetched it, so pre-provisioned runs
+    (use_s3_fallback=False) could not cover post-12Z hours of the last
+    day. The downloader's dates_range now mirrors the read side.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+from urllib.error import ContentTooShortError, HTTPError
+
+import pytest
+
+from bin.utils import get_model_data
+
+
+def make_logger(record):
+    """Return a logger stand-in appending (level, message) to record."""
+    def log_as(level):
+        return lambda msg, *args, **_kw: record.append(
+            (level, msg % args if args else msg))
+    return SimpleNamespace(info=log_as('info'), warning=log_as('warning'),
+                           error=log_as('error'), debug=log_as('debug'))
+
+
+def make_props(tmp_path, ofs, whichcast, ofsfiletype='stations'):
+    """Return a minimal ModelProperties stand-in with a written config."""
+    conf_path = tmp_path / 'ofs_dps.conf'
+    conf_path.write_text(
+        '[directories]\n'
+        f'home={tmp_path}\n'
+        'netcdf_dir=netcdf\n'
+        f'model_historical_dir={tmp_path / "example_data"}\n'
+        '[urls]\n'
+        'nodd_s3=https://noaa-nos-ofs-pds.s3.amazonaws.com/\n'
+        'nodd_s3_stofs3d=https://noaa-nos-stofs3d-pds.s3.amazonaws.com/\n'
+        'nodd_s3_stofs2d=https://noaa-gestofs-pds.s3.amazonaws.com/\n',
+        encoding='utf-8',
+    )
+    return SimpleNamespace(
+        ofs=ofs, whichcast=whichcast, ofsfiletype=ofsfiletype,
+        config_file=str(conf_path), model_path='',
+        start_date_full='2025-07-01T00:00:00Z',
+        end_date_full='2025-07-02T00:00:00Z',
+    )
+
+
+def make_file_list_for(tmp_path, ofs, whichcast, ofsfiletype='stations'):
+    """Run the list_of_dir -> make_file_list chain and return the file list."""
+    logger = make_logger([])
+    prop = make_props(tmp_path, ofs, whichcast, ofsfiletype)
+    dir_list, dates = get_model_data.list_of_dir(
+        prop, f'{ofs}/netcdf', logger)
+    return get_model_data.make_file_list(prop, dates, dir_list, logger)
+
+
+CBOFS_URL = ('https://noaa-nos-ofs-pds.s3.amazonaws.com/cbofs/netcdf/'
+             '2025/07/01/cbofs.t00z.20250701.stations.nowcast.nc')
+
+
+def _download(tmp_path, side_effect, url=CBOFS_URL):
+    """Call _download_single_file with a mocked urlretrieve; return results."""
+    logged = []
+    logger = make_logger(logged)
+    savepath = f'{tmp_path.as_posix()}/'
+    target_dir = tmp_path / 'cbofs' / 'netcdf' / '2025' / '07' / '01'
+    target_dir.mkdir(parents=True, exist_ok=True)
+    prefix_map = ('cbofs/netcdf/', 'cbofs/netcdf/')
+    with patch('bin.utils.get_model_data.urllib.request.urlretrieve',
+               side_effect=side_effect) as mock_get, \
+            patch('bin.utils.get_model_data.time.sleep'):
+        # pylint: disable-next=protected-access
+        local_path = get_model_data._download_single_file(
+            url, savepath, logger, prefix_map=prefix_map)
+    final = target_dir / 'cbofs.t00z.20250701.stations.nowcast.nc'
+    part = target_dir / 'cbofs.t00z.20250701.stations.nowcast.nc.part'
+    return local_path, final, part, mock_get, logged
+
+
+# ---------------------------------------------------------------------------
+# (a) Atomic downloads: .part never promoted, interrupted runs recover
+# ---------------------------------------------------------------------------
+
+def test_truncated_download_never_promoted(tmp_path):
+    """A transfer that dies mid-download leaves neither final nor .part."""
+    def truncate(_url, dst):
+        with open(dst, 'wb') as fil:
+            fil.write(b'trunc')
+        raise ContentTooShortError('connection dropped', b'trunc')
+
+    local_path, final, part, _, logged = _download(tmp_path, truncate)
+    assert local_path is None
+    assert not final.exists(), 'truncated file must not reach the final path'
+    assert not part.exists(), 'failed .part file must be cleaned up'
+    assert any(lvl == 'error' and 'Download failed' in msg
+               for lvl, msg in logged)
+
+
+def test_interrupted_download_retried_next_run(tmp_path):
+    """A stale .part from a killed run is removed and the file re-fetched."""
+    def fetch(_url, dst):
+        with open(dst, 'wb') as fil:
+            fil.write(b'complete-data')
+
+    target_dir = tmp_path / 'cbofs' / 'netcdf' / '2025' / '07' / '01'
+    target_dir.mkdir(parents=True)
+    stale = target_dir / 'cbofs.t00z.20250701.stations.nowcast.nc.part'
+    stale.write_bytes(b'trunc')
+
+    local_path, final, part, mock_get, logged = _download(tmp_path, fetch)
+    assert local_path == final.as_posix()
+    assert final.read_bytes() == b'complete-data'
+    assert not part.exists()
+    assert mock_get.call_count == 1
+    assert any(lvl == 'warning' and 'stale partial' in msg
+               for lvl, msg in logged)
+
+
+def test_completed_file_still_skipped(tmp_path):
+    """A file already at the final path is skipped without re-download."""
+    target_dir = tmp_path / 'cbofs' / 'netcdf' / '2025' / '07' / '01'
+    target_dir.mkdir(parents=True)
+    final_pre = target_dir / 'cbofs.t00z.20250701.stations.nowcast.nc'
+    final_pre.write_bytes(b'already-here')
+
+    local_path, final, _, mock_get, logged = _download(tmp_path, None)
+    assert local_path == final.as_posix()
+    assert final.read_bytes() == b'already-here'
+    mock_get.assert_not_called()
+    assert any(lvl == 'info' and 'already exists' in msg
+               for lvl, msg in logged)
+
+
+def test_http_503_retry_semantics_preserved(tmp_path):
+    """Two 503s then success: three attempts, file promoted, no .part."""
+    calls = {'n': 0}
+
+    def flaky(url, dst):
+        calls['n'] += 1
+        if calls['n'] < 3:
+            raise HTTPError(url, 503, 'Service Unavailable', None, None)
+        with open(dst, 'wb') as fil:
+            fil.write(b'third-time-lucky')
+
+    local_path, final, part, mock_get, _ = _download(tmp_path, flaky)
+    assert local_path == final.as_posix()
+    assert final.read_bytes() == b'third-time-lucky'
+    assert not part.exists()
+    assert mock_get.call_count == 3
+
+
+def test_retrieve_atomic_promotes_on_success(tmp_path):
+    """_retrieve_atomic downloads to .part and renames into place."""
+    final = tmp_path / 'file.nc'
+
+    def fetch(_url, dst):
+        assert dst == f'{final.as_posix()}.part'
+        with open(dst, 'wb') as fil:
+            fil.write(b'payload')
+
+    with patch('bin.utils.get_model_data.urllib.request.urlretrieve',
+               side_effect=fetch):
+        # pylint: disable-next=protected-access
+        get_model_data._retrieve_atomic('http://x/file.nc', final.as_posix())
+    assert final.read_bytes() == b'payload'
+    assert not (tmp_path / 'file.nc.part').exists()
+
+
+# ---------------------------------------------------------------------------
+# (b) Bucket key extraction via urlparse (no '.com' assumption)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize('url', [
+    'https://noaa-nos-ofs-pds.s3.amazonaws.com/cbofs/netcdf/2025/07/01/f.nc',
+    'https://ofs-mirror.s3.us-gov-east-1.example.org/cbofs/netcdf/'
+    '2025/07/01/f.nc',
+    'http://localhost:9000/cbofs/netcdf/2025/07/01/f.nc',
+])
+def test_url_to_local_path_any_endpoint(url):
+    """The key is the URL path for .com and non-.com endpoints alike."""
+    # pylint: disable-next=protected-access
+    local = get_model_data._url_to_local_path(
+        url, '/data/', ('cbofs/netcdf/', 'cbofs/netcdf/'))
+    assert local == '/data/cbofs/netcdf/2025/07/01/f.nc'
+
+
+def test_url_to_local_path_swaps_bucket_prefix_non_com():
+    """STOFS bucket prefix translation works without a '.com' host."""
+    url = ('https://stofs-mirror.example.net/STOFS-3D-Atl/'
+           'stofs_3d_atl.20250701/stofs_3d_atl.t12z.points.cwl.temp.salt.vel.nc')
+    # pylint: disable-next=protected-access
+    local = get_model_data._url_to_local_path(
+        url, '/data/', ('stofs_3d_atl/netcdf/', 'STOFS-3D-Atl/'))
+    assert local == ('/data/stofs_3d_atl/netcdf/stofs_3d_atl.20250701/'
+                     'stofs_3d_atl.t12z.points.cwl.temp.salt.vel.nc')
+
+
+# ---------------------------------------------------------------------------
+# (c) savepath anchored on the trailing {ofs}/{netcdf_dir}/ component
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize('first_dir,prefix,expected', [
+    # OFS name in the working directory must not truncate the base path
+    ('/home/user/cbofs_runs/data/model/cbofs/netcdf/2025/07/01',
+     'cbofs/netcdf/', '/home/user/cbofs_runs/data/model/'),
+    ('/base/example_data/cbofs/netcdf/2025/07/01',
+     'cbofs/netcdf/', '/base/example_data/'),
+    ('/base/example_data/stofs_3d_atl/netcdf/stofs_3d_atl.20250701',
+     'stofs_3d_atl/netcdf/', '/base/example_data/'),
+    # Relative base path
+    ('example_data/cbofs/netcdf/2025/07/01',
+     'cbofs/netcdf/', 'example_data/'),
+    # Layout rooted directly at {ofs}/{netcdf_dir}/
+    ('cbofs/netcdf/2025/07/01', 'cbofs/netcdf/', ''),
+])
+def test_derive_savepath(first_dir, prefix, expected):
+    """savepath is everything above the anchored {ofs}/{netcdf_dir}/."""
+    # pylint: disable-next=protected-access
+    assert get_model_data._derive_savepath([first_dir], prefix) == expected
+
+
+def test_derive_savepath_missing_layout_raises():
+    """A save directory without the layout component is an error."""
+    with pytest.raises(ValueError, match='cbofs/netcdf/'):
+        # pylint: disable-next=protected-access
+        get_model_data._derive_savepath(['/somewhere/else'], 'cbofs/netcdf/')
+
+
+# ---------------------------------------------------------------------------
+# (d) STOFS-3D stations nowcast fetches the day-(end+1) 12Z cycle
+# ---------------------------------------------------------------------------
+
+def test_stofs3d_stations_nowcast_includes_end_plus_one(tmp_path):
+    """The downloader lists the same end+1 points file the reader needs."""
+    files = make_file_list_for(tmp_path, 'stofs_3d_atl', 'nowcast')
+    # 06/30 (start-1) through 07/03 (end+1), one t12z points file per day
+    assert len(files) == 4
+    assert any('stofs_3d_atl.20250703' in f for f in files)
+    assert files[-1].endswith(
+        'stofs_3d_atl.20250703/stofs_3d_atl.t12z.points.cwl.temp.salt.vel.nc')
+
+
+def test_stofs3d_stations_forecast_b_unchanged(tmp_path):
+    """forecast_b keeps the start-1..end range (no look-ahead day)."""
+    files = make_file_list_for(tmp_path, 'stofs_3d_atl', 'forecast_b')
+    assert len(files) == 3
+    assert not any('20250703' in f for f in files)
+
+
+def test_stofs3d_fields_nowcast_unchanged(tmp_path):
+    """The look-ahead applies to stations only, not fields files."""
+    files = make_file_list_for(tmp_path, 'stofs_3d_atl', 'nowcast',
+                               ofsfiletype='fields')
+    assert files
+    assert not any('20250703' in f for f in files)
+
+
+def test_cbofs_stations_nowcast_unchanged(tmp_path):
+    """Non-STOFS nowcast file lists keep the start-1..end range."""
+    files = make_file_list_for(tmp_path, 'cbofs', 'nowcast')
+    # 3 days (06/30-07/02) x 4 cycles
+    assert len(files) == 12
+    assert not any('/07/03/' in f for f in files)

--- a/tests/schism_points_cast_subsetting_test.py
+++ b/tests/schism_points_cast_subsetting_test.py
@@ -1,0 +1,261 @@
+"""Tests for per-cast subsetting of SCHISM (STOFS-3D) points files.
+
+STOFS-3D per-cycle points files carry the nowcast and forecast periods
+concatenated on one time axis (verified against operational NODD
+output: 1200 six-minute steps spanning cycle - 24 h + dt through
+cycle + 96 h). ``fix_schism_points_dataset`` must keep only the
+segments belonging to the requested whichcast, exactly as
+``fix_adcirc_dataset`` does for STOFS-2D-Global:
+
+- nowcast: each cycle's times <= its cycle time;
+- forecast_b: each cycle's times > its cycle time, with the downstream
+  dedup (keep='last') stitching overlaps in favor of the newer cycle;
+- forecast_a: the single requested initialization's forecast segment.
+
+The synthetic datasets mimic two consecutive STOFS-3D-Atl 12Z cycles
+with an hourly timestep (24 nowcast + 96 forecast steps per file); the
+subsetter infers the timestep and block boundaries from the time
+coordinate itself, so the coarser spacing exercises the same logic.
+"""
+
+import logging
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+import xarray as xr
+
+from ofs_skill.model_processing.intake_scisa import (
+    fix_schism_points_dataset,
+    needs_schism_points_cast_subsetting,
+)
+
+NOWCAST_H = 24
+FORECAST_H = 96
+CYCLE_1 = np.datetime64('2025-07-01T12:00')
+CYCLE_2 = np.datetime64('2025-07-02T12:00')
+
+
+def _logger():
+    return logging.getLogger('schism_points_cast_subsetting_test')
+
+
+def _cycle_block(cycle, block_id, step=np.timedelta64(1, 'h'),
+                 n_now=NOWCAST_H, n_fcst=FORECAST_H):
+    """One per-cycle points file: nowcast then forecast, concatenated.
+
+    Times run from ``cycle - n_now*step + step`` through
+    ``cycle + n_fcst*step`` (first n_now steps <= cycle are nowcast,
+    remainder are forecast), matching the observed operational layout.
+    Values encode provenance: block_id*1000 + step index.
+    """
+    n_total = n_now + n_fcst
+    times = cycle - n_now * step + step * np.arange(1, n_total + 1)
+    values = block_id * 1000.0 + np.arange(n_total, dtype=float)
+    return times, values
+
+
+def _dataset(blocks, n_station=3):
+    """Concatenate per-cycle blocks in file order, like nested intake."""
+    times = np.concatenate([b[0] for b in blocks])
+    vals = np.concatenate([b[1] for b in blocks])
+    zeta = np.tile(vals[:, None], (1, n_station))
+    return xr.Dataset(
+        data_vars={'zeta': (('time', 'station'), zeta)},
+        coords={'time': times},
+    )
+
+
+def _two_cycle_dataset():
+    return _dataset([
+        _cycle_block(CYCLE_1, block_id=1),
+        _cycle_block(CYCLE_2, block_id=2),
+    ])
+
+
+def _prop(whichcast, ofs='stofs_3d_atl', **kwargs):
+    return SimpleNamespace(
+        model_source='schism',
+        ofs=ofs,
+        ofsfiletype='stations',
+        whichcast=whichcast,
+        **kwargs,
+    )
+
+
+def _apply_pipeline_dedup(ds, whichcast):
+    """Replicate the duplicate-time removal from intake_model."""
+    keep = 'first' if whichcast == 'forecast_a' else 'last'
+    return ds.drop_duplicates(dim='time', keep=keep)
+
+
+def test_nowcast_keeps_only_nowcast_segments():
+    """nowcast keeps each cycle's times <= its cycle time, nothing else."""
+    ds = fix_schism_points_dataset(
+        _prop('nowcast'), _two_cycle_dataset(), _logger())
+
+    times = ds['time'].values
+    assert len(times) == 2 * NOWCAST_H
+    # Cycle 1 nowcast: (cycle1 - 24h, cycle1]; cycle 2: (cycle2 - 24h, cycle2]
+    assert times.min() == CYCLE_1 - np.timedelta64(NOWCAST_H - 1, 'h')
+    assert times.max() == CYCLE_2
+    # No forecast values may survive: nowcast step indices are < 24
+    step_idx = ds['zeta'].values[:, 0] % 1000
+    assert (step_idx < NOWCAST_H).all()
+    # Segments are disjoint, so the pipeline dedup must be a no-op
+    assert len(_apply_pipeline_dedup(ds, 'nowcast')['time']) == len(times)
+
+
+def test_forecast_b_keeps_only_forecast_segments():
+    """forecast_b keeps each cycle's times > its cycle time, nothing else."""
+    ds = fix_schism_points_dataset(
+        _prop('forecast_b'), _two_cycle_dataset(), _logger())
+
+    times = ds['time'].values
+    assert len(times) == 2 * FORECAST_H
+    assert times.min() == CYCLE_1 + np.timedelta64(1, 'h')
+    assert times.max() == CYCLE_2 + np.timedelta64(FORECAST_H, 'h')
+    # Nothing from any nowcast segment may survive
+    step_idx = ds['zeta'].values[:, 0] % 1000
+    assert (step_idx >= NOWCAST_H).all()
+
+
+def test_forecast_b_dedup_prefers_newer_cycle_forecast():
+    """At overlapping valid times the stitched forecast_b series must
+    come from the newer cycle's forecast — never from its nowcast."""
+    ds = fix_schism_points_dataset(
+        _prop('forecast_b'), _two_cycle_dataset(), _logger())
+    ds = _apply_pipeline_dedup(ds, 'forecast_b')
+
+    times = ds['time'].values
+    vals = ds['zeta'].values[:, 0]
+    block_of = vals // 1000
+
+    # Valid times up to and including cycle 2 exist only in cycle 1's
+    # forecast; after cycle 2 both cycles overlap and the newer wins.
+    assert (block_of[times <= CYCLE_2] == 1).all()
+    assert (block_of[times > CYCLE_2] == 2).all()
+    # A valid hour inside cycle 2's nowcast period must be cycle 1's
+    # forecast value (this was the defect: keep='last' used to
+    # substitute cycle 2's nowcast).
+    probe = CYCLE_2 - np.timedelta64(12, 'h')
+    val = float(vals[times == probe][0])
+    assert val // 1000 == 1
+    assert val % 1000 >= NOWCAST_H
+
+
+def test_forecast_a_keeps_only_requested_initialization():
+    """forecast_a keeps the requested cycle's full horizon and drops the
+    previous day's initialization entirely."""
+    ds = fix_schism_points_dataset(
+        _prop('forecast_a', startdate='2025070200', forecast_hr='12z'),
+        _two_cycle_dataset(), _logger())
+
+    times = ds['time'].values
+    vals = ds['zeta'].values[:, 0]
+    assert len(times) == FORECAST_H
+    assert times.min() == CYCLE_2 + np.timedelta64(1, 'h')
+    assert times.max() == CYCLE_2 + np.timedelta64(FORECAST_H, 'h')
+    # Everything must come from cycle 2 (the requested initialization);
+    # previously keep='first' kept cycle 1's forecast for the first
+    # 72 h of the horizon.
+    assert (vals // 1000 == 2).all()
+    assert (vals % 1000 >= NOWCAST_H).all()
+    # forecast_a dedup (keep='first') must not change the selection
+    assert len(_apply_pipeline_dedup(ds, 'forecast_a')['time']) == len(times)
+
+
+def test_forecast_a_duplicated_single_file():
+    """intake_model doubles a length-1 urlpath list; both copies match
+    the requested cycle and the dedup collapses them."""
+    ds = _dataset([
+        _cycle_block(CYCLE_2, block_id=2),
+        _cycle_block(CYCLE_2, block_id=2),
+    ])
+    out = fix_schism_points_dataset(
+        _prop('forecast_a', startdate='2025070200', forecast_hr='12z'),
+        ds, _logger())
+    out = _apply_pipeline_dedup(out, 'forecast_a')
+    assert len(out['time']) == FORECAST_H
+
+
+def test_forecast_a_missing_requested_cycle_raises():
+    """A forecast_a run whose requested cycle file is absent must fail
+    loudly instead of silently scoring another initialization."""
+    with pytest.raises(ValueError, match='no timesteps matched'):
+        fix_schism_points_dataset(
+            _prop('forecast_a', startdate='2025070500', forecast_hr='12z'),
+            _two_cycle_dataset(), _logger())
+
+
+def test_forecast_a_requires_cycle_identification():
+    """forecast_a without startdate/forecast_hr cannot pick a cycle."""
+    with pytest.raises(ValueError, match='forecast_a requires'):
+        fix_schism_points_dataset(
+            _prop('forecast_a', startdate=None, forecast_hr=None),
+            _two_cycle_dataset(), _logger())
+
+
+def test_rejects_non_schism_or_non_stations():
+    """The subsetter refuses non-SCHISM and non-stations datasets."""
+    with pytest.raises(ValueError, match='SCHISM points'):
+        fix_schism_points_dataset(
+            SimpleNamespace(model_source='adcirc', ofsfiletype='stations',
+                            ofs='stofs_2d_glo', whichcast='nowcast'),
+            _two_cycle_dataset(), _logger())
+    with pytest.raises(ValueError, match='SCHISM points'):
+        fix_schism_points_dataset(
+            SimpleNamespace(model_source='schism', ofsfiletype='fields',
+                            ofs='stofs_3d_atl', whichcast='nowcast'),
+            _two_cycle_dataset(), _logger())
+
+
+def test_dispatch_guard_scopes_to_stofs_3d_points_only():
+    """Only STOFS-3D stations datasets take the new subsetting path;
+    SCHISM fields, the per-cast SCHISM OFS (loofs2/secofs), and other
+    model sources are untouched."""
+    def prop_for(model_source, ofs, ofsfiletype):
+        return SimpleNamespace(model_source=model_source, ofs=ofs,
+                               ofsfiletype=ofsfiletype)
+
+    assert needs_schism_points_cast_subsetting(
+        prop_for('schism', 'stofs_3d_atl', 'stations'))
+    assert needs_schism_points_cast_subsetting(
+        prop_for('schism', 'stofs_3d_pac', 'stations'))
+    assert not needs_schism_points_cast_subsetting(
+        prop_for('schism', 'stofs_3d_atl', 'fields'))
+    assert not needs_schism_points_cast_subsetting(
+        prop_for('schism', 'loofs2', 'stations'))
+    assert not needs_schism_points_cast_subsetting(
+        prop_for('schism', 'secofs', 'stations'))
+    assert not needs_schism_points_cast_subsetting(
+        prop_for('adcirc', 'stofs_2d_glo', 'stations'))
+    assert not needs_schism_points_cast_subsetting(
+        prop_for('fvcom', 'necofs', 'stations'))
+
+
+def test_irregular_block_still_subsets_by_time(caplog):
+    """A truncated file (short block) warns but the time-based boundary
+    still yields a correct nowcast/forecast split."""
+    full = _cycle_block(CYCLE_1, block_id=1)
+    # Cycle 2's file truncated to 24 nowcast + 48 forecast steps
+    short_times, short_vals = _cycle_block(
+        CYCLE_2, block_id=2, n_fcst=48)
+    ds = _dataset([full, (short_times, short_vals)])
+
+    with caplog.at_level(logging.WARNING):
+        out = fix_schism_points_dataset(_prop('nowcast'), ds, _logger())
+    assert any('expected' in rec.message for rec in caplog.records)
+
+    times = out['time'].values
+    assert len(times) == 2 * NOWCAST_H
+    assert times.max() == CYCLE_2
+    assert (out['zeta'].values[:, 0] % 1000 < NOWCAST_H).all()
+    assert times.min() == CYCLE_1 - np.timedelta64(NOWCAST_H - 1, 'h')
+
+
+def test_tiny_dataset_passthrough():
+    """A degenerate single-timestep dataset passes through unchanged."""
+    ds = _dataset([(np.array([CYCLE_1]), np.array([1000.0]))])
+    out = fix_schism_points_dataset(_prop('nowcast'), ds, _logger())
+    assert len(out['time']) == 1

--- a/tests/stofs_stations_model_depths_test.py
+++ b/tests/stofs_stations_model_depths_test.py
@@ -1,0 +1,255 @@
+"""
+Regression tests for STOFS-3D stations model depth indexing (issue: model
+ctl-file creation for temp/salt/currents crashed with UnboundLocalError).
+
+The STOFS-3D points (stations) files are surface-only: ``temperature``
+and ``salinity`` are sampled at the water surface and ``u``/``v`` are
+surface velocities, all on ``(time, station)`` with no vertical
+coordinate. The SCHISM stations branch of ``index_nearest_depth`` only
+knew ``loofs2`` and ``secofs``, so for ``stofs_3d_atl``/``stofs_3d_pac``
+the local ``model_depths`` was never assigned and the first use raised
+``UnboundLocalError`` — killing model ctl-file creation for every
+variable except water level (which exits early).
+
+These tests cover:
+- the surface-only STOFS-3D branch for temp/salt/cu (layer 0, depth 0.0);
+- non-regression for the loofs2 and secofs depth-array shapes;
+- the explicit NotImplementedError for unknown SCHISM OFS (instead of
+  an UnboundLocalError from a silent fall-through);
+- end-to-end ctl-file creation through ``write_ofs_ctlfile`` with a
+  synthetic dataset shaped like the real STOFS-3D-Atl points file.
+"""
+from __future__ import annotations
+
+import logging
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+import xarray as xr
+
+from ofs_skill.model_processing.indexing import index_nearest_depth
+from ofs_skill.model_processing.write_ofs_ctlfile import write_ofs_ctlfile
+
+LOGGER = logging.getLogger('stofs_stations_model_depths_test')
+
+
+def _stations_prop(ofs: str) -> SimpleNamespace:
+    """Minimal prop object for the stations branch of index_nearest_depth."""
+    return SimpleNamespace(ofs=ofs, ofsfiletype='stations')
+
+
+def _stofs_points_like(n_time: int = 4, n_station: int = 3) -> dict:
+    """Synthetic mapping shaped like the STOFS-3D points file variables.
+
+    Mirrors the real ``stofs_3d_atl.tXXz.points.cwl.temp.salt.vel.nc``
+    layout: every variable is 2-D ``(time, station)``; there is no
+    vertical coordinate (no zCoordinates/zcor/zcoords).
+    """
+    shape = (n_time, n_station)
+    return {
+        'zeta': np.zeros(shape),
+        'temperature': np.full(shape, 20.0),
+        'salinity': np.full(shape, 30.0),
+        'u': np.full(shape, 0.1),
+        'v': np.full(shape, -0.1),
+        'x': np.array([-66.983, -70.244, -71.05])[:n_station],
+        'y': np.array([44.905, 43.658, 42.35])[:n_station],
+    }
+
+
+# Coord rows as parsed from an obs station ctl file: [lat, lon, ?, depth, ...]
+_OBS_ROWS = [
+    ['44.905', '-66.983', '0.0', '0.00', '0.0'],
+    ['43.658', '-70.244', '0.0', '4.50', '0.0'],
+    ['42.350', '-71.050', '0.0', '2.00', '0.0'],
+]
+
+
+@pytest.mark.parametrize('ofs', ['stofs_3d_atl', 'stofs_3d_pac'])
+@pytest.mark.parametrize('name_var', ['temp', 'salt', 'cu'])
+def test_stofs_3d_stations_surface_only_depths(ofs, name_var):
+    """STOFS-3D stations files are surface-only: every matched station
+    gets layer 0 / depth 0.0, unmatched stations get NaN — and no
+    UnboundLocalError."""
+    prop = _stations_prop(ofs)
+    index_min_dist = [0, 2, np.nan]
+
+    index_min_depth, depth_value = index_nearest_depth(
+        prop, index_min_dist, _stofs_points_like(), _OBS_ROWS,
+        'schism', name_var, ofs, LOGGER,
+    )
+
+    assert index_min_depth[0] == 0
+    assert index_min_depth[1] == 0
+    assert np.isnan(index_min_depth[2])
+    assert depth_value[0] == 0.0
+    assert depth_value[1] == 0.0
+    assert np.isnan(depth_value[2])
+    assert len(index_min_depth) == len(index_min_dist)
+    assert len(depth_value) == len(index_min_dist)
+
+
+def test_stofs_3d_stations_wl_unchanged():
+    """Water level keeps its existing surface handling."""
+    prop = _stations_prop('stofs_3d_atl')
+    index_min_depth, depth_value = index_nearest_depth(
+        prop, [0, 1], _stofs_points_like(), _OBS_ROWS,
+        'schism', 'wl', 'stofs_3d_atl', LOGGER,
+    )
+    assert index_min_depth == [0, 0]
+    assert list(depth_value) == [0.0, 0.0]
+
+
+def test_loofs2_stations_depth_selection_nonregression():
+    """loofs2 keeps its zcoords (node, depth) nearest-depth lookup."""
+    prop = _stations_prop('loofs2')
+    # 3 nodes x 4 depth levels, model depths negative (SCHISM convention)
+    zcoords = np.tile(np.array([-0.5, -2.0, -5.0, -10.0]), (3, 1))
+    model = {'zcoords': zcoords}
+    obs_rows = [['43.658', '-70.244', '0.0', '4.50', '0.0']]
+
+    index_min_depth, depth_value = index_nearest_depth(
+        prop, [1], model, obs_rows, 'schism', 'temp', 'loofs2', LOGGER,
+    )
+
+    # obs depth 4.5 m -> nearest model level is -5.0 m (index 2)
+    assert index_min_depth == [2]
+    assert depth_value[0] == pytest.approx(5.0)
+
+
+def test_secofs_stations_depth_selection_nonregression():
+    """secofs keeps its zCoordinates (time, depth, node) lookup."""
+    prop = _stations_prop('secofs')
+    # 1 time x 4 depth levels x 3 nodes
+    z = np.tile(np.array([-0.5, -2.0, -5.0, -10.0])[:, None], (1, 1, 3))
+    model = {'zCoordinates': z}
+    obs_rows = [['43.658', '-70.244', '0.0', '4.50', '0.0']]
+
+    index_min_depth, depth_value = index_nearest_depth(
+        prop, [1], model, obs_rows, 'schism', 'temp', 'secofs', LOGGER,
+    )
+
+    assert index_min_depth == [2]
+    assert depth_value[0] == pytest.approx(5.0)
+
+
+def test_secofs_stations_missing_depth_surface_fallback():
+    """secofs without zCoordinates falls back to the surface layer."""
+    prop = _stations_prop('secofs')
+    # salinity (time, depth, station): surface layer index = shape[1] - 1
+    model = {'salinity': np.zeros((5, 4, 3))}
+    obs_rows = _OBS_ROWS[:2]
+
+    index_min_depth, depth_value = index_nearest_depth(
+        prop, [0, 1], model, obs_rows, 'schism', 'salt', 'secofs', LOGGER,
+    )
+
+    assert index_min_depth == [3, 3]
+    assert list(depth_value) == [0.0, 0.0]
+
+
+def test_unknown_schism_ofs_raises_not_implemented():
+    """A SCHISM OFS without wired-in depth handling must fail loudly,
+    not with an UnboundLocalError from a silent fall-through."""
+    prop = _stations_prop('futureofs')
+    with pytest.raises(NotImplementedError, match='futureofs'):
+        index_nearest_depth(
+            prop, [0], _stofs_points_like(), _OBS_ROWS[:1],
+            'schism', 'temp', 'futureofs', LOGGER,
+        )
+
+
+# ---------------------------------------------------------------------------
+# End-to-end ctl-file creation through write_ofs_ctlfile
+# ---------------------------------------------------------------------------
+
+_STATION_NAMES = [
+    'PSBM1 SOUS41 8410140 ME Eastport',
+    'CASM1 SOUS41 8418150 ME Portland',
+    'BHBM3 SOUS41 8443970 MA Boston',
+]
+
+
+def _stofs_points_dataset() -> xr.Dataset:
+    """Synthetic xarray Dataset shaped like the STOFS-3D-Atl points file."""
+    n_time, n_station = 4, 3
+    shape = (n_time, n_station)
+    return xr.Dataset(
+        {
+            'zeta': (('time', 'station'), np.zeros(shape)),
+            'temperature': (('time', 'station'), np.full(shape, 20.0)),
+            'salinity': (('time', 'station'), np.full(shape, 30.0)),
+            'u': (('time', 'station'), np.full(shape, 0.1)),
+            'v': (('time', 'station'), np.full(shape, -0.1)),
+            'station_name': (('station',), np.array(_STATION_NAMES)),
+            'x': (('station',), np.array([-66.983, -70.244, -71.05])),
+            'y': (('station',), np.array([44.905, 43.658, 42.35])),
+        },
+        coords={'time': np.arange(n_time)},
+    )
+
+
+def _write_obs_ctl(path, name_var):
+    """Write a minimal obs station ctl file (two lines per station)."""
+    rows = [
+        ('8410140', 'Eastport', '44.905', '-66.983', '0.00'),
+        ('8418150', 'Portland', '43.658', '-70.244', '4.50'),
+        # Not present in the model station names -> should be skipped
+        ('9999999', 'Nowhere', '10.000', '-60.000', '0.00'),
+    ]
+    with open(path, 'w', encoding='utf-8') as fh:
+        for sid, name, lat, lon, depth in rows:
+            fh.write(f'{sid} {sid}_{name_var}_stofs_3d_atl_CO-OPS "{name}"\n')
+            fh.write(f'  {lat} {lon} 0.0  {depth}  0.0\n')
+
+
+@pytest.mark.parametrize('variable, name_var', [
+    ('water_temperature', 'temp'),
+    ('salinity', 'salt'),
+    ('currents', 'cu'),
+])
+def test_write_ofs_ctlfile_stofs_stations(tmp_path, variable, name_var):
+    """Model ctl files for temp/salt/cu are created for STOFS-3D stations
+    with the standard 6-column layout, layer 0 and depth 0.0."""
+    ctl_dir = tmp_path / 'control_files'
+    ctl_dir.mkdir()
+    _write_obs_ctl(ctl_dir / f'stofs_3d_atl_{name_var}_station.ctl', name_var)
+
+    conf = tmp_path / 'ofs_dps.conf'
+    conf.write_text(
+        '[directories]\n'
+        f'model_historical_dir={tmp_path.as_posix()}\n'
+        'netcdf_dir=netcdf\n',
+        encoding='utf-8',
+    )
+
+    prop = SimpleNamespace(
+        ofs='stofs_3d_atl',
+        ofsfiletype='stations',
+        model_source='schism',
+        var_list=[variable],
+        user_input_location=False,
+        control_files_path=str(ctl_dir),
+        config_file=str(conf),
+    )
+
+    write_ofs_ctlfile(prop, _stofs_points_dataset(), LOGGER)
+
+    out = ctl_dir / f'stofs_3d_atl_{name_var}_model_station.ctl'
+    assert out.is_file(), 'model ctl file was not created'
+    lines = out.read_text(encoding='utf-8').splitlines()
+    # Two of the three obs stations match model station names
+    assert len(lines) == 2
+    for line, (sid, lat, lon) in zip(
+            lines,
+            [('8410140', '44.905', '-66.983'),
+             ('8418150', '43.658', '-70.244')]):
+        cols = line.split()
+        # node layer lat lon station_id depth
+        assert len(cols) == 6
+        assert cols[1] == '0'
+        assert cols[2] == lat
+        assert cols[3] == lon
+        assert cols[4] == sid
+        assert cols[5] == '0.0'

--- a/tests/stofs_stations_nodd_test.py
+++ b/tests/stofs_stations_nodd_test.py
@@ -64,6 +64,12 @@ class MockProps:  # pylint: disable=too-few-public-methods
         self.end_date_full = '20250702-00:00:00'
 
 
+def _fake_urlretrieve(_url, dst):
+    """Stand-in for urlretrieve: writes bytes to the destination path."""
+    with open(dst, 'wb') as fil:
+        fil.write(b'data')
+
+
 def write_conf(tmp_path, netcdf_dir):
     """Write a minimal config with the given netcdf_dir and return its path."""
     conf = configparser.ConfigParser()
@@ -161,7 +167,8 @@ def test_download_single_file_local_path_restores_netcdf_dir(tmp_path):
     savepath = f'{tmp_path.as_posix()}/'
     target_dir = tmp_path / 'stofs_3d_atl' / 'netcdf' / 'stofs_3d_atl.20250701'
     target_dir.mkdir(parents=True)
-    with patch('bin.utils.get_model_data.urllib.request.urlretrieve') as mock_get:
+    with patch('bin.utils.get_model_data.urllib.request.urlretrieve',
+               side_effect=_fake_urlretrieve) as mock_get:
         # pylint: disable-next=protected-access
         local_path = get_model_data._download_single_file(
             url, savepath, logger,
@@ -171,7 +178,8 @@ def test_download_single_file_local_path_restores_netcdf_dir(tmp_path):
         f'{tmp_path.as_posix()}/stofs_3d_atl/netcdf/stofs_3d_atl.20250701/'
         'stofs_3d_atl.t12z.points.cwl.temp.salt.vel.nc'
     )
-    mock_get.assert_called_once_with(url, local_path)
+    # Downloads go to a temporary .part name and are promoted on success
+    mock_get.assert_called_once_with(url, f'{local_path}.part')
 
 
 def test_download_single_file_savepath_with_bucket_prefix(tmp_path):
@@ -183,7 +191,8 @@ def test_download_single_file_savepath_with_bucket_prefix(tmp_path):
     savepath = f'{base.as_posix()}/'
     target_dir = base / 'stofs_3d_atl' / 'netcdf' / 'stofs_3d_atl.20250701'
     target_dir.mkdir(parents=True)
-    with patch('bin.utils.get_model_data.urllib.request.urlretrieve') as mock_get:
+    with patch('bin.utils.get_model_data.urllib.request.urlretrieve',
+               side_effect=_fake_urlretrieve) as mock_get:
         # pylint: disable-next=protected-access
         local_path = get_model_data._download_single_file(
             url, savepath, logger,
@@ -193,7 +202,8 @@ def test_download_single_file_savepath_with_bucket_prefix(tmp_path):
         f'{base.as_posix()}/stofs_3d_atl/netcdf/stofs_3d_atl.20250701/'
         'stofs_3d_atl.t12z.points.cwl.temp.salt.vel.nc'
     )
-    mock_get.assert_called_once_with(url, local_path)
+    # Downloads go to a temporary .part name and are promoted on success
+    mock_get.assert_called_once_with(url, f'{local_path}.part')
 
 
 # ---------------------------------------------------------------------------

--- a/tests/stofs_stations_nodd_test.py
+++ b/tests/stofs_stations_nodd_test.py
@@ -22,11 +22,18 @@ from unittest.mock import patch
 
 import pytest
 
+import importlib
+
 from bin.utils import get_model_data
 from ofs_skill.model_processing.list_of_files import (
     construct_s3_url,
     get_nodd_prefix_map,
 )
+
+# The package __init__ re-exports a function named list_of_files that
+# shadows the submodule attribute, so resolve the module via importlib.
+list_of_files_module = importlib.import_module(
+    'ofs_skill.model_processing.list_of_files')
 
 
 class MockLogger:
@@ -90,11 +97,15 @@ def write_conf(tmp_path, netcdf_dir):
 
 
 def build_urls(tmp_path, ofs, whichcast, netcdf_dir):
-    """Run the list_of_dir -> make_file_list -> list_of_urls chain."""
+    """Run the list_of_dir -> make_file_list -> list_of_urls chain.
+
+    netcdf_dir only lands in the config file: the setting is retired,
+    so the layout (and every URL) must come out identical regardless.
+    """
     logger = MockLogger()
     prop = MockProps(ofs=ofs, whichcast=whichcast,
                      config_file=write_conf(tmp_path, netcdf_dir))
-    nodd_path = ofs if not netcdf_dir else f'{ofs}/{netcdf_dir}'
+    nodd_path = f'{ofs}/netcdf'
     dir_list, dates = get_model_data.list_of_dir(prop, nodd_path, logger)
     file_list = get_model_data.make_file_list(prop, dates, dir_list, logger)
     return get_model_data.list_of_urls(file_list, prop, logger)
@@ -121,7 +132,8 @@ def test_make_file_list_stofs3d_stations_points_name(tmp_path, whichcast):
 
 @pytest.mark.parametrize('netcdf_dir', ['netcdf', '', 'model_output'])
 def test_list_of_urls_stofs3d_bucket_layout(tmp_path, netcdf_dir):
-    """STOFS-3D URLs use the STOFS-3D-Atl/ prefix with no netcdf/ level."""
+    """STOFS-3D URLs use the STOFS-3D-Atl/ prefix with no netcdf/ level,
+    whatever value the retired netcdf_dir setting holds in the config."""
     urls = build_urls(tmp_path, 'stofs_3d_atl', 'nowcast', netcdf_dir)
     for url in urls:
         assert url.startswith((
@@ -137,7 +149,8 @@ def test_list_of_urls_stofs3d_bucket_layout(tmp_path, netcdf_dir):
 
 @pytest.mark.parametrize('netcdf_dir', ['netcdf', '', 'model_output'])
 def test_list_of_urls_stofs2d_bucket_layout(tmp_path, netcdf_dir):
-    """STOFS-2D-Global URLs have date directories at the bucket root."""
+    """STOFS-2D-Global URLs have date directories at the bucket root,
+    whatever value the retired netcdf_dir setting holds in the config."""
     urls = build_urls(tmp_path, 'stofs_2d_glo', 'nowcast', netcdf_dir)
     for url in urls:
         assert url.startswith(
@@ -207,37 +220,46 @@ def test_download_single_file_savepath_with_bucket_prefix(tmp_path):
 
 
 # ---------------------------------------------------------------------------
-# get_nodd_prefix_map: prefix pairs and netcdf_dir validation
+# get_nodd_prefix_map: fixed prefix pairs; netcdf_dir setting is retired
 # ---------------------------------------------------------------------------
 
 @pytest.mark.parametrize('ofs,netcdf_dir,expected', [
     ('stofs_3d_atl', 'netcdf', ('stofs_3d_atl/netcdf/', 'STOFS-3D-Atl/')),
-    ('stofs_3d_atl', '', ('stofs_3d_atl/', 'STOFS-3D-Atl/')),
+    ('stofs_3d_atl', '', ('stofs_3d_atl/netcdf/', 'STOFS-3D-Atl/')),
     ('stofs_3d_pac', 'netcdf', ('stofs_3d_pac/netcdf/', 'STOFS-3D-Pac/')),
     ('stofs_2d_glo', 'netcdf', ('stofs_2d_glo/netcdf/', '')),
     ('cbofs', 'netcdf', ('cbofs/netcdf/', 'cbofs/netcdf/')),
+    ('cbofs', '', ('cbofs/netcdf/', 'cbofs/netcdf/')),
+    ('cbofs', 'model_output', ('cbofs/netcdf/', 'cbofs/netcdf/')),
 ])
 def test_get_nodd_prefix_map_pairs(tmp_path, ofs, netcdf_dir, expected):
-    """Prefix pairs reflect the configured netcdf_dir and the OFS bucket."""
+    """Prefix pairs are fixed per OFS; the config value never matters."""
     logger = MockLogger()
     prop = MockProps(ofs=ofs, config_file=write_conf(tmp_path, netcdf_dir))
     assert get_nodd_prefix_map(prop, logger) == expected
 
 
-@pytest.mark.parametrize('bad_dir', [
-    '/absolute/path',
-    '..',
-    '../up',
-    'a/../b',
-    '..\\up',
-    'C:/absolute',
+@pytest.mark.parametrize('legacy_value,expect_level', [
+    ('netcdf', 'info'),
+    ('', 'warning'),
+    ('model_output', 'warning'),
+    ('/absolute/path', 'warning'),
 ])
-def test_get_nodd_prefix_map_rejects_unsafe_netcdf_dir(tmp_path, bad_dir):
-    """Absolute or parent-traversing netcdf_dir values raise ValueError."""
+def test_retired_netcdf_dir_notice(tmp_path, monkeypatch,
+                                   legacy_value, expect_level):
+    """A config that still carries netcdf_dir gets a one-time notice."""
+    monkeypatch.setattr(list_of_files_module, '_NETCDF_DIR_NOTICE_DONE',
+                        False)
     logger = MockLogger()
-    prop = MockProps(config_file=write_conf(tmp_path, bad_dir))
-    with pytest.raises(ValueError, match='netcdf_dir'):
-        get_nodd_prefix_map(prop, logger)
+    prop = MockProps(config_file=write_conf(tmp_path, legacy_value))
+    get_nodd_prefix_map(prop, logger)
+    logged = logger.warnings if expect_level == 'warning' else logger.infos
+    assert any('netcdf_dir' in msg and 'deprecated' in msg
+               for msg in logged)
+    # One-time only: a second call must not repeat the notice
+    count = len(logged)
+    get_nodd_prefix_map(prop, logger)
+    assert len(logged) == count
 
 
 # ---------------------------------------------------------------------------
@@ -277,21 +299,29 @@ def test_construct_s3_url_bucket_paths(tmp_path, ofs, local, expected):
     assert url == expected
 
 
-@pytest.mark.parametrize('netcdf_dir,subdir', [
-    ('model_output', 'model_output/'),
-    ('', ''),
+@pytest.mark.parametrize('ofs,local,expected', [
+    (
+        # Legacy layout (retired blank netcdf_dir): no netcdf/ level on disk
+        'stofs_3d_atl',
+        './example_data/stofs_3d_atl/stofs_3d_atl.20250701/'
+        'stofs_3d_atl.t12z.points.cwl.temp.salt.vel.nc',
+        'https://noaa-nos-stofs3d-pds.s3.amazonaws.com/STOFS-3D-Atl/'
+        'stofs_3d_atl.20250701/stofs_3d_atl.t12z.points.cwl.temp.salt.vel.nc',
+    ),
+    (
+        # Non-STOFS legacy layout must gain the bucket's netcdf/ level
+        'cbofs',
+        './example_data/cbofs/2025/07/01/'
+        'cbofs.t00z.20250701.stations.nowcast.nc',
+        'https://noaa-nos-ofs-pds.s3.amazonaws.com/cbofs/netcdf/2025/07/01/'
+        'cbofs.t00z.20250701.stations.nowcast.nc',
+    ),
 ])
-def test_construct_s3_url_custom_netcdf_dir(tmp_path, netcdf_dir, subdir):
-    """A non-default (or blank) netcdf_dir is stripped from STOFS paths."""
+def test_construct_s3_url_legacy_local_layout(tmp_path, ofs, local, expected):
+    """Legacy-layout local paths (no netcdf/ level) map to correct URLs."""
     logger = MockLogger()
-    prop = MockProps(ofs='stofs_3d_atl',
-                     config_file=write_conf(tmp_path, netcdf_dir))
-    local = (f'./example_data/stofs_3d_atl/{subdir}stofs_3d_atl.20250701/'
-             'stofs_3d_atl.t12z.points.cwl.temp.salt.vel.nc')
+    prop = MockProps(ofs=ofs, config_file=write_conf(tmp_path, ''))
     with patch('ofs_skill.model_processing.list_of_files.check_s3_for_file',
                return_value=True):
         url = construct_s3_url(local, prop, logger)
-    assert url == (
-        'https://noaa-nos-stofs3d-pds.s3.amazonaws.com/STOFS-3D-Atl/'
-        'stofs_3d_atl.20250701/stofs_3d_atl.t12z.points.cwl.temp.salt.vel.nc'
-    )
+    assert url == expected

--- a/tests/stofs_stations_nodd_test.py
+++ b/tests/stofs_stations_nodd_test.py
@@ -23,7 +23,10 @@ from unittest.mock import patch
 import pytest
 
 from bin.utils import get_model_data
-from ofs_skill.model_processing.list_of_files import construct_s3_url
+from ofs_skill.model_processing.list_of_files import (
+    construct_s3_url,
+    get_nodd_prefix_map,
+)
 
 
 class MockLogger:
@@ -110,20 +113,23 @@ def test_make_file_list_stofs3d_stations_points_name(tmp_path, whichcast):
 # list_of_urls: no netcdf/ level on STOFS buckets, bucket prefix swapped
 # ---------------------------------------------------------------------------
 
-@pytest.mark.parametrize('netcdf_dir', ['netcdf', ''])
+@pytest.mark.parametrize('netcdf_dir', ['netcdf', '', 'model_output'])
 def test_list_of_urls_stofs3d_bucket_layout(tmp_path, netcdf_dir):
     """STOFS-3D URLs use the STOFS-3D-Atl/ prefix with no netcdf/ level."""
     urls = build_urls(tmp_path, 'stofs_3d_atl', 'nowcast', netcdf_dir)
     for url in urls:
-        assert url.startswith(
+        assert url.startswith((
             'https://noaa-nos-stofs3d-pds.s3.amazonaws.com/STOFS-3D-Atl/'
-            'stofs_3d_atl.202507') or url.startswith(
+            'stofs_3d_atl.202507',
             'https://noaa-nos-stofs3d-pds.s3.amazonaws.com/STOFS-3D-Atl/'
-            'stofs_3d_atl.202506')
+            'stofs_3d_atl.202506',
+        ))
         assert '/netcdf/' not in url
+        if netcdf_dir:
+            assert f'/{netcdf_dir}/' not in url
 
 
-@pytest.mark.parametrize('netcdf_dir', ['netcdf', ''])
+@pytest.mark.parametrize('netcdf_dir', ['netcdf', '', 'model_output'])
 def test_list_of_urls_stofs2d_bucket_layout(tmp_path, netcdf_dir):
     """STOFS-2D-Global URLs have date directories at the bucket root."""
     urls = build_urls(tmp_path, 'stofs_2d_glo', 'nowcast', netcdf_dir)
@@ -131,6 +137,8 @@ def test_list_of_urls_stofs2d_bucket_layout(tmp_path, netcdf_dir):
         assert url.startswith(
             'https://noaa-gestofs-pds.s3.amazonaws.com/stofs_2d_glo.202')
         assert '/netcdf/' not in url
+        if netcdf_dir:
+            assert f'/{netcdf_dir}/' not in url
 
 
 def test_list_of_urls_non_stofs_unchanged(tmp_path):
@@ -156,15 +164,70 @@ def test_download_single_file_local_path_restores_netcdf_dir(tmp_path):
     with patch('bin.utils.get_model_data.urllib.request.urlretrieve') as mock_get:
         # pylint: disable-next=protected-access
         local_path = get_model_data._download_single_file(
-            url, savepath, 'stofs_3d_atl', logger,
-            bucket_prefix='STOFS-3D-Atl/',
-            local_prefix='stofs_3d_atl/netcdf/',
+            url, savepath, logger,
+            prefix_map=('stofs_3d_atl/netcdf/', 'STOFS-3D-Atl/'),
         )
     assert local_path == (
         f'{tmp_path.as_posix()}/stofs_3d_atl/netcdf/stofs_3d_atl.20250701/'
         'stofs_3d_atl.t12z.points.cwl.temp.salt.vel.nc'
     )
     mock_get.assert_called_once_with(url, local_path)
+
+
+def test_download_single_file_savepath_with_bucket_prefix(tmp_path):
+    """A savepath that itself contains 'STOFS-3D-Atl/' is never rewritten."""
+    logger = MockLogger()
+    url = ('https://noaa-nos-stofs3d-pds.s3.amazonaws.com/STOFS-3D-Atl/'
+           'stofs_3d_atl.20250701/stofs_3d_atl.t12z.points.cwl.temp.salt.vel.nc')
+    base = tmp_path / 'STOFS-3D-Atl' / 'data'
+    savepath = f'{base.as_posix()}/'
+    target_dir = base / 'stofs_3d_atl' / 'netcdf' / 'stofs_3d_atl.20250701'
+    target_dir.mkdir(parents=True)
+    with patch('bin.utils.get_model_data.urllib.request.urlretrieve') as mock_get:
+        # pylint: disable-next=protected-access
+        local_path = get_model_data._download_single_file(
+            url, savepath, logger,
+            prefix_map=('stofs_3d_atl/netcdf/', 'STOFS-3D-Atl/'),
+        )
+    assert local_path == (
+        f'{base.as_posix()}/stofs_3d_atl/netcdf/stofs_3d_atl.20250701/'
+        'stofs_3d_atl.t12z.points.cwl.temp.salt.vel.nc'
+    )
+    mock_get.assert_called_once_with(url, local_path)
+
+
+# ---------------------------------------------------------------------------
+# get_nodd_prefix_map: prefix pairs and netcdf_dir validation
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize('ofs,netcdf_dir,expected', [
+    ('stofs_3d_atl', 'netcdf', ('stofs_3d_atl/netcdf/', 'STOFS-3D-Atl/')),
+    ('stofs_3d_atl', '', ('stofs_3d_atl/', 'STOFS-3D-Atl/')),
+    ('stofs_3d_pac', 'netcdf', ('stofs_3d_pac/netcdf/', 'STOFS-3D-Pac/')),
+    ('stofs_2d_glo', 'netcdf', ('stofs_2d_glo/netcdf/', '')),
+    ('cbofs', 'netcdf', ('cbofs/netcdf/', 'cbofs/netcdf/')),
+])
+def test_get_nodd_prefix_map_pairs(tmp_path, ofs, netcdf_dir, expected):
+    """Prefix pairs reflect the configured netcdf_dir and the OFS bucket."""
+    logger = MockLogger()
+    prop = MockProps(ofs=ofs, config_file=write_conf(tmp_path, netcdf_dir))
+    assert get_nodd_prefix_map(prop, logger) == expected
+
+
+@pytest.mark.parametrize('bad_dir', [
+    '/absolute/path',
+    '..',
+    '../up',
+    'a/../b',
+    '..\\up',
+    'C:/absolute',
+])
+def test_get_nodd_prefix_map_rejects_unsafe_netcdf_dir(tmp_path, bad_dir):
+    """Absolute or parent-traversing netcdf_dir values raise ValueError."""
+    logger = MockLogger()
+    prop = MockProps(config_file=write_conf(tmp_path, bad_dir))
+    with pytest.raises(ValueError, match='netcdf_dir'):
+        get_nodd_prefix_map(prop, logger)
 
 
 # ---------------------------------------------------------------------------
@@ -202,3 +265,23 @@ def test_construct_s3_url_bucket_paths(tmp_path, ofs, local, expected):
                return_value=True):
         url = construct_s3_url(local, prop, logger)
     assert url == expected
+
+
+@pytest.mark.parametrize('netcdf_dir,subdir', [
+    ('model_output', 'model_output/'),
+    ('', ''),
+])
+def test_construct_s3_url_custom_netcdf_dir(tmp_path, netcdf_dir, subdir):
+    """A non-default (or blank) netcdf_dir is stripped from STOFS paths."""
+    logger = MockLogger()
+    prop = MockProps(ofs='stofs_3d_atl',
+                     config_file=write_conf(tmp_path, netcdf_dir))
+    local = (f'./example_data/stofs_3d_atl/{subdir}stofs_3d_atl.20250701/'
+             'stofs_3d_atl.t12z.points.cwl.temp.salt.vel.nc')
+    with patch('ofs_skill.model_processing.list_of_files.check_s3_for_file',
+               return_value=True):
+        url = construct_s3_url(local, prop, logger)
+    assert url == (
+        'https://noaa-nos-stofs3d-pds.s3.amazonaws.com/STOFS-3D-Atl/'
+        'stofs_3d_atl.20250701/stofs_3d_atl.t12z.points.cwl.temp.salt.vel.nc'
+    )

--- a/tests/stofs_stations_nodd_test.py
+++ b/tests/stofs_stations_nodd_test.py
@@ -1,0 +1,204 @@
+"""
+Unit tests for STOFS station-file download paths on the NODD (issue #205).
+
+Regression protection for two defects that made STOFS station downloads
+return HTTP 404 from the NODD S3 buckets:
+
+1. `make_file_list()` in `bin/utils/get_model_data.py` had no
+   stofs_3d_atl/stofs_3d_pac stations branch, so it built NOS-OFS-style
+   names (e.g. `stofs_3d_atl.t12z.20250630.stations.nowcast.nc`) that do
+   not exist on the bucket. The station product is a single points file
+   per cycle: `{ofs}.t{cycle}z.points.cwl.temp.salt.vel.nc`.
+
+2. URL builders kept the local `netcdf/` subdirectory in bucket paths,
+   but the STOFS buckets have no `netcdf/` level. With the shipped
+   default `netcdf_dir=netcdf`, every STOFS URL 404'd. Affected both
+   `list_of_urls()` (get_model_data.py) and `construct_s3_url()`
+   (list_of_files.py).
+"""
+
+import configparser
+from unittest.mock import patch
+
+import pytest
+
+from bin.utils import get_model_data
+from ofs_skill.model_processing.list_of_files import construct_s3_url
+
+
+class MockLogger:
+    """Collects log messages so tests can assert on them."""
+
+    def __init__(self):
+        self.infos = []
+        self.warnings = []
+        self.errors = []
+
+    def info(self, msg, *args, **_kwargs):
+        """Record an info message."""
+        self.infos.append(msg % args if args else msg)
+
+    def warning(self, msg, *args, **_kwargs):
+        """Record a warning message."""
+        self.warnings.append(msg % args if args else msg)
+
+    def error(self, msg, *args, **_kwargs):
+        """Record an error message."""
+        self.errors.append(msg % args if args else msg)
+
+
+class MockProps:  # pylint: disable=too-few-public-methods
+    """Minimal ModelProperties stand-in for get_model_data functions."""
+
+    def __init__(self, ofs='stofs_3d_atl', whichcast='nowcast',
+                 ofsfiletype='stations', config_file=None):
+        self.ofs = ofs
+        self.whichcast = whichcast
+        self.ofsfiletype = ofsfiletype
+        self.config_file = config_file
+        self.model_path = ''
+        self.start_date_full = '20250701-00:00:00'
+        self.end_date_full = '20250702-00:00:00'
+
+
+def write_conf(tmp_path, netcdf_dir):
+    """Write a minimal config with the given netcdf_dir and return its path."""
+    conf = configparser.ConfigParser()
+    conf['directories'] = {
+        'home': str(tmp_path),
+        'netcdf_dir': netcdf_dir,
+        'model_historical_dir': str(tmp_path / 'example_data'),
+    }
+    conf['urls'] = {
+        'nodd_s3': 'https://noaa-nos-ofs-pds.s3.amazonaws.com/',
+        'nodd_s3_stofs3d': 'https://noaa-nos-stofs3d-pds.s3.amazonaws.com/',
+        'nodd_s3_stofs2d': 'https://noaa-gestofs-pds.s3.amazonaws.com/',
+    }
+    conf_path = tmp_path / 'ofs_dps.conf'
+    with open(conf_path, 'w', encoding='utf-8') as fil:
+        conf.write(fil)
+    return str(conf_path)
+
+
+def build_urls(tmp_path, ofs, whichcast, netcdf_dir):
+    """Run the list_of_dir -> make_file_list -> list_of_urls chain."""
+    logger = MockLogger()
+    prop = MockProps(ofs=ofs, whichcast=whichcast,
+                     config_file=write_conf(tmp_path, netcdf_dir))
+    nodd_path = ofs if not netcdf_dir else f'{ofs}/{netcdf_dir}'
+    dir_list, dates = get_model_data.list_of_dir(prop, nodd_path, logger)
+    file_list = get_model_data.make_file_list(prop, dates, dir_list, logger)
+    return get_model_data.list_of_urls(file_list, prop, logger)
+
+
+# ---------------------------------------------------------------------------
+# make_file_list: STOFS-3D stations must use the points file name
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize('whichcast', ['nowcast', 'forecast_b'])
+def test_make_file_list_stofs3d_stations_points_name(tmp_path, whichcast):
+    """STOFS-3D station file names must be the per-cycle points file."""
+    urls = build_urls(tmp_path, 'stofs_3d_atl', whichcast, 'netcdf')
+    assert urls, 'expected at least one URL'
+    for url in urls:
+        assert url.endswith('.points.cwl.temp.salt.vel.nc')
+        assert 'stations.nowcast' not in url
+        assert 'stations.forecast' not in url
+
+
+# ---------------------------------------------------------------------------
+# list_of_urls: no netcdf/ level on STOFS buckets, bucket prefix swapped
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize('netcdf_dir', ['netcdf', ''])
+def test_list_of_urls_stofs3d_bucket_layout(tmp_path, netcdf_dir):
+    """STOFS-3D URLs use the STOFS-3D-Atl/ prefix with no netcdf/ level."""
+    urls = build_urls(tmp_path, 'stofs_3d_atl', 'nowcast', netcdf_dir)
+    for url in urls:
+        assert url.startswith(
+            'https://noaa-nos-stofs3d-pds.s3.amazonaws.com/STOFS-3D-Atl/'
+            'stofs_3d_atl.202507') or url.startswith(
+            'https://noaa-nos-stofs3d-pds.s3.amazonaws.com/STOFS-3D-Atl/'
+            'stofs_3d_atl.202506')
+        assert '/netcdf/' not in url
+
+
+@pytest.mark.parametrize('netcdf_dir', ['netcdf', ''])
+def test_list_of_urls_stofs2d_bucket_layout(tmp_path, netcdf_dir):
+    """STOFS-2D-Global URLs have date directories at the bucket root."""
+    urls = build_urls(tmp_path, 'stofs_2d_glo', 'nowcast', netcdf_dir)
+    for url in urls:
+        assert url.startswith(
+            'https://noaa-gestofs-pds.s3.amazonaws.com/stofs_2d_glo.202')
+        assert '/netcdf/' not in url
+
+
+def test_list_of_urls_non_stofs_unchanged(tmp_path):
+    """Non-STOFS URLs keep the {ofs}/netcdf/ bucket layout."""
+    urls = build_urls(tmp_path, 'cbofs', 'nowcast', 'netcdf')
+    for url in urls:
+        assert url.startswith(
+            'https://noaa-nos-ofs-pds.s3.amazonaws.com/cbofs/netcdf/')
+
+
+# ---------------------------------------------------------------------------
+# _download_single_file: bucket prefix mapped back to the local layout
+# ---------------------------------------------------------------------------
+
+def test_download_single_file_local_path_restores_netcdf_dir(tmp_path):
+    """Downloads land in the local {ofs}/{netcdf_dir}/ layout."""
+    logger = MockLogger()
+    url = ('https://noaa-nos-stofs3d-pds.s3.amazonaws.com/STOFS-3D-Atl/'
+           'stofs_3d_atl.20250701/stofs_3d_atl.t12z.points.cwl.temp.salt.vel.nc')
+    savepath = f'{tmp_path.as_posix()}/'
+    target_dir = tmp_path / 'stofs_3d_atl' / 'netcdf' / 'stofs_3d_atl.20250701'
+    target_dir.mkdir(parents=True)
+    with patch('bin.utils.get_model_data.urllib.request.urlretrieve') as mock_get:
+        # pylint: disable-next=protected-access
+        local_path = get_model_data._download_single_file(
+            url, savepath, 'stofs_3d_atl', logger,
+            bucket_prefix='STOFS-3D-Atl/',
+            local_prefix='stofs_3d_atl/netcdf/',
+        )
+    assert local_path == (
+        f'{tmp_path.as_posix()}/stofs_3d_atl/netcdf/stofs_3d_atl.20250701/'
+        'stofs_3d_atl.t12z.points.cwl.temp.salt.vel.nc'
+    )
+    mock_get.assert_called_once_with(url, local_path)
+
+
+# ---------------------------------------------------------------------------
+# construct_s3_url: netcdf/ stripped from STOFS bucket paths
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize('ofs,local,expected', [
+    (
+        'stofs_3d_atl',
+        './example_data/stofs_3d_atl/netcdf/stofs_3d_atl.20250701/'
+        'stofs_3d_atl.t12z.points.cwl.temp.salt.vel.nc',
+        'https://noaa-nos-stofs3d-pds.s3.amazonaws.com/STOFS-3D-Atl/'
+        'stofs_3d_atl.20250701/stofs_3d_atl.t12z.points.cwl.temp.salt.vel.nc',
+    ),
+    (
+        'stofs_2d_glo',
+        './example_data/stofs_2d_glo/netcdf/stofs_2d_glo.20250701/'
+        'stofs_2d_glo.t00z.points.cwl.nc',
+        'https://noaa-gestofs-pds.s3.amazonaws.com/stofs_2d_glo.20250701/'
+        'stofs_2d_glo.t00z.points.cwl.nc',
+    ),
+    (
+        'cbofs',
+        './example_data/cbofs/netcdf/2025/07/01/'
+        'cbofs.t00z.20250701.stations.nowcast.nc',
+        'https://noaa-nos-ofs-pds.s3.amazonaws.com/cbofs/netcdf/2025/07/01/'
+        'cbofs.t00z.20250701.stations.nowcast.nc',
+    ),
+])
+def test_construct_s3_url_bucket_paths(tmp_path, ofs, local, expected):
+    """construct_s3_url maps local paths to each bucket's layout."""
+    logger = MockLogger()
+    prop = MockProps(ofs=ofs, config_file=write_conf(tmp_path, 'netcdf'))
+    with patch('ofs_skill.model_processing.list_of_files.check_s3_for_file',
+               return_value=True):
+        url = construct_s3_url(local, prop, logger)
+    assert url == expected


### PR DESCRIPTION
### Description of Changes

Closes #213.

**Note: this branch is based on the PR #208 branch (`issue-205-stofs-stations-nodd`) and should merge after it — the diff shown here includes #208's commits until then.**

The reported symptom was the log announcing `NODD S3 is not responding! I'm out.` for what was actually an HTTP 404 caused by a blank `netcdf_dir=` in the config — the old STOFS workaround, which leaked into non-STOFS bucket URLs and removed their real `netcdf/` level. Two problems, both fixed here:

1. **The message**: the first-download probe caught every exception in one bucket and reported it as an outage — for a 404, a 403, a timeout, or a dropped connection alike.
2. **The trigger**: a config value could change NODD bucket URLs at all. The bucket layout is a fixed external fact; the local directory layout is internal plumbing that this package both writes and reads. A knob whose only observed uses were the default value and a workaround for a bug fixed in #208 was pure misconfiguration surface.

Rather than wording the failure better and keeping the footgun, this PR does both: honest failure classification, and retirement of the `netcdf_dir` setting entirely.

Labels: `bug`, `user experience`

### Summary of changes

**`netcdf_dir` retirement**
- The local model-file layout is always `{ofs}/netcdf/` (`NETCDF_SUBDIR` in `list_of_files.py`). All nine consumers (`get_model_data.py`, `list_of_files.py`, `check_model_files.py`, `get_node_ofs.py`, `write_ofs_ctlfile.py`, `process_schism_stations_cli.py`, `ofs_climatology.py`, `do_iceskill.py`, `create_2dplot.py`) now use it instead of reading `[directories] netcdf_dir`.
- `get_nodd_prefix_map()` no longer takes any config input, so no config value can influence a NODD URL. This also deletes the netcdf_dir path-traversal validation added in #208 — there is nothing left to validate.
- New `local_model_dir()` resolves the read-side directory with a fallback to the legacy no-subdirectory layout (what a blank `netcdf_dir` produced), so existing archives keep working without a re-download; an INFO line notes when the legacy layout is used. `construct_s3_url()` normalizes legacy-layout paths before bucket translation for the same reason.
- Configs that still carry the key get a one-time notice: INFO for the default value ("can be removed"), WARNING for anything else (the value is now ignored). The key is removed from `conf/ofs_dps.conf.example`; unknown keys are inert to `configparser`, so existing config files keep working with no coordinated update.
- Explicitly out of scope: support for externally-managed archives with arbitrary custom layouts. If that ever becomes a real need, it should be a read-only archive-path feature, not a subdir-renaming knob that also reshapes what the pipeline writes.

**Honest download-failure classification (`_log_download_failure()` in `get_model_data.py`)**
- HTTP 404 → logs the failing URL and states the NODD **is** reachable ("This is not a NODD outage"), with the likely causes (dates not available on the bucket, or a file-name/path-layout mismatch).
- Other HTTP statuses → reported as what the NODD responded with.
- Interrupted transfers (`ContentTooShortError`) → reported as interrupted, partial file discarded.
- Connection-level failures (`URLError`, timeouts) → keep the genuine unreachable/outage wording.
- Used by both the first-download probe (which previously printed the misleading line and a redundant `except (ValueError, HTTPError, Exception)`) and the per-file parallel download handler.

### Expected Outcome of Changes

- The exact misconfiguration from #213 (blank `netcdf_dir=`, non-STOFS OFS) now **downloads successfully** — verified live against the NODD with cbofs — and logs a deprecation warning explaining the setting is ignored.
- A genuine 404 (verified live by requesting dates beyond bucket availability) logs: `HTTP 404 Not Found for <url> -- the NODD is reachable, but no file exists at this URL. This is not a NODD outage. ...`
- STOFS downloads are unchanged (verified live: stofs_3d_atl stations, all four cycle files).
- A legacy-layout archive (`{ofs}/` with no `netcdf/` level) is read via the fallback with an INFO notice (verified with a real downloaded tree).
- No config file changes are required for any user; the `netcdf_dir=` blanking workaround is permanently obsolete.
- Full test suite: 921 passed, 1 skipped (net +9 vs the #208 branch: new `netcdf_dir_retirement_test.py` covering `local_model_dir` and the failure classification; the netcdf_dir validation tests are retired; prefix-map/URL tests now assert the config value is ignored).

### Developer Questions and Checklist

**Is this a high priority PR? If yes, why and is there a date by which it needs to be merged?**
Low-to-moderate: it removes a recurring user-troubleshooting trap (#213 is the second time the blank-netcdf_dir 404 was misread as a NODD outage) but changes no scientific results. Should merge after #208.

**Are there any changes needed to how the code should be run for operational runs? (Commands, flags, job timings, etc.)**
No. Existing commands and config files work unchanged. Configs may optionally drop the `netcdf_dir=` line; a one-time log notice says so.

**Does this update need to be deployed for operational runs?**
Not required; beneficial wherever operators read logs to diagnose download failures.

**Does this update require front end/web app changes? (If yes, provide documentation to Min)**
No.

**Does this impact code development work on adding SCHISM?**
No behavior change for SCHISM models; STOFS layouts are handled by the same `get_nodd_prefix_map()` as before.

**Does this impact code development work on adding ADCIRC?**
If ADCIRC buckets use another layout, `get_nodd_prefix_map()` remains the single place to add it — now with one less input to reason about.
