### PR TITLE
Fix currents 1D title/legend overlap for tall ADCP titles (#221)

### DIFF
--- a/src/ofs_skill/visualization/plotting_functions.py
+++ b/src/ofs_skill/visualization/plotting_functions.py
@@ -220,6 +220,26 @@ def get_title(
             f'{end_date}<b>'
 
 
+def count_title_lines(title: str) -> int:
+    """Return the number of visual lines an HTML plot title occupies.
+
+    Titles built by :func:`get_title` use ``<br>`` tags to break the
+    header, station, OFS/node, optional depth and ADCP-type lines, and
+    the date range onto separate rows. Currents (``cu``) titles can add
+    up to two extra rows (a depth line and an ADCP-type line) that
+    scalar titles never have, so a fixed top margin tuned for scalar
+    plots is too small and the title collides with the horizontal
+    legend (issue #221).
+
+    A title with N ``<br>`` separators spans N+1 lines. Empty inserts
+    (e.g. an omitted depth/ADCP line) never emit a ``<br>``, so this
+    count reflects the rows actually rendered.
+    """
+    if not title:
+        return 1
+    return title.count('<br>') + 1
+
+
 _COOPS_MDAPI_URL = 'https://api.tidesandcurrents.noaa.gov/mdapi/prod/'
 
 # Cache parsed model_station.ctl lookups keyed by file path so we read

--- a/src/ofs_skill/visualization/plotting_vector.py
+++ b/src/ofs_skill/visualization/plotting_vector.py
@@ -39,6 +39,7 @@ from plotly.subplots import make_subplots
 import ofs_skill.visualization.make_static_plots as make_static_plots
 from ofs_skill.visualization.make_static_plots import combine_obs_across_casts
 from ofs_skill.visualization.plotting_functions import (
+    count_title_lines,
     find_max_data_gap,
     get_error_range,
     get_markerstyles,
@@ -491,7 +492,20 @@ def oned_vector_plot1(
     # title at y=0.97 once it wraps. Track the whichcast count to grow
     # the top margin so the legend has somewhere to expand into. Same
     # dynamic-margin pattern as plotting_scalar_ice.py.
-    tmargin = 150 + 30 * max(0, len(prop.whichcasts) - 1)
+    #
+    # Issue #221: currents titles are taller than scalar titles — they
+    # can carry a depth line and an ADCP-type line (issue #141 work) on
+    # top of the header/station/OFS/date rows, for up to 6 rows. A
+    # margin tuned for the 4-row scalar title leaves the extra title
+    # rows overlapping the legend. Grow the margin by the actual title
+    # height and push the title anchor up so both fit.
+    title_text = get_title(prop, node, station_id, name_var, logger)
+    n_title_lines = count_title_lines(title_text)
+    # Scalar titles are ~4 lines; add 30 px of headroom per extra line.
+    title_extra = 30 * max(0, n_title_lines - 4)
+    tmargin = 150 + 30 * max(0, len(prop.whichcasts) - 1) + title_extra
+    title_y = 0.97 + 0.005 * max(0, n_title_lines - 4)
+
     # Figure Config
     fig.update_layout(
         # margin=dict(t=5),
@@ -553,9 +567,9 @@ def oned_vector_plot1(
             tickvals=[-X1*4, -X1*3, -X1*2, -X1, 0, X1, X1*2, X1*3, X1*4],
         ),
         title=dict(
-            text=get_title(prop, node, station_id, name_var, logger),
+            text=title_text,
             font=dict(size=14, color='black', family='Open Sans'),
-            y=0.97,  # new
+            y=title_y,  # grows with title height (issue #221)
             x=0.5, xanchor='center', yanchor='top',
         ),
         transition_ordering='traces first', dragmode='zoom',

--- a/src/ofs_skill/visualization/plotting_vector.py
+++ b/src/ofs_skill/visualization/plotting_vector.py
@@ -977,8 +977,22 @@ def oned_vector_plot2b(
 
     fig.update_traces(text=[f'{i:.1f}' for i in np.arange(0, 360, 22.5)])
 
-    figheight=(fig_info_data[0][0] * 0.9) * 600
+    totalrows = fig_info_data[0][0]
+    figheight=(totalrows * 0.9) * 600
     figwidth=fig_info_data[0][1] * 500
+
+    # Reserve a dedicated band below the plot area for the legend and the
+    # colorbar caption so neither overlaps the bottom row's compass ("S")
+    # labels. Sizing everything in paper coordinates relative to a fixed
+    # pixel bottom margin keeps the spacing consistent as the number of
+    # rows (whichcasts) changes.
+    bottom_margin_px = 90
+    # Paper-space offset of one bottom-margin height, used to place the
+    # caption and legend fully below the plotting area.
+    margin_frac = bottom_margin_px / figheight
+    caption_y = -margin_frac * 0.45
+    legend_y = -margin_frac * 0.9
+
     fig.update_layout(
         title=dict(
             text=get_title(prop, node, station_id, name_var, logger),
@@ -989,21 +1003,12 @@ def oned_vector_plot2b(
         # This determines the height of the plot based on # of rows
         height=figheight,
         width=figwidth, template='seaborn',
-        margin=dict(l=20, r=20, t=160, b=0), legend=dict(
+        margin=dict(l=20, r=20, t=160, b=bottom_margin_px), legend=dict(
             font=dict(size=14, color='black', family='Arial'),
             orientation='h',
-            yanchor='bottom',
-            y=-0.3 / fig_info_data[0][0], xanchor='center', x=0.5,
+            yanchor='top',
+            y=legend_y, xanchor='center', x=0.5,
             bgcolor='rgba(0,0,0,0)', ),
-    )
-
-    # Added extra annotation to explain colors and units
-    fig.add_annotation(
-        text='Current speed, meters per second',
-        xref='paper', yref='paper',
-        font=dict(size=12, color='black'),
-        x=0.31, y=-0.08,
-        showarrow=False,
     )
 
     polars = []
@@ -1036,12 +1041,30 @@ def oned_vector_plot2b(
     for polar_layout in polars:
         fig.update_layout(polar_layout)
 
-    # This is updating the subplot title
+    # This is updating the subplot title. Nudge each subplot title up a
+    # touch (in paper coords) so it clears the top compass labels
+    # (NNW/N/NNE) of the rose immediately below it — in the single-row
+    # layout the default anchor sat right on top of the NNW tick.
     for i in fig['layout']['annotations']:
         i['font'] = dict(size=16, color='black', family='Arial')
         i['yanchor'] = 'bottom'
         i['xanchor'] = 'left'
         i['x'] = i['x'] - 0.26 * (2 / fig_info_data[0][1])  # -0.26
+        i['y'] = i['y'] + 0.02
+
+    # Added extra annotation to explain colors and units. Added AFTER the
+    # subplot-title loop above so its anchor is not shifted by that loop;
+    # centered under the plot and pushed into the reserved bottom margin so
+    # it clears the bottom-row compass "S" labels (issue: caption overlapped
+    # the "S" of the lower-left Observations rose).
+    fig.add_annotation(
+        text='Current speed, meters per second',
+        xref='paper', yref='paper',
+        font=dict(size=12, color='black'),
+        x=0.5, y=caption_y,
+        xanchor='center', yanchor='top',
+        showarrow=False,
+    )
 
     naming_ws = '_'.join(prop.whichcasts)
     output_file = (

--- a/tests/title_lines_test.py
+++ b/tests/title_lines_test.py
@@ -1,0 +1,55 @@
+"""Tests for plotting_functions.count_title_lines.
+
+``count_title_lines`` sizes the dynamic top margin for the currents 1D
+time-series plot (issue #221). Currents titles carry an optional depth
+line and ADCP-type line on top of the scalar title rows, so the margin
+must grow with the actual number of ``<br>``-separated rows or the
+title overlaps the horizontal legend.
+"""
+import unittest
+
+from ofs_skill.visualization.plotting_functions import count_title_lines
+
+
+class TestCountTitleLines(unittest.TestCase):
+    """Verify the ``<br>``-based line counter used for margin sizing."""
+
+    def test_empty_title_is_one_line(self):
+        """An empty title still occupies a single visual row."""
+        self.assertEqual(count_title_lines(''), 1)
+
+    def test_no_break_is_one_line(self):
+        """A title with no ``<br>`` spans exactly one row."""
+        self.assertEqual(count_title_lines('<b>Only one line<b>'), 1)
+
+    def test_line_count_is_breaks_plus_one(self):
+        """N ``<br>`` separators render N+1 rows."""
+        self.assertEqual(count_title_lines('a<br>b<br>c'), 3)
+
+    def test_scalar_title_four_lines(self):
+        """A typical scalar title (header/station/OFS/date) is 4 rows."""
+        scalar = (
+            '<b>NOAA/NOS OFS Skill Assessment<br>'
+            'CO-OPS station:&nbsp;Providence (8454000)<br>'
+            'OFS:&nbsp;CBOFS&nbsp;&nbsp;&nbsp;Node ID:&nbsp;123'
+            '&nbsp;&nbsp;&nbsp;'
+            '<br>From:&nbsp;2025-07-01&nbsp;&nbsp;&nbsp;To:&nbsp;2025-07-02<b>'
+        )
+        self.assertEqual(count_title_lines(scalar), 4)
+
+    def test_currents_title_with_depth_and_adcp_six_lines(self):
+        """A full currents title (depth + ADCP-type rows) is 6 rows."""
+        currents = (
+            '<b>NOAA/NOS OFS Skill Assessment<br>'
+            'CO-OPS station:&nbsp;Some Bay (cb1401)<br>'
+            'OFS:&nbsp;CBOFS&nbsp;&nbsp;&nbsp;Node ID:&nbsp;123'
+            '&nbsp;&nbsp;&nbsp;'
+            '<br>Bin&nbsp;01&nbsp;—&nbsp;Obs&nbsp;depth&nbsp;2.0&nbsp;m'
+            '<br>Side-Looking ADCP'
+            '<br>From:&nbsp;2025-07-01&nbsp;&nbsp;&nbsp;To:&nbsp;2025-07-02<b>'
+        )
+        self.assertEqual(count_title_lines(currents), 6)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/title_lines_test.py
+++ b/tests/title_lines_test.py
@@ -37,6 +37,24 @@ class TestCountTitleLines(unittest.TestCase):
         )
         self.assertEqual(count_title_lines(scalar), 4)
 
+    def test_currents_title_with_depth_no_adcp_five_lines(self):
+        """A currents title with a depth row but no ADCP-type row is 5 rows.
+
+        This is the intermediate case (e.g. a USGS/CHS or side-looking
+        currents station that has a depth line but no separate ADCP-type
+        line). It exercises the ``+30`` px / ``+0.005`` margin step once and
+        locks in the 5-line (180 px) top margin.
+        """
+        currents = (
+            '<b>NOAA/NOS OFS Skill Assessment<br>'
+            'USGS station:&nbsp;Some River (01234567)<br>'
+            'OFS:&nbsp;CBOFS&nbsp;&nbsp;&nbsp;Node ID:&nbsp;123'
+            '&nbsp;&nbsp;&nbsp;'
+            '<br>Bin&nbsp;01&nbsp;—&nbsp;Obs&nbsp;depth&nbsp;2.0&nbsp;m'
+            '<br>From:&nbsp;2025-07-01&nbsp;&nbsp;&nbsp;To:&nbsp;2025-07-02<b>'
+        )
+        self.assertEqual(count_title_lines(currents), 5)
+
     def test_currents_title_with_depth_and_adcp_six_lines(self):
         """A full currents title (depth + ADCP-type rows) is 6 rows."""
         currents = (


### PR DESCRIPTION
### Description of Changes

Fixes #221 — the currents 1D time-series plot title overlapping the legend.

The currents time-series plot (`oned_vector_plot1`) reused the top-margin formula introduced by the #136 fix, which only grows the top margin with the number of whichcasts. That formula was tuned for the ~4-line **scalar** title. Currents titles are taller: they carry an extra **Obs/Model depth** line and an **ADCP-type** line (added in the #141 work) on top of the header / station / OFS+node / date rows — up to **6 lines** for a CO-OPS ADCP bin. The fixed base margin left the bottom title rows overlapping the horizontal legend, exactly as reported for GOMOFS / Portsmouth Harbor Gangway Rocks LB12Q (bin 01).

Changes:
- **`plotting_functions.py`** — new helper `count_title_lines()` that counts the `<br>`-separated rows the HTML title actually renders.
- **`plotting_vector.py`** — in `oned_vector_plot1`, build the title once, then size the top margin dynamically from the real title height (+30 px per line above the 4-line scalar baseline) and nudge the title anchor up. This composes with the existing per-whichcast margin growth, so the layout stays correct regardless of the depth/ADCP lines or the number of whichcasts.
- **`tests/title_lines_test.py`** — unit tests for `count_title_lines()` (empty / one-line / N-break titles, and the 4-line scalar, 5-line intermediate, and 6-line currents cases).

Labels: `bug`, `user experience`.

#### Currents wind-rose (`oned_vector_plot2b`) layout changes

A follow-up commit on this branch also addresses two separate layout problems on
the currents **wind-rose** plots (`oned_vector_plot2b`) and adds the
station-to-node distance to the rose titles. These are real behavior changes to
the rose plot type (beyond the #221 time-series scope) and are documented here
for transparency:

1. **Caption overlapping the compass "S" label.** The
   `"Current speed, meters per second"` caption was drawn in a zero-height
   bottom margin (`margin.b=0`) and overlapped the "S" compass label of the
   lower-left Observations rose. Fix: reserve a bottom band (`margin.b=90`),
   center the caption in that band (top-anchored, `x=0.5`), and move the
   horizontal legend below the roses. All offsets are sized in paper
   coordinates relative to figure height, so the layout stays correct for the
   1-row (single whichcast) and multi-row layouts.

   | layout | fig height | caption clearance below roses |
   |---|---|---|
   | 1-row (nowcast) | 540 px | +22 px (clear) |
   | 2-row (nowcast+forecast_b) | 1080 px | +31 px (clear) |

2. **Subplot titles overlapping the top compass labels.** In the single-row
   layout the subplot titles ("Observations", "Model Nowcast Guidance") sat on
   top of the roses' upper compass labels (NNW/N/NNE). Nudged the subplot-title
   anchors up (`y += 0.02`) so they clear the labels.

3. **Station-to-node distance in the rose title.** Added the station-to-node
   distance to the rose titles in the same `(X km from station)` format already
   used on the time-series plots, so readers can judge how representative the
   matched node is. Ported the distance helpers (`build_node_dist_fragment`,
   `get_station_node_distance_km`, `_haversine_km`, `_load_model_node_coords`,
   `_load_obs_station_coords`) into `plotting_functions.py` and wired them into
   `get_title`, so the annotation now appears consistently across the
   time-series, rose, and stick plots.

> Note: those distance helpers also exist on `main`, so a rebase/merge of this
> branch onto `main` may surface a trivial duplicate-definition conflict.

### Expected Outcome of Changes

Currents time-series HTML plots (and their static PNG equivalents) render with the full title clear of the legend. No change to plot data or filenames, and scalar (wl/temp/salt) plots are untouched. The currents **wind-rose** plot (`oned_vector_plot2b`) layout is also updated — see the wind-rose section above. Verified on the exact issue station:

| | top margin (`margin.t`) | title anchor (`title.y`) |
|---|---|---|
| PRE-fix (GOMOFS `pm0101_b01`, 6-line title) | 150 px → title collides with legend | 0.97 |
| POST-fix (same run) | 210 px → title clears legend | 0.98 |

Single-whichcast currents titles now use 150/180/210 px for 4/5/6-line titles; the per-whichcast growth from #136 still applies on top. The 5-line intermediate case (depth line but no ADCP-type line, e.g. a USGS/CHS or side-looking currents station) exercises the `+30`/`+0.005` step once and is now covered by a dedicated unit test.

### Developer Questions and Checklist

**Is this a high priority PR? If yes, why and is there a date by which it needs to be merged?**
No.

**Are there any changes needed to how the code should be run for operational runs? (Commands, flags, job timings, etc.)**
No. Same commands and flags.

**Does this update need to be deployed for operational runs?**
Yes — it's a cosmetic fix to operational currents plots, so it should ship with the next release, but nothing is time-critical.

**Does this update require front end/web app changes? (If yes, provide documentation to Min)**
No.

**Does this impact code development work on adding SCHISM?**
No.

**Does this impact code development work on adding ADCIRC?**
No.

**Does this impact the expected number of output files for integration tests (i.e., will the integration test fail even though code changes result in desired change in outputs?)**
No. Same set and count of output files; only plot layout (margin/title anchor) changed.

- [x] Developer's name is removed throughout the code?
- [x] Did you add relevant labels to the PR?
- [x] Have you run pylint and is the code at an acceptable pylint score (>8)? (`plotting_functions.py` scores 9.67/10; `ruff` clean on all touched files.)
- [x] Jobs contain the appropriate file checking and handle errors for any missing data? (Title building is unchanged; `count_title_lines` is a pure string helper with an empty-string guard.)
- [x] Is log free of critical ERRORs or WARNINGs? For errors that are not critical and can remain in code, is there sufficient handling and logging? (No new logging paths; the GOMOFS test run finished with `Finished create_1dplot!` and no new errors.)

### Testing Instructions

Reproduced against the station from the issue (GOMOFS currents, CO-OPS Portsmouth Harbor Gangway Rocks ADCP `pm0101`), March 1–4 2026:

```bash
# 1. Download GOMOFS station output
python ./bin/utils/get_model_data.py -p ./ -o gomofs \
    -s 2026-03-01T00:00:00Z -e 2026-03-04T00:00:00Z -ws nowcast -t stations

# 2. Build the currents 1D plots
python ./bin/visualization/create_1dplot.py -p ./ -o gomofs \
    -s 2026-03-01T00:00:00Z -e 2026-03-04T00:00:00Z -d MLLW \
    -ws nowcast -so co-ops -vs currents
```

Open `data/visual/gomofs_pm0101_b01_currents_timeseries_nowcast_stations.html`. The 6-line title (header / CO-OPS station / OFS+Node / Bin+depth / Downward-Looking ADCP / date range) should sit fully above the horizontal legend with no overlap. Checking the layout confirms `margin.t=210` post-fix vs. `margin.t=150` pre-fix. Any CO-OPS ADCP bin (`pm0101_b01`…`b08`) exercises the tall-title path.

Unit tests:

```bash
pytest tests/title_lines_test.py -q
```

Wind-rose layout (NECOFS, CO-OPS York Spit LB 22 ADCP `cb0201_b10`,
2026-02-15 → 2026-05-14):

```bash
python ./bin/visualization/create_1dplot.py -p ./ -o necofs \
    -s 2026-02-15T00:00:00Z -e 2026-05-14T00:00:00Z -d MLLW \
    -ws nowcast,forecast_b -so co-ops -vs currents
```

The rose title reads `... Node ID: 184 (0.1 km from station) ...`, the caption
sits clear of the "S" label, and the subplot titles clear the NNW/N/NNE labels.

> Note: `data/` and `control_files/` should be renamed/removed before a fresh run (Section 3.5 warning). I ran the reproduction in an isolated scratch directory so my local `data/`/`control_files/` were untouched.

### Reminder checklist for PR reviewer

- [ ] Run PEP8 compliance tests to ensure the code follows best practices
- [ ] Check that documentation in the script is sufficient
- [ ] Validate the output values (if applicable) to make sure the calculations are correct and make scientific/physical sense; include a comment on the pull request including what validation you performed, for replicability.
- [ ] Test code both on Windows and Linux (and MacOS, if available), using several OFS as test cases
- [ ] **Test for all 'cast' options: forecast_a, forecast_b, and nowcast**
- [ ] When approving or commenting on a pull request, add information on the calls you use in case they need to be replicated or referenced.

