### PR TITLE
Add descriptive headers to `.obs`, `.prd`, and `.ctl` files with legacy compatibility

### DIFF
--- a/src/ofs_skill/model_processing/do_horizon_skill.py
+++ b/src/ofs_skill/model_processing/do_horizon_skill.py
@@ -21,6 +21,7 @@ import pandas as pd
 from ofs_skill.model_processing import do_horizon_skill_utils, get_fcst_cycle
 from ofs_skill.model_processing.get_node_ofs import get_node_ofs
 from ofs_skill.obs_retrieval.station_ctl_file_extract import station_ctl_file_extract
+from ofs_skill.utils.file_headers import series_rows_to_skip
 from ofs_skill.skill_assessment.get_skill import name_convent, ofs_ctlfile_extract
 from ofs_skill.visualization import plot_forecast_hours
 
@@ -220,6 +221,7 @@ def merge_obs_series_scalar(prop, logger):
                             obs_path,
                             delim_whitespace=True,
                             header=None,
+                            skiprows=series_rows_to_skip(obs_path),
                         )
                     else:
                         logger.error(

--- a/src/ofs_skill/model_processing/get_node_ofs.py
+++ b/src/ofs_skill/model_processing/get_node_ofs.py
@@ -268,7 +268,14 @@ def ofs_ctlfile_extract(prop, name_var, model, logger):
                 filename, encoding='utf-8'
         ) as file:
             model_ctlfile = file.read()
-            lines = model_ctlfile.split('\n')[1:]
+            lines = model_ctlfile.split('\n')
+            # Check if the file has contents AND if the first line is header
+            if len(lines) > 0 and 'Station ID' in lines[0]:
+                # It has the 2 header rows, so skip them
+                lines = lines[2:]
+            else:
+                # No headers found, process normally
+                pass
             lines = [i.split(' ') for i in lines]
             lines = [list(filter(None, i)) for i in lines]
             nodes = np.array(lines[:-1])[:, 0]
@@ -1872,7 +1879,7 @@ def get_node_ofs(prop, logger, model_dataset=None):
                         encoding='utf-8',
                     ) as output:
                         if name_conventions[0] == 'cu':
-                            output.write('Days elapsed since Jan. 1, Year, Month, Day, Hours, Minutes, Current speed (m/s), Current direction (0-359), u, v\n')
+                            output.write('Julian days, Year, Month, Day, Hours, Minutes, Current speed (m/s), Current direction (0-359), u, v\n')
                         else:
                             obs_col = None
                             if name_conventions[0] == 'wl':
@@ -1881,7 +1888,7 @@ def get_node_ofs(prop, logger, model_dataset=None):
                                 obs_col = 'Water temperature (C)'
                             elif name_conventions[0] == 'salt':
                                 obs_col = 'Salinity (PSU)'
-                            output.write(f'Days elapsed since Jan. 1, Year, Month, Day, Hours, Minutes, {obs_col}\n')
+                            output.write(f'Julian days, Year, Month, Day, Hours, Minutes, {obs_col}\n')
                         for line in formatted_series:
                             output.write(str(line) + '\n')
                         logger.info(

--- a/src/ofs_skill/model_processing/get_node_ofs.py
+++ b/src/ofs_skill/model_processing/get_node_ofs.py
@@ -36,6 +36,11 @@ from ofs_skill.model_processing.model_source import get_model_source
 from ofs_skill.model_processing.write_ofs_ctlfile import write_ofs_ctlfile
 from ofs_skill.obs_retrieval import scalar, utils, vector
 from ofs_skill.obs_retrieval.utils import get_parallel_config
+from ofs_skill.utils.file_headers import (
+    SERIES_HEADER_PREFIX,
+    series_header,
+    strip_model_ctl_header,
+)
 from ofs_skill.utils.timeseries_coverage import covers_run_window, parse_run_window
 
 logger = logging.getLogger(__name__)
@@ -269,13 +274,9 @@ def ofs_ctlfile_extract(prop, name_var, model, logger):
         ) as file:
             model_ctlfile = file.read()
             lines = model_ctlfile.split('\n')
-            # Check if the file has contents AND if the first line is header
-            if len(lines) > 0 and 'Station ID' in lines[0]:
-                # It has the 2 header rows, so skip them
-                lines = lines[2:]
-            else:
-                # No headers found, process normally
-                pass
+            # Drop the single header line, if present (legacy files
+            # have none)
+            lines = strip_model_ctl_header(lines)
             lines = [i.split(' ') for i in lines]
             lines = [list(filter(None, i)) for i in lines]
             nodes = np.array(lines[:-1])[:, 0]
@@ -1442,7 +1443,13 @@ def _all_prd_files_complete(prop_local, ofs_ctlfile, name_var,
             continue
         try:
             with open(path, encoding='utf-8') as fh:
+                # Don't count the header line toward the expected
+                # timesteps, or a file truncated one data row short
+                # would pass this check.
+                first = fh.readline()
                 row_count = sum(1 for _ in fh)
+                if first and not first.startswith(SERIES_HEADER_PREFIX):
+                    row_count += 1
         except (OSError, UnicodeDecodeError) as ex:
             logger.warning(
                 'Could not read %s for row-count check (%s); treating '
@@ -1817,6 +1824,11 @@ def get_node_ofs(prop, logger, model_dataset=None):
                         'w',
                         encoding='utf-8',
                     ) as output:
+                        # Same header as the other .prd branch so the
+                        # file format is not cast-dependent; omitted
+                        # for empty series to keep blank files 0 bytes.
+                        if len(formatted_series) > 0:
+                            output.write(series_header(name_conventions[0]))
                         for line in formatted_series:
                             output.write(str(line) + '\n')
                         logger.info(
@@ -1878,17 +1890,11 @@ def get_node_ofs(prop, logger, model_dataset=None):
                         'w',
                         encoding='utf-8',
                     ) as output:
-                        if name_conventions[0] == 'cu':
-                            output.write('Julian days, Year, Month, Day, Hours, Minutes, Current speed (m/s), Current direction (0-359), u, v\n')
-                        else:
-                            obs_col = None
-                            if name_conventions[0] == 'wl':
-                                obs_col = 'Water level (m)'
-                            elif name_conventions[0] == 'temp':
-                                obs_col = 'Water temperature (C)'
-                            elif name_conventions[0] == 'salt':
-                                obs_col = 'Salinity (PSU)'
-                            output.write(f'Julian days, Year, Month, Day, Hours, Minutes, {obs_col}\n')
+                        # Header only when there is data: an empty .prd
+                        # must stay 0 bytes so the getsize() blank-file
+                        # checks downstream keep working.
+                        if len(formatted_series) > 0:
+                            output.write(series_header(name_conventions[0]))
                         for line in formatted_series:
                             output.write(str(line) + '\n')
                         logger.info(

--- a/src/ofs_skill/model_processing/get_node_ofs.py
+++ b/src/ofs_skill/model_processing/get_node_ofs.py
@@ -268,7 +268,7 @@ def ofs_ctlfile_extract(prop, name_var, model, logger):
                 filename, encoding='utf-8'
         ) as file:
             model_ctlfile = file.read()
-            lines = model_ctlfile.split('\n')
+            lines = model_ctlfile.split('\n')[1:]
             lines = [i.split(' ') for i in lines]
             lines = [list(filter(None, i)) for i in lines]
             nodes = np.array(lines[:-1])[:, 0]
@@ -1871,6 +1871,17 @@ def get_node_ofs(prop, logger, model_dataset=None):
                         'w',
                         encoding='utf-8',
                     ) as output:
+                        if name_conventions[0] == 'cu':
+                            output.write('Days elapsed since Jan. 1, Year, Month, Day, Hours, Minutes, Current speed (m/s), Current direction (0-359), u, v\n')
+                        else:
+                            obs_col = None
+                            if name_conventions[0] == 'wl':
+                                obs_col = 'Water level (m)'
+                            elif name_conventions[0] == 'temp':
+                                obs_col = 'Water temperature (C)'
+                            elif name_conventions[0] == 'salt':
+                                obs_col = 'Salinity (PSU)'
+                            output.write(f'Days elapsed since Jan. 1, Year, Month, Day, Hours, Minutes, {obs_col}\n')
                         for line in formatted_series:
                             output.write(str(line) + '\n')
                         logger.info(

--- a/src/ofs_skill/model_processing/parse_ofs_ctlfile.py
+++ b/src/ofs_skill/model_processing/parse_ofs_ctlfile.py
@@ -80,7 +80,14 @@ def parse_ofs_ctlfile(filename: str) -> tuple[list[list[str]], list[int], list[i
         model_ctlfile = file.read()
 
     # Split into lines and parse (ignore first header row)
-    raw_lines = model_ctlfile.split('\n')[1:]
+    raw_lines = model_ctlfile.split('\n')
+    # Check if the file has contents AND if the first line is header
+    if len(raw_lines) > 0 and 'Station ID' in raw_lines[0]:
+        # It has the 2 header rows, so skip them
+        raw_lines = raw_lines[2:]
+    else:
+        # No headers found, process normally
+        pass
     split_lines: list[list[str]] = [line.split(' ') for line in raw_lines]
     # Remove empty strings from each line
     split_lines = [list(filter(None, line)) for line in split_lines]

--- a/src/ofs_skill/model_processing/parse_ofs_ctlfile.py
+++ b/src/ofs_skill/model_processing/parse_ofs_ctlfile.py
@@ -79,8 +79,8 @@ def parse_ofs_ctlfile(filename: str) -> tuple[list[list[str]], list[int], list[i
     with open(filename, encoding='utf-8') as file:
         model_ctlfile = file.read()
 
-    # Split into lines and parse
-    raw_lines = model_ctlfile.split('\n')
+    # Split into lines and parse (ignore first header row)
+    raw_lines = model_ctlfile.split('\n')[1:]
     split_lines: list[list[str]] = [line.split(' ') for line in raw_lines]
     # Remove empty strings from each line
     split_lines = [list(filter(None, line)) for line in split_lines]

--- a/src/ofs_skill/model_processing/parse_ofs_ctlfile.py
+++ b/src/ofs_skill/model_processing/parse_ofs_ctlfile.py
@@ -9,6 +9,8 @@ from pathlib import Path
 
 import numpy as np
 
+from ofs_skill.utils.file_headers import strip_model_ctl_header
+
 
 def parse_ofs_ctlfile(filename: str) -> tuple[list[list[str]], list[int], list[int], list[float], list[str]]:
     """
@@ -79,15 +81,9 @@ def parse_ofs_ctlfile(filename: str) -> tuple[list[list[str]], list[int], list[i
     with open(filename, encoding='utf-8') as file:
         model_ctlfile = file.read()
 
-    # Split into lines and parse (ignore first header row)
-    raw_lines = model_ctlfile.split('\n')
-    # Check if the file has contents AND if the first line is header
-    if len(raw_lines) > 0 and 'Station ID' in raw_lines[0]:
-        # It has the 2 header rows, so skip them
-        raw_lines = raw_lines[2:]
-    else:
-        # No headers found, process normally
-        pass
+    # Split into lines; drop the single header line, if present (legacy
+    # files have none)
+    raw_lines = strip_model_ctl_header(model_ctlfile.split('\n'))
     split_lines: list[list[str]] = [line.split(' ') for line in raw_lines]
     # Remove empty strings from each line
     split_lines = [list(filter(None, line)) for line in split_lines]

--- a/src/ofs_skill/model_processing/write_ofs_ctlfile.py
+++ b/src/ofs_skill/model_processing/write_ofs_ctlfile.py
@@ -745,6 +745,7 @@ def write_ofs_ctlfile(prop: Any, model: Any, logger: Logger) -> Any:
                         'w',
                         encoding='utf-8',
                     ) as output:
+                        output.write('Node/station index, Depth layer index, Latitude, Longitude, Station ID, Water depth (m)\n')
                         for ctl_entry in model_ctl_file:
                             output.write(str(ctl_entry))
                 elif prop.ofsfiletype == 'stations':
@@ -754,6 +755,7 @@ def write_ofs_ctlfile(prop: Any, model: Any, logger: Logger) -> Any:
                         'w',
                         encoding='utf-8',
                     ) as output:
+                        output.write('Node/station index, Depth layer index, Latitude, Longitude, Station ID, Water depth (m)\n')
                         for ctl_entry in model_ctl_file:
                             output.write(str(ctl_entry))
 

--- a/src/ofs_skill/model_processing/write_ofs_ctlfile.py
+++ b/src/ofs_skill/model_processing/write_ofs_ctlfile.py
@@ -37,6 +37,7 @@ import numpy as np
 import ofs_skill.model_processing.indexing as indexing
 from ofs_skill.obs_retrieval import utils
 from ofs_skill.obs_retrieval.station_ctl_file_extract import station_ctl_file_extract
+from ofs_skill.utils.file_headers import MODEL_CTL_HEADER, OBS_CTL_HEADER
 
 # Public alias for the shape-normalising static-coord helper. Keeps the
 # ctl writer source 1:1 with the indexing layer (both call sites need the
@@ -214,6 +215,11 @@ def _resolve_side_looking_depths(
     if updated and control_file_path:
         try:
             with open(control_file_path, 'w', encoding='utf-8') as fh:
+                # Re-emit the header the original writer produced —
+                # station_ctl_file_extract strips it, so a rewrite
+                # without it would silently revert the file to the
+                # legacy headerless format.
+                fh.write(OBS_CTL_HEADER)
                 for info, coords in zip(info_rows, coord_rows):
                     fh.write(
                         f'{info[0]} {info[1]} "{info[2]}"\n'
@@ -745,7 +751,11 @@ def write_ofs_ctlfile(prop: Any, model: Any, logger: Logger) -> Any:
                         'w',
                         encoding='utf-8',
                     ) as output:
-                        output.write('Node/station index, Depth layer index, Latitude, Longitude, Station ID, Water depth (m)\n')
+                        # Header only when there is data: an empty ctl
+                        # must stay 0 bytes so the getsize() blank-file
+                        # checks downstream keep working.
+                        if model_ctl_file:
+                            output.write(MODEL_CTL_HEADER)
                         for ctl_entry in model_ctl_file:
                             output.write(str(ctl_entry))
                 elif prop.ofsfiletype == 'stations':
@@ -755,7 +765,8 @@ def write_ofs_ctlfile(prop: Any, model: Any, logger: Logger) -> Any:
                         'w',
                         encoding='utf-8',
                     ) as output:
-                        output.write('Node/station index, Depth layer index, Latitude, Longitude, Station ID, Water depth (m)\n')
+                        if model_ctl_file:
+                            output.write(MODEL_CTL_HEADER)
                         for ctl_entry in model_ctl_file:
                             output.write(str(ctl_entry))
 

--- a/src/ofs_skill/obs_retrieval/get_station_observations.py
+++ b/src/ofs_skill/obs_retrieval/get_station_observations.py
@@ -579,7 +579,7 @@ def _fetch_and_format_station(
                         name_var + '_station.obs'))
                 with open(obs_path, 'w', encoding='utf-8') as output:
                     if name_var == 'cu':
-                        output.write('Days elapsed since Jan. 1, Year, Month, Day, Hours, Minutes, Current speed (m/s), Current direction (0-359), u, v\n')
+                        output.write('Julian days, Year, Month, Day, Hours, Minutes, Current speed (m/s), Current direction (0-359), u, v\n')
                     else:
                         obs_col = None
                         if name_var == 'wl':
@@ -588,7 +588,7 @@ def _fetch_and_format_station(
                             obs_col = 'Water temperature (C)'
                         elif name_var == 'salt':
                             obs_col = 'Salinity (PSU)'
-                        output.write(f'Days elapsed since Jan. 1, Year, Month, Day, Hours, Minutes, {obs_col}\n')
+                        output.write(f'Julian days, Year, Month, Day, Hours, Minutes, {obs_col}\n')
                     for line in formatted_series:
                         output.write(str(line) + '\n')
                     logger.info(

--- a/src/ofs_skill/obs_retrieval/get_station_observations.py
+++ b/src/ofs_skill/obs_retrieval/get_station_observations.py
@@ -578,6 +578,17 @@ def _fetch_and_format_station(
                     str(station_id + '_' + ofs + '_' +
                         name_var + '_station.obs'))
                 with open(obs_path, 'w', encoding='utf-8') as output:
+                    if name_var == 'cu':
+                        output.write('Days elapsed since Jan. 1, Year, Month, Day, Hours, Minutes, Current speed (m/s), Current direction (0-359), u, v\n')
+                    else:
+                        obs_col = None
+                        if name_var == 'wl':
+                            obs_col = 'Water level (m)'
+                        elif name_var == 'temp':
+                            obs_col = 'Water temperature (C)'
+                        elif name_var == 'salt':
+                            obs_col = 'Salinity (PSU)'
+                        output.write(f'Days elapsed since Jan. 1, Year, Month, Day, Hours, Minutes, {obs_col}\n')
                     for line in formatted_series:
                         output.write(str(line) + '\n')
                     logger.info(

--- a/src/ofs_skill/obs_retrieval/get_station_observations.py
+++ b/src/ofs_skill/obs_retrieval/get_station_observations.py
@@ -113,6 +113,7 @@ from ofs_skill.obs_retrieval import (
 from ofs_skill.obs_retrieval.currents_bins_override import (
     split_virtual_currents_id,
 )
+from ofs_skill.utils.file_headers import series_header
 from ofs_skill.obs_retrieval.retrieve_chs_station import retrieve_chs_station
 from ofs_skill.obs_retrieval.retrieve_ndbc_station import retrieve_ndbc_station
 from ofs_skill.obs_retrieval.retrieve_t_and_c_station import retrieve_t_and_c_station
@@ -578,17 +579,11 @@ def _fetch_and_format_station(
                     str(station_id + '_' + ofs + '_' +
                         name_var + '_station.obs'))
                 with open(obs_path, 'w', encoding='utf-8') as output:
-                    if name_var == 'cu':
-                        output.write('Julian days, Year, Month, Day, Hours, Minutes, Current speed (m/s), Current direction (0-359), u, v\n')
-                    else:
-                        obs_col = None
-                        if name_var == 'wl':
-                            obs_col = 'Water level (m)'
-                        elif name_var == 'temp':
-                            obs_col = 'Water temperature (C)'
-                        elif name_var == 'salt':
-                            obs_col = 'Salinity (PSU)'
-                        output.write(f'Julian days, Year, Month, Day, Hours, Minutes, {obs_col}\n')
+                    # Header only when there is data: an empty .obs
+                    # must stay 0 bytes so the getsize() blank-file
+                    # checks downstream keep working.
+                    if len(formatted_series) > 0:
+                        output.write(series_header(name_var))
                     for line in formatted_series:
                         output.write(str(line) + '\n')
                     logger.info(

--- a/src/ofs_skill/obs_retrieval/station_ctl_file_extract.py
+++ b/src/ofs_skill/obs_retrieval/station_ctl_file_extract.py
@@ -77,7 +77,14 @@ def station_ctl_file_extract(ctlfile_path: str) -> Optional[tuple[list[list[str]
         ctlfile = f.read()
 
     # Split into lines, ignoring the first two header rows
-    lines = ctlfile.split('\n')[2:]
+    lines = ctlfile.split('\n')
+    # Check if the file has contents AND if the first line is header
+    if len(lines) > 0 and 'Station ID' in lines[0]:
+        # It has the 2 header rows, so skip them
+        lines = lines[2:]
+    else:
+        # No headers found, process normally
+        pass
 
     # Extract station info (even lines: 0, 2, 4, ...)
     raw_lines1 = lines[0::2]

--- a/src/ofs_skill/obs_retrieval/station_ctl_file_extract.py
+++ b/src/ofs_skill/obs_retrieval/station_ctl_file_extract.py
@@ -76,8 +76,8 @@ def station_ctl_file_extract(ctlfile_path: str) -> Optional[tuple[list[list[str]
     with open(ctlfile_path, encoding='utf-8') as f:
         ctlfile = f.read()
 
-    # Split into lines
-    lines = ctlfile.split('\n')
+    # Split into lines, ignoring the first two header rows
+    lines = ctlfile.split('\n')[2:]
 
     # Extract station info (even lines: 0, 2, 4, ...)
     raw_lines1 = lines[0::2]

--- a/src/ofs_skill/obs_retrieval/station_ctl_file_extract.py
+++ b/src/ofs_skill/obs_retrieval/station_ctl_file_extract.py
@@ -7,6 +7,8 @@ Extract and parse observation station information from control files.
 import os
 from typing import Optional
 
+from ofs_skill.utils.file_headers import strip_obs_ctl_header
+
 
 def station_ctl_file_extract(ctlfile_path: str) -> Optional[tuple[list[list[str]], list[list[str]]]]:
     """
@@ -76,15 +78,11 @@ def station_ctl_file_extract(ctlfile_path: str) -> Optional[tuple[list[list[str]
     with open(ctlfile_path, encoding='utf-8') as f:
         ctlfile = f.read()
 
-    # Split into lines, ignoring the first two header rows
-    lines = ctlfile.split('\n')
-    # Check if the file has contents AND if the first line is header
-    if len(lines) > 0 and 'Station ID' in lines[0]:
-        # It has the 2 header rows, so skip them
-        lines = lines[2:]
-    else:
-        # No headers found, process normally
-        pass
+    # Split into lines; drop the two header rows, if present (legacy
+    # files have none). Detection is anchored to the line start so a
+    # station name containing 'Station ID' cannot be mistaken for a
+    # header.
+    lines = strip_obs_ctl_header(ctlfile.split('\n'))
 
     # Extract station info (even lines: 0, 2, 4, ...)
     raw_lines1 = lines[0::2]

--- a/src/ofs_skill/obs_retrieval/write_obs_ctlfile.py
+++ b/src/ofs_skill/obs_retrieval/write_obs_ctlfile.py
@@ -983,7 +983,7 @@ def _process_variable(
             encoding='utf-8',
         ) as output:
             output.write('Station ID, Station info, Name\n')
-            output.write('Latitude, Longitude, Datum offset (m), Water depth (m), Station datum\n')
+            output.write('  Latitude, Longitude, Target-to-station datum offset (m), Water depth (m), Station datum (if applicable; zero otherwise)\n')
             for i in ctl_file:
                 output.write(str(i))
             logger.info(

--- a/src/ofs_skill/obs_retrieval/write_obs_ctlfile.py
+++ b/src/ofs_skill/obs_retrieval/write_obs_ctlfile.py
@@ -982,6 +982,8 @@ def _process_variable(
             'w',
             encoding='utf-8',
         ) as output:
+            output.write('Station ID, Station info, Name\n')
+            output.write('Latitude, Longitude, Datum offset (m), Water depth (m), Station datum\n')
             for i in ctl_file:
                 output.write(str(i))
             logger.info(

--- a/src/ofs_skill/obs_retrieval/write_obs_ctlfile.py
+++ b/src/ofs_skill/obs_retrieval/write_obs_ctlfile.py
@@ -30,6 +30,7 @@ from typing import Optional
 import pandas as pd
 
 from ofs_skill.obs_retrieval import retrieve_properties, utils, vdatum_resilient
+from ofs_skill.utils.file_headers import OBS_CTL_HEADER
 from ofs_skill.obs_retrieval.chs_utils import (
     CHS_IWLS_BASE_URL,
     CHS_SINE_BASE_URL,
@@ -982,8 +983,11 @@ def _process_variable(
             'w',
             encoding='utf-8',
         ) as output:
-            output.write('Station ID, Station info, Name\n')
-            output.write('  Latitude, Longitude, Target-to-station datum offset (m), Water depth (m), Station datum (if applicable; zero otherwise)\n')
+            # Header only when there is data: an empty ctl must stay
+            # 0 bytes so station_ctl_file_extract keeps returning None
+            # for blank files.
+            if ctl_file:
+                output.write(OBS_CTL_HEADER)
             for i in ctl_file:
                 output.write(str(i))
             logger.info(

--- a/src/ofs_skill/skill_assessment/get_skill.py
+++ b/src/ofs_skill/skill_assessment/get_skill.py
@@ -118,8 +118,8 @@ def ofs_ctlfile_extract(prop, name_var, logger, model_dataset=None):
         if os.path.getsize(ctl_path) > 0:
             with open(ctl_path, encoding='utf-8') as file:
                 read_ofs_ctl_file = file.read()
-
-                lines = read_ofs_ctl_file.split('\n')
+                # Split into lines, ignoring the first header row
+                lines = read_ofs_ctl_file.split('\n')[1:]
                 lines = [x for x in lines if x != '']
                 lines = [i.split(' ') for i in lines]
                 lines = [list(filter(None, i)) for i in lines]
@@ -167,6 +167,7 @@ def prepare_series(read_station_ctl_file, read_ofs_ctl_file, prop,
                 obs_df = pd.read_csv(obs_path,
                     sep=r'\s+',
                     header=None,
+                    skiprows=1, # Added to skip the new header line
                 )
             else:
                 logger.error(
@@ -196,6 +197,7 @@ def prepare_series(read_station_ctl_file, read_ofs_ctl_file, prop,
                 ofs_df = pd.read_csv(prd_path,
                     sep=r'\s+',
                     header=None,
+                    skiprows=1
                 )
             else:
                 logger.error(
@@ -237,6 +239,7 @@ def prepare_series(read_station_ctl_file, read_ofs_ctl_file, prop,
                 ofs_df = pd.read_csv(prd_path,
                     sep=r'\s+',
                     header=None,
+                    skiprows=1
                     )
             except EmptyDataError:
                 return None

--- a/src/ofs_skill/skill_assessment/get_skill.py
+++ b/src/ofs_skill/skill_assessment/get_skill.py
@@ -119,7 +119,14 @@ def ofs_ctlfile_extract(prop, name_var, logger, model_dataset=None):
             with open(ctl_path, encoding='utf-8') as file:
                 read_ofs_ctl_file = file.read()
                 # Split into lines, ignoring the first header row
-                lines = read_ofs_ctl_file.split('\n')[1:]
+                lines = read_ofs_ctl_file.split('\n')
+                # Check if the file has contents AND if the first line is header
+                if len(lines) > 0 and 'Station ID' in lines[0]:
+                    # It has the 2 header rows, so skip them
+                    lines = lines[2:]
+                else:
+                    # No headers found, process normally
+                    pass
                 lines = [x for x in lines if x != '']
                 lines = [i.split(' ') for i in lines]
                 lines = [list(filter(None, i)) for i in lines]
@@ -164,10 +171,19 @@ def prepare_series(read_station_ctl_file, read_ofs_ctl_file, prop,
 
         if os.path.isfile(obs_path):
             if os.path.getsize(obs_path) > 0:
+                # peek at the first line
+                with open(obs_path, encoding='utf-8') as f:
+                    first_line = f.readline()
+
+                # check for your specific header text
+                if 'Julian days' in first_line:
+                    rows_to_skip = 1
+                else:
+                    rows_to_skip = 0
                 obs_df = pd.read_csv(obs_path,
                     sep=r'\s+',
                     header=None,
-                    skiprows=1, # Added to skip the new header line
+                    skiprows=rows_to_skip, # Added to skip the new header line
                 )
             else:
                 logger.error(
@@ -194,10 +210,15 @@ def prepare_series(read_station_ctl_file, read_ofs_ctl_file, prop,
 
             prd_path = os.path.join(prop.data_model_1d_node_path,prdfile)
             if os.path.isfile(prd_path):
+                # check for your specific header text
+                if 'Julian days' in first_line:
+                    rows_to_skip = 1
+                else:
+                    rows_to_skip = 0
                 ofs_df = pd.read_csv(prd_path,
                     sep=r'\s+',
                     header=None,
-                    skiprows=1
+                    skiprows=rows_to_skip
                 )
             else:
                 logger.error(
@@ -236,10 +257,15 @@ def prepare_series(read_station_ctl_file, read_ofs_ctl_file, prop,
                                       model_dataset=cached)
                 _set_cached_model(prop, result)
             try:
+                # check for your specific header text
+                if 'Julian days' in first_line:
+                    rows_to_skip = 1
+                else:
+                    rows_to_skip = 0
                 ofs_df = pd.read_csv(prd_path,
                     sep=r'\s+',
                     header=None,
-                    skiprows=1
+                    skiprows=rows_to_skip
                     )
             except EmptyDataError:
                 return None

--- a/src/ofs_skill/skill_assessment/get_skill.py
+++ b/src/ofs_skill/skill_assessment/get_skill.py
@@ -29,6 +29,7 @@ from ofs_skill.obs_retrieval.utils import get_parallel_config
 from ofs_skill.skill_assessment import format_paired_one_d, metrics_paired_one_d
 from ofs_skill.skill_assessment.make_skill_maps import make_skill_maps
 from ofs_skill.tidal_analysis.extremes import extract_water_level_extrema
+from ofs_skill.utils.file_headers import series_rows_to_skip, strip_model_ctl_header
 from ofs_skill.utils.timeseries_coverage import (
     covers_run_window,
     parse_run_window,
@@ -118,15 +119,9 @@ def ofs_ctlfile_extract(prop, name_var, logger, model_dataset=None):
         if os.path.getsize(ctl_path) > 0:
             with open(ctl_path, encoding='utf-8') as file:
                 read_ofs_ctl_file = file.read()
-                # Split into lines, ignoring the first header row
-                lines = read_ofs_ctl_file.split('\n')
-                # Check if the file has contents AND if the first line is header
-                if len(lines) > 0 and 'Station ID' in lines[0]:
-                    # It has the 2 header rows, so skip them
-                    lines = lines[2:]
-                else:
-                    # No headers found, process normally
-                    pass
+                # Split into lines; drop the single header line, if
+                # present (legacy files have none)
+                lines = strip_model_ctl_header(read_ofs_ctl_file.split('\n'))
                 lines = [x for x in lines if x != '']
                 lines = [i.split(' ') for i in lines]
                 lines = [list(filter(None, i)) for i in lines]
@@ -171,20 +166,21 @@ def prepare_series(read_station_ctl_file, read_ofs_ctl_file, prop,
 
         if os.path.isfile(obs_path):
             if os.path.getsize(obs_path) > 0:
-                # peek at the first line
-                with open(obs_path, encoding='utf-8') as f:
-                    first_line = f.readline()
-
-                # check for your specific header text
-                if 'Julian days' in first_line:
-                    rows_to_skip = 1
-                else:
-                    rows_to_skip = 0
-                obs_df = pd.read_csv(obs_path,
-                    sep=r'\s+',
-                    header=None,
-                    skiprows=rows_to_skip, # Added to skip the new header line
-                )
+                try:
+                    obs_df = pd.read_csv(obs_path,
+                        sep=r'\s+',
+                        header=None,
+                        skiprows=series_rows_to_skip(obs_path),
+                    )
+                except EmptyDataError:
+                    logger.error(
+                        '%s/%s_%s_%s_station.obs has no data rows',
+                        prop.data_observations_1d_station_path,
+                        read_station_ctl_file[0][obs_row][0],
+                        prop.ofs,
+                        name_var,
+                    )
+                    return formatted_series
             else:
                 logger.error(
                     '%s/%s_%s_%s_station.obs is empty',
@@ -210,20 +206,14 @@ def prepare_series(read_station_ctl_file, read_ofs_ctl_file, prop,
 
             prd_path = os.path.join(prop.data_model_1d_node_path,prdfile)
             if os.path.isfile(prd_path):
-
-                # peek at the first line
-                with open(prd_path, encoding='utf-8') as f:
-                    first_line = f.readline()
-                # check for your specific header text
-                if 'Julian days' in first_line:
-                    rows_to_skip = 1
-                else:
-                    rows_to_skip = 0
-                ofs_df = pd.read_csv(prd_path,
-                    sep=r'\s+',
-                    header=None,
-                    skiprows=rows_to_skip
-                )
+                try:
+                    ofs_df = pd.read_csv(prd_path,
+                        sep=r'\s+',
+                        header=None,
+                        skiprows=series_rows_to_skip(prd_path)
+                    )
+                except EmptyDataError:
+                    return None
             else:
                 logger.error(
                     '%s/%s_%s_%s_%s_%s_%s_%s_model.prd is missing',
@@ -261,18 +251,10 @@ def prepare_series(read_station_ctl_file, read_ofs_ctl_file, prop,
                                       model_dataset=cached)
                 _set_cached_model(prop, result)
             try:
-                # peek at the first line
-                with open(prd_path, encoding='utf-8') as f:
-                    first_line = f.readline()
-                # check for your specific header text
-                if 'Julian days' in first_line:
-                    rows_to_skip = 1
-                else:
-                    rows_to_skip = 0
                 ofs_df = pd.read_csv(prd_path,
                     sep=r'\s+',
                     header=None,
-                    skiprows=rows_to_skip
+                    skiprows=series_rows_to_skip(prd_path)
                     )
             except EmptyDataError:
                 return None

--- a/src/ofs_skill/skill_assessment/get_skill.py
+++ b/src/ofs_skill/skill_assessment/get_skill.py
@@ -210,6 +210,10 @@ def prepare_series(read_station_ctl_file, read_ofs_ctl_file, prop,
 
             prd_path = os.path.join(prop.data_model_1d_node_path,prdfile)
             if os.path.isfile(prd_path):
+
+                # peek at the first line
+                with open(prd_path, encoding='utf-8') as f:
+                    first_line = f.readline()
                 # check for your specific header text
                 if 'Julian days' in first_line:
                     rows_to_skip = 1
@@ -257,6 +261,9 @@ def prepare_series(read_station_ctl_file, read_ofs_ctl_file, prop,
                                       model_dataset=cached)
                 _set_cached_model(prop, result)
             try:
+                # peek at the first line
+                with open(prd_path, encoding='utf-8') as f:
+                    first_line = f.readline()
                 # check for your specific header text
                 if 'Julian days' in first_line:
                     rows_to_skip = 1

--- a/src/ofs_skill/utils/file_headers.py
+++ b/src/ofs_skill/utils/file_headers.py
@@ -1,0 +1,73 @@
+"""
+Single source of truth for the descriptive header lines written to (and
+detected in) the text data files produced by the skill assessment:
+model control files (``*_model[_station].ctl``), observation control
+files (``*_station.ctl``), and time-series files (``.obs``/``.prd``).
+
+Writers import the header constants; readers use the ``strip_*`` /
+``*_rows_to_skip`` helpers so that detection stays anchored to the
+exact text the writers emit. Legacy files without headers pass through
+all helpers unchanged.
+"""
+
+
+# Model control file: one header line.
+MODEL_CTL_HEADER_PREFIX = 'Node/station index'
+MODEL_CTL_HEADER = (
+    'Node/station index, Depth layer index, Latitude, Longitude, '
+    'Station ID, Model layer depth (m)\n'
+)
+
+# Observation control file: two header lines (entries are two lines per
+# station, so the header is two lines to preserve even/odd parity).
+OBS_CTL_HEADER_PREFIX = 'Station ID'
+OBS_CTL_HEADER = (
+    'Station ID, Source ID, Station Name\n'
+    '  Latitude, Longitude, Target-to-station datum offset (m), '
+    'Water depth (m), Station datum (if applicable; zero otherwise)\n'
+)
+
+# Time-series files (.obs and .prd): one header line.
+SERIES_HEADER_PREFIX = 'Julian days'
+_SERIES_TIME_COLS = 'Julian days, Year, Month, Day, Hours, Minutes'
+_SERIES_VALUE_LABELS = {
+    'cu': 'Current speed (m/s), Current direction (0-359), u, v',
+    'wl': 'Water level (m)',
+    'temp': 'Water temperature (C)',
+    'salt': 'Salinity (PSU)',
+}
+
+
+def series_header(name_var):
+    """Return the .obs/.prd header line for a variable.
+
+    Falls back to the raw variable name for variables without a mapped
+    label, so an unmapped variable never writes a literal 'None'.
+    """
+    label = _SERIES_VALUE_LABELS.get(name_var, name_var)
+    return f'{_SERIES_TIME_COLS}, {label}\n'
+
+
+def strip_model_ctl_header(lines):
+    """Drop the single model-ctl header line if present (legacy files
+    pass through unchanged)."""
+    if lines and lines[0].startswith(MODEL_CTL_HEADER_PREFIX):
+        return lines[1:]
+    return lines
+
+
+def strip_obs_ctl_header(lines):
+    """Drop the two obs-ctl header lines if present (legacy files pass
+    through unchanged). Anchored to the line start so a station name
+    containing 'Station ID' cannot be mistaken for a header."""
+    if lines and lines[0].startswith(OBS_CTL_HEADER_PREFIX):
+        return lines[2:]
+    return lines
+
+
+def series_rows_to_skip(path):
+    """Number of header rows (0 or 1) to skip when reading a .obs/.prd
+    file with pandas."""
+    with open(path, encoding='utf-8') as peek:
+        first_line = peek.readline()
+    return 1 if first_line.startswith(SERIES_HEADER_PREFIX) else 0

--- a/tests/coops_currents_bins_test.py
+++ b/tests/coops_currents_bins_test.py
@@ -594,6 +594,8 @@ def test_station_ctl_file_extract_preserves_virtual_id(tmp_path):
 
     ctl = tmp_path / 'cbofs_cu_station.ctl'
     ctl.write_text(
+        'Station ID, Source ID, Station Name\n'
+        '  Latitude, Longitude, Target-to-station datum offset (m), Water depth (m), Station datum (if applicable; zero otherwise)\n'
         '8454000_b05 8454000_b05_cu_cbofs_CO-OPS "Providence (bin 05)"\n'
         '  41.807 -71.401 0.0  -10.00  0.0\n'
     )
@@ -647,6 +649,8 @@ def test_get_title_includes_bin_line_for_virtual_id(
     # is the path that exercises the issue #141 fix.
     ctl = tmp_path / 'cbofs_cu_station.ctl'
     ctl.write_text(
+        'Station ID, Source ID, Station Name\n'
+        '  Latitude, Longitude, Target-to-station datum offset (m), Water depth (m), Station datum (if applicable; zero otherwise)\n'
         '8454000_b02 8454000_b02_cu_cbofs_CO-OPS "Providence (bin 02)"\n'
         '  41.807 -71.401 0.0  -4.00  0.0  0.50  up\n'
     )
@@ -716,6 +720,7 @@ def test_get_title_includes_model_depth_from_ctl(
     ctl_dir = tmp_path / 'control_files'
     ctl_dir.mkdir()
     (ctl_dir / 'cbofs_cu_model_station.ctl').write_text(
+        'Node/station index, Depth layer index, Latitude, Longitude, Station ID, Water depth (m)\n'
         '41 6 41.807 -71.401 8454000_b02 3.8\n'
     )
 

--- a/tests/coops_currents_bins_test.py
+++ b/tests/coops_currents_bins_test.py
@@ -720,7 +720,7 @@ def test_get_title_includes_model_depth_from_ctl(
     ctl_dir = tmp_path / 'control_files'
     ctl_dir.mkdir()
     (ctl_dir / 'cbofs_cu_model_station.ctl').write_text(
-        'Node/station index, Depth layer index, Latitude, Longitude, Station ID, Water depth (m)\n'
+        'Node/station index, Depth layer index, Latitude, Longitude, Station ID, Model layer depth (m)\n'
         '41 6 41.807 -71.401 8454000_b02 3.8\n'
     )
 

--- a/tests/file_headers_roundtrip_test.py
+++ b/tests/file_headers_roundtrip_test.py
@@ -1,0 +1,175 @@
+"""
+Writer -> reader round-trip tests for the descriptive file headers.
+
+The header constants in ofs_skill.utils.file_headers are written by the
+ctl/.obs/.prd writers and must be stripped by every reader without
+losing the first data row. These tests pin the writer/reader agreement
+for each file type, for headered (new), headerless (legacy), and
+single-entry files.
+"""
+
+import logging
+from types import SimpleNamespace
+
+import pandas as pd
+import pytest
+
+from ofs_skill.model_processing.get_node_ofs import (
+    ofs_ctlfile_extract as node_ctlfile_extract,
+)
+from ofs_skill.model_processing.parse_ofs_ctlfile import parse_ofs_ctlfile
+from ofs_skill.obs_retrieval.station_ctl_file_extract import (
+    station_ctl_file_extract,
+)
+from ofs_skill.skill_assessment.get_skill import (
+    ofs_ctlfile_extract as skill_ctlfile_extract,
+)
+from ofs_skill.utils.file_headers import (
+    MODEL_CTL_HEADER,
+    OBS_CTL_HEADER,
+    series_header,
+    series_rows_to_skip,
+    strip_model_ctl_header,
+    strip_obs_ctl_header,
+)
+
+logger = logging.getLogger(__name__)
+
+MODEL_CTL_ROWS = [
+    '14 0 38.985  -76.475  8575512  0.0\n',
+    '32 0 37.999  -76.448  8635750  0.0\n',
+    '41 6 41.807  -71.401  8638901  3.8\n',
+]
+
+OBS_CTL_ROWS = [
+    '8575512 8575512_wl_cbofs_CO-OPS "Annapolis"\n'
+    '  38.983 -76.4816 0.0  0.0  0.0\n',
+    '8635750 8635750_wl_cbofs_CO-OPS "Lewisetta"\n'
+    '  37.9946 -76.4674 0.0  0.0  0.0\n',
+]
+
+
+def _write_model_ctl(tmp_path, rows, header=True):
+    ctl_dir = tmp_path / 'control_files'
+    ctl_dir.mkdir(exist_ok=True)
+    path = ctl_dir / 'cbofs_wl_model_station.ctl'
+    path.write_text(
+        (MODEL_CTL_HEADER if header else '') + ''.join(rows),
+        encoding='utf-8',
+    )
+    return path
+
+
+def _model_prop(tmp_path):
+    return SimpleNamespace(
+        ofs='cbofs',
+        ofsfiletype='stations',
+        control_files_path=str(tmp_path / 'control_files'),
+        ctl_flag=1,
+    )
+
+
+@pytest.mark.parametrize('header', [True, False])
+def test_parse_ofs_ctlfile_keeps_all_stations(tmp_path, header):
+    """parse_ofs_ctlfile must return every station, headered or not."""
+    path = _write_model_ctl(tmp_path, MODEL_CTL_ROWS, header=header)
+    _, nodes, depths, shifts, ids = parse_ofs_ctlfile(str(path))
+    assert nodes == [14, 32, 41]
+    assert depths == [0, 0, 6]
+    assert ids == ['8575512', '8635750', '8638901']
+    assert shifts == [0.0, 0.0, 3.8]
+
+
+@pytest.mark.parametrize('header', [True, False])
+def test_skill_ctlfile_extract_keeps_all_stations(tmp_path, header):
+    """get_skill's ctl extractor must return every station."""
+    _write_model_ctl(tmp_path, MODEL_CTL_ROWS, header=header)
+    result = skill_ctlfile_extract(_model_prop(tmp_path), 'wl', logger)
+    assert result is not None
+    _, nodes, _, _, ids = result
+    assert nodes == [14, 32, 41]
+    assert ids == ['8575512', '8635750', '8638901']
+
+
+@pytest.mark.parametrize('header', [True, False])
+def test_node_ctlfile_extract_keeps_all_stations(tmp_path, header):
+    """get_node_ofs's ctl extractor must return every station."""
+    _write_model_ctl(tmp_path, MODEL_CTL_ROWS, header=header)
+    result = node_ctlfile_extract(
+        _model_prop(tmp_path), 'wl', None, logger)
+    assert result is not None
+    _, nodes, _, _, ids = result
+    assert nodes == [14, 32, 41]
+    assert ids == ['8575512', '8635750', '8638901']
+
+
+def test_single_station_model_ctl_survives_header(tmp_path):
+    """A one-station file must not come back empty (regression: the
+    readers used to skip two lines for a one-line header)."""
+    path = _write_model_ctl(tmp_path, MODEL_CTL_ROWS[:1])
+    _, nodes, _, _, ids = parse_ofs_ctlfile(str(path))
+    assert nodes == [14]
+    assert ids == ['8575512']
+    result = skill_ctlfile_extract(_model_prop(tmp_path), 'wl', logger)
+    assert result is not None and result[1] == [14]
+
+
+@pytest.mark.parametrize('header', [True, False])
+def test_station_ctl_file_extract_keeps_all_stations(tmp_path, header):
+    """The obs-ctl extractor must keep station/coord line pairing."""
+    path = tmp_path / 'cbofs_wl_station.ctl'
+    path.write_text(
+        (OBS_CTL_HEADER if header else '') + ''.join(OBS_CTL_ROWS),
+        encoding='utf-8',
+    )
+    result = station_ctl_file_extract(str(path))
+    assert result is not None
+    info_rows, coord_rows = result
+    assert [row[0] for row in info_rows] == ['8575512', '8635750']
+    assert coord_rows[0][0] == '38.983'
+
+
+def test_series_header_roundtrip(tmp_path):
+    """.obs/.prd written with a header must read back with the first
+    data row intact; legacy files must read identically."""
+    rows = [
+        '2461247.50000000 2026  7 26  0  0    0.9630',
+        '2461247.50416667 2026  7 26  0  6    0.9410',
+    ]
+    headered = tmp_path / 'new_station.obs'
+    headered.write_text(
+        series_header('wl') + '\n'.join(rows) + '\n', encoding='utf-8')
+    legacy = tmp_path / 'legacy_station.obs'
+    legacy.write_text('\n'.join(rows) + '\n', encoding='utf-8')
+
+    assert series_rows_to_skip(str(headered)) == 1
+    assert not series_rows_to_skip(str(legacy))
+
+    frames = [
+        pd.read_csv(str(p), sep=r'\s+', header=None,
+                    skiprows=series_rows_to_skip(str(p)))
+        for p in (headered, legacy)
+    ]
+    assert frames[0].equals(frames[1])
+    assert len(frames[0]) == len(rows)
+    assert frames[0].iloc[0, 6] == pytest.approx(0.9630)
+
+
+def test_series_header_labels():
+    """Header labels come from the shared map; unknowns fail soft."""
+    assert series_header('wl').startswith('Julian days')
+    assert 'Water level (m)' in series_header('wl')
+    assert 'u, v' in series_header('cu')
+    # Unmapped variables fall back to the variable name, never 'None'.
+    assert 'None' not in series_header('mystery_var')
+    assert 'mystery_var' in series_header('mystery_var')
+
+
+def test_strip_helpers_are_noops_on_data():
+    """Legacy data lines and empty inputs pass through untouched."""
+    data = MODEL_CTL_ROWS[0].split('\n')
+    assert strip_model_ctl_header(data) == data
+    obs = OBS_CTL_ROWS[0].split('\n')
+    assert strip_obs_ctl_header(obs) == obs
+    assert not strip_model_ctl_header([])
+    assert not strip_obs_ctl_header([])

--- a/tests/write_ofs_ctlfile_minimal_intake_test.py
+++ b/tests/write_ofs_ctlfile_minimal_intake_test.py
@@ -139,11 +139,16 @@ def _write_obs_station_ctl(control_dir, ofs, name_var, stations):
     """Write a minimal obs station.ctl file the writer will read.
 
     Format (per station_ctl_file_extract):
+        <Header Line 1>
+        <Header Line 2>
         <ID> <ID>_<SRC> "<name>"
           <lat> <lon> <depth> <pad> <datum>
     """
     path = control_dir / f'{ofs}_{name_var}_station.ctl'
-    lines = []
+    lines = [
+        'Station ID, Station info, Name',
+        '  Latitude, Longitude, Target-to-station datum offset (m), Water depth (m), Station datum (if applicable; zero otherwise)'
+    ]
     for sid, lat, lon, depth in stations:
         lines.append(f'{sid} {sid}_COOPS "Station {sid}"')
         lines.append(f'  {lat} {lon} {depth} 0.0 MLLW')
@@ -202,6 +207,10 @@ def test_write_ofs_ctlfile_fvcom_stations_minimal_intake(
     written_lines = [
         ln for ln in out_path.read_text().splitlines() if ln.strip()
     ]
+
+    # The model .ctl file now contains a single header row; skip it
+    written_lines = written_lines[1:]
+
     assert len(written_lines) == len(chosen_nodes), (
         f'expected {len(chosen_nodes)} ctl rows, got {len(written_lines)}: '
         f'{written_lines!r}'

--- a/tests/write_ofs_ctlfile_minimal_intake_test.py
+++ b/tests/write_ofs_ctlfile_minimal_intake_test.py
@@ -36,6 +36,7 @@ import pytest
 import xarray as xr
 
 from ofs_skill.model_processing.write_ofs_ctlfile import write_ofs_ctlfile
+from ofs_skill.utils.file_headers import OBS_CTL_HEADER
 
 # ---------------------------------------------------------------------------
 # Fixture: synthetic multi-file FVCOM stations dataset
@@ -145,14 +146,11 @@ def _write_obs_station_ctl(control_dir, ofs, name_var, stations):
           <lat> <lon> <depth> <pad> <datum>
     """
     path = control_dir / f'{ofs}_{name_var}_station.ctl'
-    lines = [
-        'Station ID, Station info, Name',
-        '  Latitude, Longitude, Target-to-station datum offset (m), Water depth (m), Station datum (if applicable; zero otherwise)'
-    ]
+    lines = []
     for sid, lat, lon, depth in stations:
         lines.append(f'{sid} {sid}_COOPS "Station {sid}"')
         lines.append(f'  {lat} {lon} {depth} 0.0 MLLW')
-    path.write_text('\n'.join(lines) + '\n')
+    path.write_text(OBS_CTL_HEADER + '\n'.join(lines) + '\n')
     return path
 
 


### PR DESCRIPTION
### Description of Changes

This PR adds descriptive column headers to observation (`.obs`), model (`.prd`), and control file (`.ctl`) text files, improving data usability. The implementation includes backward compatibility detection to handle both new files with headers and legacy files without headers.

#### Key Changes

**1. Header Addition to Output Files**
Added standardized descriptive headers to all data output files:

**Observation/Production data files (.obs, .prd):**
- Currents (cu): `Julian days, Year, Month, Day, Hours, Minutes, Current speed (m/s), Current direction (0-359), u, v`
- Water level (wl): `Julian days, Year, Month, Day, Hours, Minutes, Water level (m)`
- Temperature (temp): `Julian days, Year, Month, Day, Hours, Minutes, Water temperature (C)`
- Salinity (salt): `Julian days, Year, Month, Day, Hours, Minutes, Salinity (PSU)`

**Control files (.ctl):**
- Model: `Node/station index, Depth layer index, Latitude, Longitude, Station ID, Water depth (m)`
- Observation:
  - Line 1: `Station ID, Station info, Name`
  - Line 2: `  Latitude, Longitude, Target-to-station datum offset (m), Water depth (m), Station datum (if applicable; zero otherwise)`

**2. Test Updates**
- Updated mock control file creation to include header rows
- Tests now generate files in the new format with headers
- Test assertions account for header skipping in output validation

**3. Backward Compatibility**
✅ **Fully backward compatible** — No breaking changes
- Legacy files without headers continue to work unchanged
- New files with headers are automatically detected and parsed correctly

### Expected Outcome of Changes

- **Self-documenting data files**: Column meanings are now user-readable without external documentation
- **Zero disruption**: Existing data and workflows continue to function normally

### Developer Questions and Checklist
**Is this a high priority PR? If yes, why and is there a date by which it needs to be merged?**
No. Standard priority.

**Are there any changes needed to how the code should be run on the server? (Commands, flags, job timings, etc.)**
No.

**Does this update need to be installed on the server?**
Yes.

**Does this update require front end/web app changes? (If yes, provide documentation to Min)**
No.

**Does this impact code development work on adding SCHISM? (If yes, tag Atieh)**
No.

**Does this impact code development work on adding ADCIRC?**
_No/Yes + tag Jack if yes_
No.

**Does this impact the expected number of output files for integration tests (i.e., will the integration test fail even though code changes result in desired change in the number of outputs?)**
No.

- [x] Developer's name is removed throughout the code?
- [x] Did you add relevant labels to the PR?
- [x] Have you run pylint and is the code at an acceptable pylint score? (>8.0)
- [x] Jobs contain the appropriate file checking and handle errors for any missing data?
- [x] Is log free of critical ERRORs or WARNINGs? For errors that are not critical and can remain in code, is there sufficient handling and logging?

### Testing Instructions

1. Run existing test suite. All tests should pass.
2. Run the full 1D pipeline. Check `.prd`, `.obs`, and `.ctl` files for correct headers.
3. Delete headers from .ctl files, and delete the `data` dir. Then re-run the same 1D call with the legacy `.ctl` files. Run should complete using the old-style `.ctl` files.
4. Choose a few `.obs` and/or `.prd` files, and delete the headers. Delete `./data/skill/` and `./data/visuals/` and re-run the same 1D call. Check to see if the stations whose headers were deleted still produce results in `./data/skill/` and `./data/visuals/`.

### Reminder checklist for PR reviewer:
- [ ] Run PEP8 compliance tests to ensure the code follows best practices
- [ ] Check that documentation in the script is sufficient
- [ ] Validate the output values (if applicable) to make sure the calculations are correct and make scientific/physical sense; include a comment on the pull request including what validation you performed, for replicability.
- [ ] Test code both locally and on the linux server, using several OFS as test cases
- [ ] **Test for all ‘cast’ options: forecast_a, forecast_b, and nowcast**
- [ ] When approving or commenting on a pull request, add information on the calls you use in case they need to be replicated.