### PR TITLE
Runtime quick wins: only_bins currents fetch, deepcopy guard, config plumbing

### DIFF
--- a/bin/tidal_analysis/run_harmonic_analysis.py
+++ b/bin/tidal_analysis/run_harmonic_analysis.py
@@ -388,7 +388,7 @@ def run_harmonic_analysis_station_loop(
     # ------------------------------------------------------------------
     # Phase 2: Dispatch work items to ProcessPoolExecutor
     # ------------------------------------------------------------------
-    parallel_config = get_parallel_config(logger)
+    parallel_config = get_parallel_config(logger, config_file=_conf)
     max_workers = parallel_config['ha_workers']
 
     if work_items:
@@ -1107,7 +1107,8 @@ def run_harmonic_analysis(prop, logger):
             )
 
     # Dispatch variable processing — parallel or sequential
-    parallel_cfg = get_parallel_config(logger)
+    parallel_cfg = get_parallel_config(
+        logger, config_file=getattr(prop, 'config_file', None))
     ha_vars = [v for v in prop.var_list if v in ('water_level', 'currents')]
     if parallel_cfg['parallel_variables'] and len(ha_vars) > 1:
         logger.info('Processing %d HA variables in parallel', len(ha_vars))

--- a/bin/utils/get_model_data.py
+++ b/bin/utils/get_model_data.py
@@ -616,7 +616,8 @@ def download_data(prop, list_of_urls1, dir_list, logger):
         # list_of_urls = list_of_urls2
 
     # Download remaining files in parallel
-    parallel_config = get_parallel_config(logger)
+    parallel_config = get_parallel_config(
+        logger, config_file=getattr(prop, 'config_file', None))
     max_workers = parallel_config['model_download_workers']
 
     with ThreadPoolExecutor(max_workers=max_workers) as executor:

--- a/bin/visualization/create_1dplot.py
+++ b/bin/visualization/create_1dplot.py
@@ -651,7 +651,8 @@ def create_1dplot_2nd_part(
     # must run sequentially.
     _ensure_paired_data_exists(read_ofs_ctl_file, prop, var_info, logger)
 
-    parallel_config = get_parallel_config(logger)
+    parallel_config = get_parallel_config(
+        logger, config_file=getattr(prop, 'config_file', None))
     num_stations = len(read_ofs_ctl_file[1])
     use_parallel = (parallel_config.get('parallel_plotting', True)
                     and num_stations > 1)
@@ -1125,7 +1126,8 @@ def create_1dplot(prop, logger):
             _emit_summary_barplots(p, var_info, logger)
 
     # --- Forecast cycle parallelism for forecast_a mode ---
-    parallel_config = get_parallel_config(logger)
+    parallel_config = get_parallel_config(
+        logger, config_file=getattr(prop, 'config_file', None))
     if 'forecast_a' in prop.whichcast:
         #_, forecast_cycles = get_fcst_hours(prop.ofs)
         forecast_cycles = [int(prop.forecast_hr[:-1])]

--- a/conf/ofs_dps.conf.example
+++ b/conf/ofs_dps.conf.example
@@ -190,6 +190,16 @@ parallel_variables=False
 # only if you have RAM to spare. 1 = fully serialized extraction.
 parallel_extract_slots=2
 
+# CO-OPS API rate limiting. The process-wide limiter allows
+# coops_request_concurrency simultaneous requests and spaces request
+# starts by coops_request_gap_sec seconds. The defaults (2 / 0.5) were
+# tuned against CO-OPS throttling on long historical windows — raising
+# them speeds up observation retrieval but risks HTTP 403 chunk drops
+# if CO-OPS throttles your IP. Note obs_coops_workers above this limit
+# adds no throughput; the limiter is the effective cap.
+coops_request_concurrency=2
+coops_request_gap_sec=0.5
+
 # Workflow-level parallelism: run obs download + model extraction concurrently
 parallel_workflow=False
 

--- a/conf/ofs_dps.conf.example
+++ b/conf/ofs_dps.conf.example
@@ -268,3 +268,11 @@ station_match_max_dist_km=4.0
 #   h5netcdf = force the h5netcdf engine (NetCDF-4/HDF5 files only;
 #              fails on NetCDF-3 files)
 engine_strategy=auto
+
+# Ctl-file creation decides per-bin CO-OPS ADCP currents availability
+# with short probe requests (one full-window scan per station plus one
+# short confirmation per bin) instead of downloading the full window
+# for every bin — the ctl stage only needs a yes/no per bin, and the
+# full downloads dominated multi-month run times. Set False to restore
+# the full-download scan (e.g. to cross-check probe decisions).
+ctl_availability_probe=True

--- a/src/ofs_skill/model_processing/model_properties.py
+++ b/src/ofs_skill/model_processing/model_properties.py
@@ -5,7 +5,17 @@ This module defines the ModelProperties class which holds configuration
 and path information for OFS model operations.
 """
 
+import copy
 from typing import Any
+
+# Attributes excluded from deepcopy. ``_cached_model`` holds the loaded
+# xarray model dataset (a dask graph referencing hundreds of backing
+# files); deep-copying it is expensive and no consumer needs a private
+# copy — every access goes through ``getattr(..., None)`` and treats a
+# missing attribute as a cache miss. Without this guard, the per-station
+# ``copy.deepcopy(prop)`` in the plotting fan-out duplicated the whole
+# dataset twice per station.
+_DEEPCOPY_SKIP_ATTRS = frozenset({'_cached_model', '_cached_model_key'})
 
 
 class ModelProperties:
@@ -151,3 +161,20 @@ class ModelProperties:
     def __repr__(self) -> str:
         """String representation of ModelProperties."""
         return f"ModelProperties(ofs='{self.ofs}', datum='{self.datum}')"
+
+    def __deepcopy__(self, memo):
+        """Deep-copy all attributes except the cached model dataset.
+
+        Copies come back without ``_cached_model`` / ``_cached_model_key``;
+        consumers read those via ``getattr(..., None)`` and treat their
+        absence as a cache miss, so behavior is unchanged apart from the
+        copy no longer dragging a full dask graph along.
+        """
+        cls = self.__class__
+        clone = cls.__new__(cls)
+        memo[id(self)] = clone
+        for key, value in self.__dict__.items():
+            if key in _DEEPCOPY_SKIP_ATTRS:
+                continue
+            setattr(clone, key, copy.deepcopy(value, memo))
+        return clone

--- a/src/ofs_skill/obs_retrieval/get_station_observations.py
+++ b/src/ofs_skill/obs_retrieval/get_station_observations.py
@@ -97,6 +97,7 @@ import logging.config
 import os
 import socket
 import sys
+import threading
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime, timedelta
 from pathlib import Path
@@ -130,6 +131,13 @@ from ofs_skill.obs_retrieval.write_obs_ctlfile import write_obs_ctlfile
 
 TIMEOUT_SEC = 120 # default API timeout in seconds
 socket.setdefaulttimeout(TIMEOUT_SEC)
+
+# Serializes the station ctl file build across variable threads.
+# ``write_obs_ctlfile`` creates the ctl files for ALL variables in a
+# single pass, so under parallel_variables every variable thread that
+# finds its own ctl file missing would otherwise launch the same full
+# build concurrently — quadruplicating the CO-OPS currents scan.
+_ctl_create_lock = threading.Lock()
 
 def parameter_validation(argu_list, datum_list, logger):
     """ Parameter validation """
@@ -636,6 +644,55 @@ def _fetch_and_format_station(
         return None
 
 
+def _create_station_ctl_file(
+    ctl_file_path, prop, datum, start_date, end_date, path, ofs,
+    stationowner, var_list, logger, config_file=None,
+):
+    """Build the station ctl files and return the parsed result for
+    ``ctl_file_path``.
+
+    Runs under ``_ctl_create_lock`` so only one variable thread executes
+    the full ``write_obs_ctlfile`` build; the others queue on the lock,
+    re-check existence after acquiring it, and find the file written by
+    the winning thread. The lock covers only this create path — threads
+    whose ctl file already exists never touch it.
+    """
+    with _ctl_create_lock:
+        read_station_ctl_file = station_ctl_file_extract(ctl_file_path)
+        if read_station_ctl_file is not None:
+            logger.info(
+                'Station ctl file %s was created by a concurrent '
+                'variable thread; skipping duplicate creation.',
+                ctl_file_path,
+            )
+            return read_station_ctl_file
+        try:
+            logger.info(
+                'Station ctl file not found. Creating station ctl file!. '
+                'This might take a couple of minutes'
+            )
+            write_obs_ctlfile(
+                start_date, end_date, datum, path, ofs,
+                stationowner, var_list, logger,
+                currents_bins_csv=getattr(
+                    prop, 'currents_bins_csv', None),
+                config_file=config_file,
+            )
+            read_station_ctl_file = station_ctl_file_extract(ctl_file_path)
+            logger.info('Station ctl file created '
+                        'successfully')
+            return read_station_ctl_file
+        except Exception as ex:
+            logger.error(
+                'Errors happened when creating station '
+                'ctl files -- %s.',
+                str(ex)
+            )
+            raise Exception('Error happened when '
+                            'creating station '
+                            'ctl files') from ex
+
+
 def _process_variable_obs(
     variable, prop, datum, datum_list, start_date, end_date,
     start_date_full, end_date_full, path, ofs, stationowner, var_list,
@@ -711,11 +768,11 @@ def _process_variable_obs(
     # This will try to read the station ctl file for the given ofs and for
     # all variables. If not found then it will create it using
     # write_obs_ctlfile.py
-    read_station_ctl_file = \
-        station_ctl_file_extract(
-        r'' + control_files_path + '/' + ofs +\
-            '_' + name_var + '_station.ctl'
+    ctl_file_path = (
+        r'' + control_files_path + '/' + ofs +
+        '_' + name_var + '_station.ctl'
     )
+    read_station_ctl_file = station_ctl_file_extract(ctl_file_path)
 
     if read_station_ctl_file is not None:
         logger.info('Station ctl file (%s_%s_station.ctl) '
@@ -725,40 +782,10 @@ def _process_variable_obs(
                     'delete the current file.', ofs, name_var,
                     control_files_path)
     else:
-        try:
-            logger.info(
-                'Station ctl file not found. Creating station ctl file!. '
-                'This might take a couple of minutes'
-            )
-            write_obs_ctlfile(
-                start_date, end_date, datum, path, ofs,
-                stationowner, var_list, logger,
-                currents_bins_csv=getattr(
-                    prop, 'currents_bins_csv', None),
-                config_file=config_file,
-            )
-            read_station_ctl_file = (
-                station_ctl_file_extract(
-                    r''
-                    + control_files_path
-                    + '/'
-                    + ofs
-                    + '_'
-                    + name_var
-                    + '_station.ctl'
-                )
-            )
-            logger.info('Station ctl file created '
-                        'successfully')
-        except Exception as ex:
-            logger.error(
-                'Errors happened when creating station '
-                'ctl files -- %s.',
-                str(ex)
-            )
-            raise Exception('Error happened when '
-                            'creating station '
-                            'ctl files') from ex
+        read_station_ctl_file = _create_station_ctl_file(
+            ctl_file_path, prop, datum, start_date, end_date, path, ofs,
+            stationowner, var_list, logger, config_file=config_file,
+        )
 
     logger.info('Downloading data found in the station ctl files')
 

--- a/src/ofs_skill/obs_retrieval/get_station_observations.py
+++ b/src/ofs_skill/obs_retrieval/get_station_observations.py
@@ -115,7 +115,10 @@ from ofs_skill.obs_retrieval.currents_bins_override import (
 )
 from ofs_skill.obs_retrieval.retrieve_chs_station import retrieve_chs_station
 from ofs_skill.obs_retrieval.retrieve_ndbc_station import retrieve_ndbc_station
-from ofs_skill.obs_retrieval.retrieve_t_and_c_station import retrieve_t_and_c_station
+from ofs_skill.obs_retrieval.retrieve_t_and_c_station import (
+    configure_coops_rate_limit,
+    retrieve_t_and_c_station,
+)
 from ofs_skill.obs_retrieval.retrieve_usgs_station import retrieve_usgs_station
 from ofs_skill.obs_retrieval.station_ctl_file_extract import station_ctl_file_extract
 from ofs_skill.obs_retrieval.utils import get_parallel_config
@@ -386,8 +389,8 @@ def _fetch_and_format_station(
     try:
         station_id = station_info[0]
         source = station_info[3]
-        datum_list = (utils.Utils(config_file).read_config_section('datums', logger)\
-                           ['datum_list']).split(' ')
+        # ``datum_list`` arrives as a parameter, read from config once by
+        # the caller — no per-station config re-read here.
 
         # Each worker gets its own RetrieveProperties — critical for
         # thread safety since the object carries mutable request state.
@@ -432,11 +435,35 @@ def _fetch_and_format_station(
                 retrieve_input.variable = variable
                 retrieve_input.datum = common_value
 
+                # For currents, restrict retrieval to the one bin this ctl
+                # row asked for. Without ``only_bins`` the retrieval walks
+                # every bin of the parent ADCP (30-day chunks each) and this
+                # caller keeps one — K bins per station meant K× the CO-OPS
+                # requests per row, all through the shared rate limiter.
+                only_bins = {bin_num} if bin_num is not None else None
                 timeseries = retrieve_t_and_c_station(
                     retrieve_input, logger,
                     control_files_path,
                     config_file=config_file,
+                    only_bins=only_bins,
                     )
+
+                if (only_bins is not None
+                        and isinstance(timeseries, dict)
+                        and bin_num not in timeseries):
+                    # The pinned bin returned nothing. Preserve the legacy
+                    # any-available-bin fallback by retrying unrestricted;
+                    # rare path, so the extra fetch only happens when the
+                    # requested bin is genuinely absent.
+                    logger.warning(
+                        'CO-OPS currents bin %s of station %s returned no '
+                        'data with a restricted fetch; retrying across all '
+                        'bins.', bin_num, station_id)
+                    timeseries = retrieve_t_and_c_station(
+                        retrieve_input, logger,
+                        control_files_path,
+                        config_file=config_file,
+                        )
 
                 if variable == 'currents' and isinstance(timeseries, dict):
                     # Pick out the requested bin. When no bin suffix was
@@ -749,6 +776,15 @@ def _process_variable_obs(
 
         # Read parallel config for worker counts
         parallel_cfg = get_parallel_config(logger, config_file=config_file)
+
+        # Apply any configured CO-OPS rate-limit override before the
+        # station fan-out. Defaults (2 concurrent / 0.5 s gap) stay in
+        # force unless the [parallelization] section says otherwise.
+        configure_coops_rate_limit(
+            concurrency=parallel_cfg.get('coops_request_concurrency'),
+            gap_sec=parallel_cfg.get('coops_request_gap_sec'),
+            logger=logger,
+        )
 
         # Currents retrieval now issues one HTTP call per ADCP bin per
         # station, so it is orders of magnitude more request-dense than

--- a/src/ofs_skill/obs_retrieval/get_station_observations.py
+++ b/src/ofs_skill/obs_retrieval/get_station_observations.py
@@ -480,6 +480,19 @@ def _fetch_and_format_station(
                     if bin_num is not None and bin_num in timeseries:
                         timeseries = timeseries[bin_num]
                         logger.info('Picked currents bin successfully!')
+                    elif bin_num is not None and timeseries:
+                        # Virtual bin row whose exact bin is still absent
+                        # after the unrestricted retry. Substituting another
+                        # bin here would publish that bin's data under this
+                        # row's virtual ID and depth, silently corrupting
+                        # the skill statistics — skip the station instead.
+                        logger.error(
+                            'CO-OPS currents bin %s not found for station '
+                            '%s (available: %s); skipping station rather '
+                            'than substituting another bin\'s data.',
+                            bin_num, station_id,
+                            sorted(timeseries.keys()))
+                        return None
                     elif timeseries:
                         fallback_key = sorted(timeseries.keys())[0]
                         logger.warning(

--- a/src/ofs_skill/obs_retrieval/retrieve_t_and_c_station.py
+++ b/src/ofs_skill/obs_retrieval/retrieve_t_and_c_station.py
@@ -338,6 +338,7 @@ def _get_with_retry(
     station_id: str,
     context: str,
     logger: Logger,
+    return_error_body: bool = False,
 ) -> Optional[dict]:
     """GET ``url`` with retries for transient CO-OPS errors.
 
@@ -350,7 +351,12 @@ def _get_with_retry(
     included in log messages so parallel workers can be disambiguated.
 
     Returns the parsed JSON payload on success, ``None`` when the call
-    hits a non-retryable error or all retries are exhausted.
+    hits a non-retryable error or all retries are exhausted. With
+    ``return_error_body=True`` a non-retryable HTTP error whose body is
+    a JSON ``{"error": ...}`` document is returned parsed instead of
+    ``None`` — callers that need to distinguish an API-level request
+    rejection (e.g. the currents "Wrong Bin Number" response, served
+    with HTTP 400) from a plain no-data drop opt in to this.
     """
     last_exc = None
     for attempt in range(1, _RETRY_MAX_ATTEMPTS + 1):
@@ -406,6 +412,17 @@ def _get_with_retry(
             return None
 
         if status >= 400:
+            if return_error_body:
+                try:
+                    body = response.json()
+                except ValueError:
+                    body = None
+                if isinstance(body, dict) and 'error' in body:
+                    logger.info(
+                        'CO-OPS %s station=%s HTTP %d with API error '
+                        'body: %s', context, station_id, status,
+                        body.get('error'))
+                    return body
             # Non-retryable 4xx/5xx (400, 401, 404, etc.) - fail fast.
             # CO-OPS returns 400 "No data was found" for stations with
             # no observations in the requested window; retrying won't
@@ -937,6 +954,7 @@ def retrieve_t_and_c_station(
     control_files_path: Optional[str] = None,
     only_bins: Optional[set[int]] = None,
     config_file=None,
+    availability_probe: bool = False,
 ) -> Optional[Union[pd.DataFrame, dict[int, pd.DataFrame]]]:
     """
     Retrieve time series observations from NOAA Tides and Currents station.
@@ -960,6 +978,11 @@ def retrieve_t_and_c_station(
             When supplied, the datagetter is only called for those
             bins — used by ``write_obs_ctlfile`` to honour the user
             currents-bins CSV without fetching every bin.
+        availability_probe: When True (currents only), establish per-bin
+            data availability with the short probe (issue #239) instead
+            of downloading the full window for every bin. Only the
+            ctl-file creation stage sets this — the obs-retrieval stage
+            needs the actual timeseries and keeps full downloads.
 
     Returns:
         For ``variable == 'currents'``:
@@ -1002,6 +1025,7 @@ def retrieve_t_and_c_station(
             logger=logger,
             only_bins=only_bins,
             control_files_path=control_files_path,
+            availability_probe=availability_probe,
         )
 
     t_c.start_dt = datetime.strptime(retrieve_input.start_date, '%Y%m%d')
@@ -1203,6 +1227,324 @@ def _bin_depth_from_record(entry: dict) -> Optional[float]:
     return None
 
 
+# ---------------------------------------------------------------------------
+# Ctl-stage currents availability probe (issue #239)
+#
+# At ctl-file creation the only download-derived fact the emitter uses
+# is per-bin data presence — every other field of a ctl row comes from
+# MDAPI metadata. The probe establishes that presence with one no-bin
+# full-window scan (30-day chunks, early stop at the first chunk with
+# in-window data) plus one short-range per-bin confirmation anchored at
+# the known-data timestamp, instead of downloading the full window for
+# every bin. Metadata scopes the candidate bins but never decides
+# emit/reject — the datagetter always has the final word, because MDAPI
+# deployment records and the observation archive diverge in both
+# directions on historical windows.
+# ---------------------------------------------------------------------------
+
+# Substring of the datagetter error body returned (HTTP 400) when a
+# no-bin currents request hits a station whose real_time_bin is null:
+# "Wrong Bin Number: The Bin Number cannot be null or empty for the
+# currents survey".
+_WRONG_BIN_ERROR_TEXT = 'wrong bin number'
+
+
+def _is_wrong_bin_error(obs: Optional[dict]) -> bool:
+    """True when the datagetter rejected a no-bin currents request
+    because the station's real_time_bin is null."""
+    if not isinstance(obs, dict):
+        return False
+    error = obs.get('error')
+    if not isinstance(error, dict):
+        return False
+    return _WRONG_BIN_ERROR_TEXT in str(error.get('message', '')).lower()
+
+
+def _probe_rows_in_range(
+    obs: Optional[dict],
+    range_start: datetime,
+    range_end: datetime,
+    bin_num: Optional[int],
+    logger: Logger,
+) -> list[dict]:
+    """Filter datagetter rows to ``[range_start, range_end]``.
+
+    Applies the same per-row bin cross-check as the full retrieval
+    (rows whose ``b`` field mismatches an explicitly requested bin are
+    skipped). Rows with unparseable speed/direction still count — the
+    emit rule is timestamp presence, not value validity.
+    """
+    rows: list[dict] = []
+    if not isinstance(obs, dict):
+        return rows
+    for row in obs.get('data', []) or []:
+        if bin_num is not None:
+            row_bin = _coerce_int(row.get('b'))
+            if row_bin is not None and row_bin != bin_num:
+                logger.warning(
+                    'CO-OPS datagetter returned bin=%s for '
+                    'request bin=%s, skipping row', row_bin, bin_num)
+                continue
+        try:
+            row_dt = datetime.strptime(row['t'], '%Y-%m-%d %H:%M')
+        except (KeyError, TypeError, ValueError):
+            continue
+        if range_start <= row_dt <= range_end:
+            rows.append(row)
+    return rows
+
+
+def _probe_scan_for_data(
+    station_id: str,
+    bin_num: Optional[int],
+    fallback_bin: Optional[int],
+    scan_start: datetime,
+    scan_end: datetime,
+    api_url: str,
+    logger: Logger,
+) -> Optional[list[dict]]:
+    """Scan ``[scan_start, scan_end]`` in 30-day chunks for any data row,
+    stopping at the first chunk that yields one.
+
+    ``bin_num=None`` issues no-bin requests (the datagetter then serves
+    the station's real_time_bin). When such a request is rejected with
+    the documented "Wrong Bin Number" error (real_time_bin null), the
+    same chunk is retried with ``fallback_bin`` pinned and the rest of
+    the scan continues with it. A negative scan must cover the FULL
+    window before the station can be rejected — 1-day head/tail
+    sampling false-rejects stations whose data starts mid-window.
+
+    Returns the first chunk's in-range rows, or ``None`` when the whole
+    scan came back empty.
+    """
+    delta = timedelta(days=30)
+    cur = scan_start
+    while cur <= scan_end:
+        date_i = cur.strftime('%Y%m%d')
+        date_f = (cur + delta).strftime('%Y%m%d')
+        bin_qs = f'&bin={bin_num}' if bin_num is not None else ''
+        url = (
+            f'{api_url}/datagetter?begin_date={date_i}&end_date={date_f}'
+            f'&station={station_id}&product=currents{bin_qs}'
+            f'&time_zone=gmt&units=metric&format=json'
+        )
+        context = (f'currents bin={bin_num} (probe scan)'
+                   if bin_num is not None else 'currents (probe scan)')
+        obs = _get_with_retry(url, station_id, context, logger,
+                              return_error_body=True)
+
+        if bin_num is None and _is_wrong_bin_error(obs):
+            if fallback_bin is None:
+                logger.warning(
+                    'CO-OPS station %s no-bin probe rejected '
+                    '(real_time_bin is null) and no metadata bin is '
+                    'available for an explicit retry; treating as no '
+                    'data.', station_id)
+                return None
+            logger.info(
+                'CO-OPS station %s no-bin probe rejected (real_time_bin '
+                'is null); retrying chunk with explicit bin=%d.',
+                station_id, fallback_bin)
+            bin_num = fallback_bin
+            continue  # re-request the same chunk with the explicit bin
+
+        rows = _probe_rows_in_range(obs, scan_start, scan_end, bin_num,
+                                    logger)
+        if rows:
+            return rows
+        cur += delta
+    return None
+
+
+def _probe_confirm_bin(
+    station_id: str,
+    bin_num: int,
+    anchor_dt: datetime,
+    range_start: datetime,
+    range_end: datetime,
+    api_url: str,
+    logger: Logger,
+) -> list[dict]:
+    """Short-range per-bin confirmation anchored at a known-data timestamp.
+
+    Mirrors the backward-search URL shape of ``_fetch_currents_chunked``
+    (``end_date=<day>&range=24``); the end date is the day AFTER the
+    anchor so the 24-hour window covers the anchor's own day. Per-bin
+    presence cannot be inferred from the station-level scan because the
+    historical archive is not uniform across bins.
+
+    Returns the in-range rows (empty list when the bin has no data at
+    the anchor).
+    """
+    end_date = (anchor_dt + timedelta(days=1)).strftime('%Y%m%d')
+    url = (
+        f'{api_url}/datagetter?end_date={end_date}&range=24'
+        f'&station={station_id}&product=currents&bin={bin_num}'
+        f'&time_zone=gmt&units=metric&format=json'
+    )
+    obs = _get_with_retry(
+        url, station_id, f'currents bin={bin_num} (probe confirm)', logger)
+    return _probe_rows_in_range(obs, range_start, range_end, bin_num, logger)
+
+
+def _probe_scan_range(
+    station_id: str,
+    deployment_info: Optional[dict],
+    has_depth_shifts: bool,
+    start_dt_0: datetime,
+    end_dt_0: datetime,
+    logger: Logger,
+) -> tuple[datetime, datetime]:
+    """Return the date range the availability probe may treat as decisive.
+
+    Mirrors the most-recent-deployment restriction of the full
+    retrieval (see ``_fetch_currents_chunked``): when bin depths shift
+    across deployments and more than one deployment period overlaps the
+    window, only data inside the most recent period can flip a station
+    to emit, so the probe scans (and anchors its confirms) inside that
+    period only.
+    """
+    if not has_depth_shifts:
+        return start_dt_0, end_dt_0
+    periods, _ = _active_deployment_periods(
+        deployment_info, start_dt_0, end_dt_0, logger)
+    if len(periods) <= 1:
+        return start_dt_0, end_dt_0
+    keep_start, keep_end = periods[-1]
+    logger.info(
+        'CO-OPS station %s availability probe restricted to the most '
+        'recent deployment period (%s to %s) to match the '
+        'bin-depth-shift handling of the full retrieval.',
+        station_id, keep_start.strftime('%Y-%m-%d %H:%M'),
+        keep_end.strftime('%Y-%m-%d %H:%M'))
+    return keep_start, keep_end
+
+
+def _make_probe_frame(rows: list[dict]) -> pd.DataFrame:
+    """Assemble the small probe DataFrame in the same column shape as
+    the full retrieval so downstream attrs consumers are indifferent."""
+    dates: list[str] = []
+    speeds: list[float] = []
+    dirs: list[float] = []
+    for row in rows:
+        try:
+            speed_m = float(row['s']) / 100  # cm/s → m/s
+        except (TypeError, ValueError, KeyError):
+            speed_m = float('nan')
+        try:
+            direction = float(row['d'])
+        except (TypeError, ValueError, KeyError):
+            direction = float('nan')
+        dates.append(row['t'])
+        speeds.append(speed_m)
+        dirs.append(direction)
+    df = pd.DataFrame({
+        'DateTime': pd.to_datetime(dates),
+        'DEP01': pd.to_numeric(0.0),
+        'DIR': pd.to_numeric(dirs),
+        'OBS': pd.to_numeric(speeds),
+    })
+    return df.sort_values(by='DateTime').drop_duplicates(subset='DateTime')
+
+
+def _probe_updown_currents_availability(
+    station_id: str,
+    start_dt_0: datetime,
+    end_dt_0: datetime,
+    api_url: str,
+    bin_records: list[dict],
+    deployment_info: Optional[dict],
+    hfb: Optional[float],
+    orientation_label: str,
+    mounting_type: str,
+    only_bins: Optional[set[int]],
+    has_depth_shifts: bool,
+    logger: Logger,
+) -> Optional[dict[int, pd.DataFrame]]:
+    """Availability-probe replacement for the per-bin full-window
+    downloads of the up/down fan-out path at ctl-file time.
+
+    Emits exactly the bins whose short-range confirmation returns data;
+    a station whose full-window scan finds nothing is rejected with the
+    same ``None`` the full path returns for an empty result.
+    """
+    candidates: list[tuple[int, Optional[float]]] = []
+    for entry in bin_records:
+        try:
+            bin_num = int(entry.get('num', entry.get('bin')))  # type: ignore[arg-type]
+        except (KeyError, TypeError, ValueError):
+            continue
+        if only_bins is not None and bin_num not in only_bins:
+            continue
+        candidates.append((bin_num, _bin_depth_from_record(entry)))
+
+    if not candidates:
+        logger.info(
+            'CO-OPS currents retrieval for station %s returned no bins '
+            'with data.', station_id)
+        return None
+
+    scan_start, scan_end = _probe_scan_range(
+        station_id, deployment_info, has_depth_shifts,
+        start_dt_0, end_dt_0, logger)
+    scan_rows = _probe_scan_for_data(
+        station_id, None, candidates[0][0], scan_start, scan_end,
+        api_url, logger)
+    if scan_rows is None:
+        logger.info(
+            'CO-OPS currents availability probe for station %s found no '
+            'data in the requested window; station rejected.', station_id)
+        return None
+
+    # Safe parse: rows already passed strptime in _probe_rows_in_range.
+    anchor_dt = datetime.strptime(scan_rows[0]['t'], '%Y-%m-%d %H:%M')
+
+    result: dict[int, pd.DataFrame] = {}
+    missing_depth: list[int] = []
+    for bin_num, depth in candidates:
+        if depth is None:
+            missing_depth.append(bin_num)
+            depth = 0.0
+        confirm_rows = _probe_confirm_bin(
+            station_id, bin_num, anchor_dt, scan_start, scan_end,
+            api_url, logger)
+        if not confirm_rows:
+            logger.info(
+                'CO-OPS station %s bin %d not confirmed at known-data '
+                'timestamp %s; bin not emitted.', station_id, bin_num,
+                anchor_dt.strftime('%Y-%m-%d %H:%M'))
+            continue
+        df = _make_probe_frame(confirm_rows)
+        df['DEP01'] = pd.to_numeric(depth)
+        df.attrs['bin'] = bin_num
+        df.attrs['depth'] = depth
+        df.attrs['orientation'] = orientation_label
+        df.attrs['mounting_type'] = mounting_type
+        df.attrs['height_from_bottom'] = hfb
+        df.attrs['has_historical_depth_shifts'] = has_depth_shifts
+        result[bin_num] = df
+
+    if missing_depth:
+        logger.error(
+            'CO-OPS station %s (%s) bins endpoint returned no depth for '
+            'bins %s; depth recorded as 0.0 m. This is unexpected for '
+            'non-side ADCPs — check MDAPI metadata.',
+            station_id, mounting_type, missing_depth)
+
+    if not result:
+        logger.info(
+            'CO-OPS currents retrieval for station %s returned no bins '
+            'with data.', station_id)
+        return None
+
+    _record_mounting(mounting_type)
+    logger.info(
+        'CO-OPS currents availability probe for station %s (%s, %d '
+        'bin(s)): %s', station_id, mounting_type, len(result),
+        sorted(result.keys()))
+    return result
+
+
 def _retrieve_currents_all_bins(
     station_id: str,
     start_date: str,
@@ -1212,6 +1554,7 @@ def _retrieve_currents_all_bins(
     logger: Logger,
     only_bins: Optional[set[int]] = None,
     control_files_path: Optional[str] = None,
+    availability_probe: bool = False,
 ) -> Optional[dict[int, pd.DataFrame]]:
     """Retrieve CO-OPS currents data for every bin of an ADCP station.
 
@@ -1242,6 +1585,13 @@ def _retrieve_currents_all_bins(
     When ``only_bins`` is provided, the bin iteration is restricted to
     that set — short-circuits the CO-OPS HTTP traffic when a user has
     supplied a currents-bins override CSV listing only specific bins.
+
+    ``availability_probe=True`` (ctl-file creation only, issue #239)
+    replaces the full-window per-bin downloads with the availability
+    probe: metadata resolution, the deployment-summary CSV export, and
+    the mounting tally are unchanged, and the returned dict has the
+    same shape and ``df.attrs``, but each DataFrame holds only the
+    short confirmation sample rather than the full window.
 
     Returns ``dict[int, DataFrame]`` keyed by bin number, or ``None`` if
     no bin yielded any in-window data.
@@ -1321,6 +1671,7 @@ def _retrieve_currents_all_bins(
             only_bins=only_bins,
             has_depth_shifts=has_depth_shifts,
             logger=logger,
+            availability_probe=availability_probe,
         )
 
     # up / down / unknown: per-bin fan-out path. The bins endpoint
@@ -1339,6 +1690,22 @@ def _retrieve_currents_all_bins(
             hfb=hfb,
             orientation_label=orientation_label,
             mounting_type=mounting_type,
+            has_depth_shifts=has_depth_shifts,
+            logger=logger,
+        )
+
+    elif availability_probe:
+        final_result = _probe_updown_currents_availability(
+            station_id=station_id,
+            start_dt_0=start_dt_0,
+            end_dt_0=end_dt_0,
+            api_url=api_url,
+            bin_records=bin_records,
+            deployment_info=deployment_info,
+            hfb=hfb,
+            orientation_label=orientation_label,
+            mounting_type=mounting_type,
+            only_bins=only_bins,
             has_depth_shifts=has_depth_shifts,
             logger=logger,
         )
@@ -1411,15 +1778,23 @@ def _retrieve_currents_all_bins(
     # --- CALCULATE OVERALL ACTUAL GAP AND TRIGGER CSV EXPORT ---
     actual_gap_str = 'N/A'
     if final_result:
-        # Determine the maximum gap found across all successfully returned bins
-        max_gap_days = max(
-            (df.attrs.get('actual_gap_days', 0.0) for df in final_result.values()),
-            default=0.0
-        )
-        if max_gap_days > 0.01:
-            actual_gap_str = f'{max_gap_days:.2f} days'
+        if availability_probe:
+            # The probe downloads only availability samples, so the
+            # observed gap coverage is unknown at ctl time; reporting
+            # 'None' here would falsely claim gap-free data.
+            actual_gap_str = 'N/A (availability probe)'
         else:
-            actual_gap_str = 'None'
+            # Determine the maximum gap found across all successfully
+            # returned bins
+            max_gap_days = max(
+                (df.attrs.get('actual_gap_days', 0.0)
+                 for df in final_result.values()),
+                default=0.0
+            )
+            if max_gap_days > 0.01:
+                actual_gap_str = f'{max_gap_days:.2f} days'
+            else:
+                actual_gap_str = 'None'
     else:
         # Complete failure/empty window
         try:
@@ -1480,6 +1855,7 @@ def _retrieve_side_looking_currents(
     only_bins: Optional[set[int]],
     has_depth_shifts: bool,
     logger: Logger,
+    availability_probe: bool = False,
 ) -> Optional[dict[int, pd.DataFrame]]:
     """Side-looking ADCP currents retrieval (issue #140).
 
@@ -1533,18 +1909,34 @@ def _retrieve_side_looking_currents(
 
     depth_unknown = sensor_depth is None
     depth_value = sensor_depth if sensor_depth is not None else 0.0
+    if availability_probe:
+        probe_scan_start, probe_scan_end = _probe_scan_range(
+            station_id, deployment_info, has_depth_shifts,
+            start_dt_0, end_dt_0, logger)
     result: dict[int, pd.DataFrame] = {}
     for chosen_bin in chosen_bins:
-        df = _fetch_currents_chunked(
-            station_id=station_id,
-            bin_num=chosen_bin,
-            start_dt_0=start_dt_0,
-            end_dt_0=end_dt_0,
-            api_url=api_url,
-            logger=logger,
-            deployment_info=deployment_info,
-            has_depth_shifts=has_depth_shifts,
-        )
+        if availability_probe:
+            # A side-looking station already fetches a single pinned bin
+            # over the window, so the probe is the same scan with early
+            # stop — no per-bin confirmation pass exists here. The bin
+            # stays pinned explicitly: a no-bin request resolves to the
+            # era dissemination bin, which can diverge from the current
+            # real_time_bin on historical windows.
+            scan_rows = _probe_scan_for_data(
+                station_id, chosen_bin, None, probe_scan_start,
+                probe_scan_end, api_url, logger)
+            df = _make_probe_frame(scan_rows) if scan_rows else None
+        else:
+            df = _fetch_currents_chunked(
+                station_id=station_id,
+                bin_num=chosen_bin,
+                start_dt_0=start_dt_0,
+                end_dt_0=end_dt_0,
+                api_url=api_url,
+                logger=logger,
+                deployment_info=deployment_info,
+                has_depth_shifts=has_depth_shifts,
+            )
         if df is None:
             logger.info(
                 'CO-OPS side-looking station %s (bin=%d) returned no '

--- a/src/ofs_skill/obs_retrieval/retrieve_t_and_c_station.py
+++ b/src/ofs_skill/obs_retrieval/retrieve_t_and_c_station.py
@@ -149,6 +149,15 @@ _station_info_cache: dict[str, Optional[dict]] = {}
 # live one level deeper at ``stations/{id}/deployments.json``.
 _station_deployment_cache: dict[str, Optional[dict]] = {}
 
+# Per-run cache of ``check_bin_depth_changes`` results keyed by
+# station_id. The audit's expanded ``deployments,bins`` MDAPI request is
+# issued from both ``_retrieve_currents_all_bins`` and
+# ``log_and_export_deployment_info``, so an uncached lookup fires twice
+# per station scan (and again at the obs stage). Cleared by
+# ``reset_run_counters``.
+_bin_depth_change_cache: dict[str, bool] = {}
+_bin_depth_change_cache_lock = threading.Lock()
+
 # Canonical ADCP mounting symbols. Single source of truth — every
 # emitter, parser, label formatter, and run counter funnels through
 # this set so a future MDAPI vocabulary addition can be supported by
@@ -171,8 +180,9 @@ _adcp_mounting_counter_lock = threading.Lock()
 def reset_run_counters() -> None:
     """Reset module-level run counters before a fresh skill-assessment run.
 
-    Currently only resets the ADCP mounting-type tally. Idempotent and
-    safe to call from any thread (counters are guarded by a lock).
+    Resets the ADCP mounting-type tally, the deployment-summary CSV
+    export dedup set, and the bin-depth-change audit cache. Idempotent
+    and safe to call from any thread (all state is guarded by locks).
     """
     with _adcp_mounting_counter_lock:
         for key in _adcp_mounting_counter:
@@ -180,6 +190,9 @@ def reset_run_counters() -> None:
 
     with _csv_export_lock:
         _exported_stations.clear()
+
+    with _bin_depth_change_cache_lock:
+        _bin_depth_change_cache.clear()
 
 
 def canonicalize_mounting_symbol(value: Any) -> str:
@@ -538,7 +551,27 @@ def check_bin_depth_changes(
 
     Queries the MDAPI with expand=deployments,bins to get the full historical
     bin profiles, groups them by deployment ID, and compares the configurations.
+
+    Results are cached per station for the duration of the run — the
+    audit is invoked from multiple call sites per station scan and the
+    answer cannot change mid-run. The cache is cleared by
+    ``reset_run_counters``.
     """
+    with _bin_depth_change_cache_lock:
+        if station_id in _bin_depth_change_cache:
+            return _bin_depth_change_cache[station_id]
+    result = _check_bin_depth_changes_uncached(station_id, mdapi_url, logger)
+    with _bin_depth_change_cache_lock:
+        _bin_depth_change_cache[station_id] = result
+    return result
+
+
+def _check_bin_depth_changes_uncached(
+    station_id: str,
+    mdapi_url: str,
+    logger: Logger,
+) -> bool:
+    """Uncached implementation behind ``check_bin_depth_changes``."""
     url = f'{mdapi_url}/webapi/stations/{station_id}.json?expand=deployments,bins&units=metric'
 
     payload = _get_with_retry(url, station_id, 'bin-depth-audit', logger)

--- a/src/ofs_skill/obs_retrieval/retrieve_t_and_c_station.py
+++ b/src/ofs_skill/obs_retrieval/retrieve_t_and_c_station.py
@@ -81,6 +81,38 @@ _exported_stations: set[str] = set()  # Tracks stations written to CSV in the cu
 _coops_last_request_time = 0.0  # pylint: disable=invalid-name
 
 
+def configure_coops_rate_limit(concurrency=None, gap_sec=None, logger=None):
+    """Override the process-wide CO-OPS limiter from configuration.
+
+    Called by ``get_station_observations`` before the station fan-out with
+    the ``coops_request_concurrency`` / ``coops_request_gap_sec`` values
+    from the [parallelization] config section. Replacing the semaphore is
+    only safe while no request is in flight, which holds at that call
+    point; requests already queued on the old semaphore finish under it.
+
+    No-ops (keeping the tuned defaults) when values are None or unchanged.
+    """
+    global _COOPS_CONCURRENCY_LIMIT, _COOPS_MIN_REQUEST_GAP_SEC, \
+        _coops_request_semaphore  # pylint: disable=global-statement
+    if concurrency is not None:
+        concurrency = max(1, int(concurrency))
+        if concurrency != _COOPS_CONCURRENCY_LIMIT:
+            _COOPS_CONCURRENCY_LIMIT = concurrency
+            _coops_request_semaphore = threading.Semaphore(concurrency)
+            if logger:
+                logger.info(
+                    'CO-OPS request concurrency set to %d (config '
+                    'override; default 2)', concurrency)
+    if gap_sec is not None:
+        gap_sec = max(0.0, float(gap_sec))
+        if gap_sec != _COOPS_MIN_REQUEST_GAP_SEC:
+            _COOPS_MIN_REQUEST_GAP_SEC = gap_sec
+            if logger:
+                logger.info(
+                    'CO-OPS request pacing gap set to %.2fs (config '
+                    'override; default 0.5s)', gap_sec)
+
+
 def _rate_limited_get(url: str, timeout: int = 120) -> requests.Response:
     """GET ``url`` through the shared session, gated by the CO-OPS semaphore
     and paced by a minimum inter-request gap.

--- a/src/ofs_skill/obs_retrieval/utils.py
+++ b/src/ofs_skill/obs_retrieval/utils.py
@@ -9,8 +9,38 @@ import logging
 import math
 import os
 import sys
+import threading
 from pathlib import Path
 from typing import Union
+
+# Parsed-config cache keyed on file path, invalidated by (mtime_ns, size).
+# The pipeline re-reads config sections constantly — per variable, per
+# station in the obs fan-out, per plot dispatch — and each call was a
+# fresh configparser.read() from disk. Caching the parsed object keeps
+# every call after the first in memory while an edited file (new mtime)
+# still reparses.
+_CONFIG_PARSE_CACHE: dict[Path, tuple[tuple[int, int],
+                                      configparser.ConfigParser]] = {}
+_CONFIG_PARSE_LOCK = threading.Lock()
+
+
+def _read_config_cached(config_file: Path) -> configparser.ConfigParser:
+    """Return a parsed ConfigParser for ``config_file``, cached by mtime.
+
+    Raises ``OSError`` when the file is missing, matching what callers
+    already handle for unreadable configs.
+    """
+    stat = os.stat(config_file)
+    key = (stat.st_mtime_ns, stat.st_size)
+    with _CONFIG_PARSE_LOCK:
+        cached = _CONFIG_PARSE_CACHE.get(config_file)
+        if cached is not None and cached[0] == key:
+            return cached[1]
+    config = configparser.ConfigParser()
+    config.read(config_file)
+    with _CONFIG_PARSE_LOCK:
+        _CONFIG_PARSE_CACHE[config_file] = (key, config)
+    return config
 
 
 class Utils:
@@ -156,10 +186,9 @@ class Utils:
         an error is logged and an empty dictionary is returned.
         """
         params = {}
-        config = configparser.ConfigParser()
 
         try:
-            config.read(self.config_file)
+            config = _read_config_cached(self.config_file)
             options = config.options(section)
 
             for option in options:
@@ -431,6 +460,8 @@ def get_parallel_config(logger=None, config_file=None):
         'parallel_obs_variables': False,
         'parallel_2d_interp': False,
         'parallel_extract_slots': 2,
+        'coops_request_concurrency': 2,
+        'coops_request_gap_sec': 0.5,
     }
 
     if logger is None:
@@ -503,11 +534,30 @@ def get_parallel_config(logger=None, config_file=None):
         except ValueError:
             pass
 
+    # Parse CO-OPS rate-limit overrides. These feed the process-wide
+    # limiter in retrieve_t_and_c_station (concurrent in-flight GETs and
+    # minimum start-to-start gap). Defaults match the values tuned
+    # against CO-OPS throttling on long historical windows; raising them
+    # risks HTTP 403 chunk drops, so they are opt-in per run.
+    val = raw.get('coops_request_concurrency', '').strip().lower()
+    if val:
+        try:
+            result['coops_request_concurrency'] = min(max(1, int(val)), 8)
+        except ValueError:
+            pass
+    val = raw.get('coops_request_gap_sec', '').strip().lower()
+    if val:
+        try:
+            result['coops_request_gap_sec'] = min(max(0.0, float(val)), 10.0)
+        except ValueError:
+            pass
+
     # If parallelization is globally disabled, force all workers to 1
     if not result['parallel_enabled']:
         for key in int_keys + ['ha_workers']:
             result[key] = 1
         result['parallel_extract_slots'] = 1
+        result['coops_request_concurrency'] = 1
 
     return result
 

--- a/src/ofs_skill/obs_retrieval/write_obs_ctlfile.py
+++ b/src/ofs_skill/obs_retrieval/write_obs_ctlfile.py
@@ -176,6 +176,21 @@ def _normalize_vdatum_name(name: str) -> str:
     return name
 
 
+def _ctl_availability_probe_enabled(config_file, logger) -> bool:
+    """Read the ``[settings] ctl_availability_probe`` escape hatch.
+
+    Defaults to True (probe enabled) when the key or section is absent.
+    False restores the full-download currents scan at ctl-file creation
+    — kept as an operator escape hatch because the probe trades the
+    exhaustive per-bin window downloads for short availability samples.
+    """
+    settings_params = utils.Utils(config_file).read_config_section(
+        'settings', logger
+    )
+    raw = settings_params.get('ctl_availability_probe', 'True')
+    return str(raw).strip().lower() in ('true', '1', 'yes')
+
+
 def _emit_coops_currents_entries(
     id_number,
     name,
@@ -274,6 +289,7 @@ def _process_coops_station(
     bin_overrides=None,
     config_file=None,
     control_files_path=None,
+    availability_probe=False,
 ):
     """Process a single CO-OPS station."""
     try:
@@ -294,6 +310,7 @@ def _process_coops_station(
             only_bins=only_bins,
             config_file=config_file,
             control_files_path=control_files_path,
+            availability_probe=(availability_probe and variable == 'currents'),
         )
         if variable == 'water_level':
             datum_found = None
@@ -827,6 +844,7 @@ def _process_variable(
     logger,
     currents_bins_overrides=None,
     config_file=None,
+    availability_probe=False,
 ):
     """Process all stations for a single variable. Writes .ctl file."""
     var_name_map = {
@@ -887,6 +905,7 @@ def _process_variable(
                         station_overrides,
                         config_file=config_file,
                         control_files_path=control_files_path,
+                        availability_probe=availability_probe,
                     )
                 )
 
@@ -1113,6 +1132,13 @@ def write_obs_ctlfile(
 
     reset_run_counters()
 
+    availability_probe = _ctl_availability_probe_enabled(config_file, logger)
+    if not availability_probe:
+        logger.info(
+            'ctl_availability_probe=False: CO-OPS currents ctl scan will '
+            'download the full window for every bin.'
+        )
+
     with ThreadPoolExecutor(max_workers=len(var_list)) as executor:
         futures = []
         for variable in var_list:
@@ -1132,6 +1158,7 @@ def write_obs_ctlfile(
                     logger,
                     currents_bins_overrides,
                     config_file,
+                    availability_probe=availability_probe,
                 )
             )
 

--- a/tests/coops_rate_limit_config_test.py
+++ b/tests/coops_rate_limit_config_test.py
@@ -1,0 +1,145 @@
+"""
+Tests for the configurable CO-OPS rate limiter and the parsed-config
+cache.
+
+``coops_request_concurrency`` / ``coops_request_gap_sec`` in the
+[parallelization] section feed ``configure_coops_rate_limit`` in
+``retrieve_t_and_c_station``. The config parse cache in ``utils`` keeps
+repeated section reads in memory, invalidated by file mtime/size.
+"""
+
+import importlib
+import logging
+
+from ofs_skill.obs_retrieval import utils
+from ofs_skill.obs_retrieval.utils import get_parallel_config
+
+# The package __init__ re-exports the function under the same name as
+# its module, so attribute-style imports resolve to the function.
+rtc = importlib.import_module(
+    'ofs_skill.obs_retrieval.retrieve_t_and_c_station')
+
+logger = logging.getLogger(__name__)
+
+
+def _write_conf(path, parallel_lines):
+    body = '[parallelization]\n' + '\n'.join(parallel_lines) + '\n'
+    path.write_text(body, encoding='utf-8')
+    return path
+
+
+class TestParallelConfigKeys:
+    def test_defaults_present(self):
+        cfg = get_parallel_config(logger)
+        assert cfg['coops_request_concurrency'] >= 1
+        assert cfg['coops_request_gap_sec'] >= 0.0
+
+    def test_overrides_parsed(self, tmp_path):
+        conf = _write_conf(tmp_path / 'ofs_dps.conf', [
+            'coops_request_concurrency=4',
+            'coops_request_gap_sec=0.25',
+        ])
+        cfg = get_parallel_config(logger, config_file=conf)
+        assert cfg['coops_request_concurrency'] == 4
+        assert cfg['coops_request_gap_sec'] == 0.25
+
+    def test_overrides_clamped(self, tmp_path):
+        conf = _write_conf(tmp_path / 'ofs_dps.conf', [
+            'coops_request_concurrency=99',
+            'coops_request_gap_sec=-3',
+        ])
+        cfg = get_parallel_config(logger, config_file=conf)
+        assert cfg['coops_request_concurrency'] == 8
+        assert cfg['coops_request_gap_sec'] == 0.0
+
+    def test_invalid_values_keep_defaults(self, tmp_path):
+        conf = _write_conf(tmp_path / 'ofs_dps.conf', [
+            'coops_request_concurrency=fast',
+            'coops_request_gap_sec=snail',
+        ])
+        cfg = get_parallel_config(logger, config_file=conf)
+        assert cfg['coops_request_concurrency'] == 2
+        assert cfg['coops_request_gap_sec'] == 0.5
+
+    def test_parallel_disabled_forces_serial_coops(self, tmp_path):
+        conf = _write_conf(tmp_path / 'ofs_dps.conf', [
+            'parallel_enabled=False',
+            'coops_request_concurrency=4',
+        ])
+        cfg = get_parallel_config(logger, config_file=conf)
+        assert cfg['coops_request_concurrency'] == 1
+
+
+class TestConfigureCoopsRateLimit:
+    def setup_method(self):
+        self._orig = (rtc._COOPS_CONCURRENCY_LIMIT,
+                      rtc._COOPS_MIN_REQUEST_GAP_SEC,
+                      rtc._coops_request_semaphore)
+
+    def teardown_method(self):
+        (rtc._COOPS_CONCURRENCY_LIMIT,
+         rtc._COOPS_MIN_REQUEST_GAP_SEC,
+         rtc._coops_request_semaphore) = self._orig
+
+    def test_defaults_are_noop(self):
+        semaphore_before = rtc._coops_request_semaphore
+        rtc.configure_coops_rate_limit(concurrency=2, gap_sec=0.5)
+        assert rtc._coops_request_semaphore is semaphore_before
+        assert rtc._COOPS_CONCURRENCY_LIMIT == 2
+        assert rtc._COOPS_MIN_REQUEST_GAP_SEC == 0.5
+
+    def test_none_is_noop(self):
+        semaphore_before = rtc._coops_request_semaphore
+        rtc.configure_coops_rate_limit(concurrency=None, gap_sec=None)
+        assert rtc._coops_request_semaphore is semaphore_before
+
+    def test_override_swaps_semaphore_and_gap(self):
+        semaphore_before = rtc._coops_request_semaphore
+        rtc.configure_coops_rate_limit(concurrency=3, gap_sec=0.25,
+                                       logger=logger)
+        assert rtc._coops_request_semaphore is not semaphore_before
+        assert rtc._COOPS_CONCURRENCY_LIMIT == 3
+        assert rtc._COOPS_MIN_REQUEST_GAP_SEC == 0.25
+
+    def test_floor_of_one(self):
+        rtc.configure_coops_rate_limit(concurrency=0, gap_sec=-1.0)
+        assert rtc._COOPS_CONCURRENCY_LIMIT == 1
+        assert rtc._COOPS_MIN_REQUEST_GAP_SEC == 0.0
+
+
+class TestConfigParseCache:
+    def test_cache_hit_returns_same_parser(self, tmp_path):
+        conf = _write_conf(tmp_path / 'a.conf', ['obs_coops_workers=3'])
+        first = utils._read_config_cached(conf)
+        second = utils._read_config_cached(conf)
+        assert first is second
+
+    def test_modified_file_reparses(self, tmp_path):
+        import os
+
+        conf = _write_conf(tmp_path / 'a.conf', ['obs_coops_workers=3'])
+        first = utils._read_config_cached(conf)
+        _write_conf(conf, ['obs_coops_workers=5'])
+        # Force a distinct mtime even on coarse-resolution filesystems.
+        stat = os.stat(conf)
+        os.utime(conf, ns=(stat.st_atime_ns, stat.st_mtime_ns + 1_000_000))
+
+        second = utils._read_config_cached(conf)
+        assert second is not first
+        assert second.get('parallelization', 'obs_coops_workers') == '5'
+
+    def test_read_config_section_uses_fresh_values(self, tmp_path):
+        import os
+
+        conf = _write_conf(tmp_path / 'b.conf', ['obs_coops_workers=3'])
+        params = utils.Utils(conf).read_config_section(
+            'parallelization', logger)
+        assert params['obs_coops_workers'] == '3'
+
+        _write_conf(conf, ['obs_coops_workers=7'])
+        stat = os.stat(conf)
+        os.utime(conf, ns=(stat.st_atime_ns, stat.st_mtime_ns + 1_000_000))
+
+        params = utils.Utils(conf).read_config_section(
+            'parallelization', logger)
+        assert params['obs_coops_workers'] == '7'

--- a/tests/ctl_availability_probe_test.py
+++ b/tests/ctl_availability_probe_test.py
@@ -1,0 +1,468 @@
+"""
+Tests for the ctl-stage CO-OPS currents availability probe (issue #239).
+
+At ctl-file creation the only download-derived fact the emitter uses is
+per-bin data presence, so ``retrieve_t_and_c_station(...,
+availability_probe=True)`` replaces the per-bin full-window downloads
+with one no-bin full-window scan (30-day chunks, early stop) plus one
+short-range per-bin confirmation anchored at the known-data timestamp.
+
+Covers:
+- probe emits exactly the bins whose confirmation returns data;
+- dead station rejected after C(W) chunk requests and nothing else
+  (the request-count collapse is the point of the feature);
+- "Wrong Bin Number" rejection (null real_time_bin) retried with an
+  explicit metadata bin;
+- station whose data starts mid-window is found by a later chunk
+  (the bh0101 scenario — head-only sampling would false-reject);
+- bin-depth-shift stations scan/anchor inside the most recent
+  deployment period only;
+- ``only_bins`` restricts the confirmation requests;
+- ``availability_probe=False`` keeps the full-download path;
+- side-looking stations run the single pinned-bin scan, no confirms;
+- the ``[settings] ctl_availability_probe`` escape hatch and its
+  threading through ``_process_coops_station``.
+
+All HTTP is mocked at the ``_get_with_retry`` seam; no test touches the
+real CO-OPS API.
+"""
+
+from __future__ import annotations
+
+import importlib
+import logging
+import re
+from unittest.mock import patch
+
+import pandas as pd
+import pytest
+
+rtc = importlib.import_module(
+    'ofs_skill.obs_retrieval.retrieve_t_and_c_station')
+woc = importlib.import_module(
+    'ofs_skill.obs_retrieval.write_obs_ctlfile')
+
+API = 'https://api.example/api/prod'
+MDAPI = 'https://api.example/mdapi/prod'
+STATION = 'cb9999'
+
+NO_DATA = {'error': {'message': (
+    'No data was found. This product may not be offered at this '
+    'station at the requested time.')}}
+WRONG_BIN = {'error': {'message': (
+    ' Wrong Bin Number: The Bin Number cannot be null or empty for '
+    'the currents survey')}}
+
+
+@pytest.fixture
+def logger():
+    logging.basicConfig(level=logging.INFO)
+    return logging.getLogger('ctl_availability_probe_test')
+
+
+def _rows(timestamps, bin_num):
+    return [
+        {'t': t, 's': '50', 'd': '90', 'b': str(bin_num)}
+        for t in timestamps
+    ]
+
+
+def _updown_bins_payload(real_time_bin=2):
+    return {
+        'nbr_of_bins': 3,
+        'units': 'metric',
+        'real_time_bin': real_time_bin,
+        'bins': [
+            {'num': 1, 'depth': 2.0, 'distance': 2.0, 'qc_flag': 1},
+            {'num': 2, 'depth': 4.0, 'distance': 4.0, 'qc_flag': 1},
+            {'num': 3, 'depth': 6.0, 'distance': 6.0, 'qc_flag': 1},
+        ],
+    }
+
+
+def _deployment_info(orientation='up', deployments=None):
+    if deployments is None:
+        deployments = [
+            {'deployed': '2026-01-01 00:00:00', 'retrieved': ''},
+        ]
+    return {
+        'orientation': orientation,
+        'sensor_depth': 8.5,
+        'measured_depth': 9.0,
+        'height_from_bottom': 0.5,
+        'deployments': deployments,
+    }
+
+
+def _prime_caches(bins_payload, deployment_info, has_depth_shifts=False):
+    """Pin all MDAPI metadata in the module caches so the only HTTP
+    traffic the test sees is datagetter traffic through _get_with_retry."""
+    rtc._depth_cache.clear()
+    rtc._depth_cache[STATION] = bins_payload
+    rtc._station_info_cache.clear()
+    rtc._station_info_cache[STATION] = {'height_from_bottom': 0.5}
+    rtc._station_deployment_cache.clear()
+    rtc._station_deployment_cache[STATION] = deployment_info
+    with rtc._bin_depth_change_cache_lock:
+        rtc._bin_depth_change_cache.clear()
+        rtc._bin_depth_change_cache[STATION] = has_depth_shifts
+
+
+class _FakeDatagetter:
+    """Recording stand-in for ``_get_with_retry``."""
+
+    def __init__(self, handler):
+        self.handler = handler
+        self.calls = []  # (url, return_error_body)
+
+    def __call__(self, url, station_id, context, logger,
+                 return_error_body=False):
+        self.calls.append((url, return_error_body))
+        return self.handler(url)
+
+    @property
+    def urls(self):
+        return [url for url, _ in self.calls]
+
+    def scan_urls(self):
+        return [u for u in self.urls if 'begin_date=' in u]
+
+    def confirm_urls(self):
+        return [u for u in self.urls if 'range=24' in u]
+
+
+def _bin_of(url):
+    m = re.search(r'[?&]bin=(\d+)', url)
+    return int(m.group(1)) if m else None
+
+
+def _run_probe(fake, logger, start_date='20260201', end_date='20260210',
+               only_bins=None, availability_probe=True):
+    with patch.object(rtc, '_get_with_retry', fake):
+        return rtc._retrieve_currents_all_bins(
+            station_id=STATION,
+            start_date=start_date,
+            end_date=end_date,
+            api_url=API,
+            mdapi_url=MDAPI,
+            logger=logger,
+            only_bins=only_bins,
+            control_files_path=None,
+            availability_probe=availability_probe,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Up/down probe: emit exactly the confirmed bins
+# ---------------------------------------------------------------------------
+
+def test_probe_emits_exactly_confirmed_bins(logger):
+    _prime_caches(_updown_bins_payload(), _deployment_info())
+
+    def handler(url):
+        if 'range=24' in url:
+            bin_num = _bin_of(url)
+            if bin_num == 3:
+                return NO_DATA
+            return {'data': _rows(['2026-02-03 10:00'], bin_num)}
+        # no-bin full-window scan chunk
+        return {'data': _rows(['2026-02-03 10:00', '2026-02-03 10:06'], 2)}
+
+    fake = _FakeDatagetter(handler)
+    result = _run_probe(fake, logger)
+
+    assert isinstance(result, dict)
+    assert set(result.keys()) == {1, 2}
+    # attrs stamped from metadata, same as the full path
+    assert result[1].attrs['depth'] == 2.0
+    assert result[2].attrs['depth'] == 4.0
+    assert result[1].attrs['mounting_type'] == 'up'
+    assert result[1].attrs['height_from_bottom'] == 0.5
+    assert result[1].attrs['bin'] == 1
+    assert 'depth_unknown' not in result[1].attrs
+    # 10-day window = 1 scan chunk; then one confirm per candidate bin
+    assert len(fake.scan_urls()) == 1
+    assert _bin_of(fake.scan_urls()[0]) is None
+    assert sorted(_bin_of(u) for u in fake.confirm_urls()) == [1, 2, 3]
+    # confirm anchored at the day AFTER the known-data timestamp
+    assert all('end_date=20260204&range=24' in u
+               for u in fake.confirm_urls())
+    assert len(fake.calls) == 4
+
+
+# ---------------------------------------------------------------------------
+# Dead station: rejected after C(W) chunk requests, nothing else
+# ---------------------------------------------------------------------------
+
+def test_probe_dead_station_costs_only_window_chunks(logger):
+    _prime_caches(_updown_bins_payload(), _deployment_info())
+
+    fake = _FakeDatagetter(lambda url: NO_DATA)
+    # 20260101-20260401 in 30-day chunks: 0101, 0131, 0302, 0401 = 4
+    result = _run_probe(fake, logger, start_date='20260101',
+                        end_date='20260401')
+
+    assert result is None
+    assert len(fake.calls) == 4
+    assert all('begin_date=' in u for u in fake.urls)
+    # never fanned out per bin, never confirmed anything
+    assert all(_bin_of(u) is None for u in fake.urls)
+    assert fake.confirm_urls() == []
+
+
+# ---------------------------------------------------------------------------
+# "Wrong Bin Number" (null real_time_bin): explicit-bin retry of the chunk
+# ---------------------------------------------------------------------------
+
+def test_probe_wrong_bin_number_falls_back_to_explicit_bin(logger):
+    _prime_caches(_updown_bins_payload(real_time_bin=None),
+                  _deployment_info())
+
+    def handler(url):
+        if 'range=24' in url:
+            return {'data': _rows(['2026-02-02 05:00'], _bin_of(url))}
+        if _bin_of(url) is None:
+            return WRONG_BIN
+        return {'data': _rows(['2026-02-02 05:00'], _bin_of(url))}
+
+    fake = _FakeDatagetter(handler)
+    result = _run_probe(fake, logger)
+
+    assert set(result.keys()) == {1, 2, 3}
+    scans = fake.scan_urls()
+    assert len(scans) == 2
+    # first attempt is no-bin; the SAME chunk is retried with the first
+    # metadata bin pinned
+    assert _bin_of(scans[0]) is None
+    assert _bin_of(scans[1]) == 1
+    assert 'begin_date=20260201' in scans[0]
+    assert 'begin_date=20260201' in scans[1]
+    # scan requests opt in to seeing the API error body
+    assert all(flag for url, flag in fake.calls if 'begin_date=' in url)
+
+
+# ---------------------------------------------------------------------------
+# Mid-window data onset (bh0101 scenario): later chunk finds the data
+# ---------------------------------------------------------------------------
+
+def test_probe_finds_mid_window_start_station(logger):
+    _prime_caches(_updown_bins_payload(), _deployment_info())
+
+    def handler(url):
+        if 'range=24' in url:
+            return {'data': _rows(['2026-03-05 12:00'], _bin_of(url))}
+        if 'begin_date=20260302' in url:
+            return {'data': _rows(['2026-03-05 12:00'], 2)}
+        return NO_DATA
+
+    fake = _FakeDatagetter(handler)
+    result = _run_probe(fake, logger, start_date='20260101',
+                        end_date='20260401')
+
+    assert set(result.keys()) == {1, 2, 3}
+    # chunks 20260101 and 20260131 were empty; scan stopped at 20260302
+    # without requesting the 4th chunk
+    assert [u.split('begin_date=')[1][:8] for u in fake.scan_urls()] == \
+        ['20260101', '20260131', '20260302']
+    assert all('end_date=20260306&range=24' in u
+               for u in fake.confirm_urls())
+
+
+# ---------------------------------------------------------------------------
+# Bin-depth shifts: scan and confirms restricted to the latest deployment
+# ---------------------------------------------------------------------------
+
+def test_probe_restricts_to_most_recent_deployment_period(logger):
+    deployments = [
+        {'deployed': '2025-06-01 00:00:00',
+         'retrieved': '2026-02-01 12:00:00'},
+        {'deployed': '2026-03-01 00:00:00', 'retrieved': ''},
+    ]
+    _prime_caches(_updown_bins_payload(),
+                  _deployment_info(deployments=deployments),
+                  has_depth_shifts=True)
+
+    def handler(url):
+        if 'range=24' in url:
+            if _bin_of(url) == 3:
+                # rows exist but only OUTSIDE the most recent deployment
+                # period — must not confirm the bin
+                return {'data': _rows(['2026-01-15 00:00'], 3)}
+            return {'data': _rows(['2026-03-02 06:00'], _bin_of(url))}
+        return {'data': _rows(['2026-03-02 06:00'], 2)}
+
+    fake = _FakeDatagetter(handler)
+    result = _run_probe(fake, logger, start_date='20260101',
+                        end_date='20260401')
+
+    assert set(result.keys()) == {1, 2}
+    # the scan starts at the most recent deployment period, not the
+    # window start — data in the earlier period cannot flip the station
+    # to emit under the full path either
+    assert 'begin_date=20260301' in fake.scan_urls()[0]
+    assert all('end_date=20260303&range=24' in u
+               for u in fake.confirm_urls())
+
+
+# ---------------------------------------------------------------------------
+# only_bins (currents-bins CSV override) restricts the confirms
+# ---------------------------------------------------------------------------
+
+def test_probe_only_bins_restricts_confirms(logger):
+    _prime_caches(_updown_bins_payload(), _deployment_info())
+
+    def handler(url):
+        if 'range=24' in url:
+            return {'data': _rows(['2026-02-03 10:00'], _bin_of(url))}
+        return {'data': _rows(['2026-02-03 10:00'], 2)}
+
+    fake = _FakeDatagetter(handler)
+    result = _run_probe(fake, logger, only_bins={2})
+
+    assert set(result.keys()) == {2}
+    assert [_bin_of(u) for u in fake.confirm_urls()] == [2]
+
+
+# ---------------------------------------------------------------------------
+# availability_probe=False keeps the full-download path
+# ---------------------------------------------------------------------------
+
+def test_probe_disabled_uses_full_per_bin_downloads(logger):
+    _prime_caches(_updown_bins_payload(), _deployment_info())
+
+    def handler(url):
+        bin_num = _bin_of(url)
+        # full coverage so the gap-patching machinery stays quiet
+        return {'data': _rows(
+            ['2026-02-01 00:00', '2026-02-09 23:54'], bin_num)}
+
+    fake = _FakeDatagetter(handler)
+    result = _run_probe(fake, logger, availability_probe=False)
+
+    assert set(result.keys()) == {1, 2, 3}
+    # one full-window download per bin — the pre-probe behavior
+    assert sorted(_bin_of(u) for u in fake.urls) == [1, 2, 3]
+    assert all('begin_date=20260201' in u for u in fake.urls)
+    assert fake.confirm_urls() == []
+    assert len(result[1]) == 2
+    assert result[1].attrs['depth'] == 2.0
+
+
+# ---------------------------------------------------------------------------
+# Side-looking stations: single pinned-bin scan, no confirmation pass
+# ---------------------------------------------------------------------------
+
+def _side_bins_payload(real_time_bin=17):
+    return {
+        'nbr_of_bins': 20,
+        'units': 'metric',
+        'real_time_bin': real_time_bin,
+        'bins': [
+            {'num': i, 'depth': None, 'distance': 5.0 + 4.0 * i,
+             'qc_flag': 1}
+            for i in range(1, 21)
+        ],
+    }
+
+
+def test_probe_side_looking_scans_pinned_bin_only(logger):
+    _prime_caches(_side_bins_payload(),
+                  _deployment_info(orientation='side'))
+
+    def handler(url):
+        assert _bin_of(url) == 17  # never no-bin, never another bin
+        return {'data': _rows(['2026-02-05 00:00'], 17)}
+
+    fake = _FakeDatagetter(handler)
+    result = _run_probe(fake, logger)
+
+    assert set(result.keys()) == {17}
+    assert result[17].attrs['depth'] == 8.5  # sensor_depth
+    assert result[17].attrs['depth_unknown'] is False
+    assert result[17].attrs['mounting_type'] == 'side'
+    assert len(fake.calls) == 1
+    assert fake.confirm_urls() == []
+
+
+def test_probe_side_looking_dead_station_rejected(logger):
+    _prime_caches(_side_bins_payload(),
+                  _deployment_info(orientation='side'))
+
+    fake = _FakeDatagetter(lambda url: NO_DATA)
+    result = _run_probe(fake, logger, start_date='20260101',
+                        end_date='20260401')
+
+    assert result is None
+    assert len(fake.calls) == 4
+    assert all(_bin_of(u) == 17 for u in fake.urls)
+
+
+# ---------------------------------------------------------------------------
+# Config escape hatch: [settings] ctl_availability_probe
+# ---------------------------------------------------------------------------
+
+def _write_conf(tmp_path, body):
+    conf = tmp_path / 'ofs_dps.conf'
+    conf.write_text(body, encoding='utf-8')
+    return conf
+
+
+def test_ctl_availability_probe_defaults_true(tmp_path, logger):
+    conf = _write_conf(tmp_path, '[settings]\nstatic_plots=False\n')
+    assert woc._ctl_availability_probe_enabled(conf, logger) is True
+
+
+def test_ctl_availability_probe_false_disables(tmp_path, logger):
+    conf = _write_conf(
+        tmp_path, '[settings]\nctl_availability_probe=False\n')
+    assert woc._ctl_availability_probe_enabled(conf, logger) is False
+
+
+def test_ctl_availability_probe_missing_section_defaults_true(
+        tmp_path, logger):
+    conf = _write_conf(tmp_path, '[directories]\nhome=.\n')
+    assert woc._ctl_availability_probe_enabled(conf, logger) is True
+
+
+# ---------------------------------------------------------------------------
+# Threading: only the ctl-stage currents call sets availability_probe
+# ---------------------------------------------------------------------------
+
+def _probe_result_frame():
+    df = pd.DataFrame({
+        'DateTime': pd.to_datetime(['2026-02-03 10:00']),
+        'DEP01': [4.0],
+        'DIR': [90.0],
+        'OBS': [0.5],
+    })
+    df.attrs.update({
+        'bin': 2, 'depth': 4.0, 'mounting_type': 'up',
+        'height_from_bottom': 0.5,
+    })
+    return df
+
+
+def test_process_coops_station_passes_probe_flag_for_currents(logger):
+    with patch.object(woc, 'retrieve_t_and_c_station',
+                      return_value={2: _probe_result_frame()}) as mock_ret:
+        entries = woc._process_coops_station(
+            STATION, 'Test Station', -70.0, 42.0,
+            '20260201', '20260210', 'currents', 'cu',
+            'MLLW', ['MLLW'], 'necofs', logger,
+            availability_probe=True,
+        )
+    assert mock_ret.call_args.kwargs['availability_probe'] is True
+    assert len(entries) == 1
+    assert f'{STATION}_b02' in entries[0]
+
+
+def test_process_coops_station_no_probe_for_other_variables(logger):
+    with patch.object(woc, 'retrieve_t_and_c_station',
+                      return_value=None) as mock_ret:
+        woc._process_coops_station(
+            STATION, 'Test Station', -70.0, 42.0,
+            '20260201', '20260210', 'water_temperature', 'temp',
+            'MLLW', ['MLLW'], 'necofs', logger,
+            availability_probe=True,
+        )
+    assert mock_ret.call_args.kwargs['availability_probe'] is False

--- a/tests/ctl_creation_dedup_test.py
+++ b/tests/ctl_creation_dedup_test.py
@@ -1,0 +1,165 @@
+"""
+Tests for cross-thread dedup of station ctl file creation and the
+per-run cache of the bin-depth-change MDAPI audit (issue #239).
+
+``write_obs_ctlfile`` builds ctl files for ALL variables in one pass,
+so under parallel_variables every variable thread that finds its own
+ctl file missing would launch the same full build concurrently.
+``_create_station_ctl_file`` serializes the create path behind
+``_ctl_create_lock`` and re-checks existence after acquiring it.
+
+``check_bin_depth_changes`` fires an expanded ``deployments,bins``
+MDAPI request from two call sites per station scan; its result is now
+cached per station for the run and cleared by ``reset_run_counters``.
+"""
+
+import importlib
+import logging
+import os
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+from types import SimpleNamespace
+
+# The package __init__ re-exports functions under the same names as
+# their modules, so attribute-style imports resolve to the functions.
+gso = importlib.import_module(
+    'ofs_skill.obs_retrieval.get_station_observations')
+rtc = importlib.import_module(
+    'ofs_skill.obs_retrieval.retrieve_t_and_c_station')
+
+logger = logging.getLogger(__name__)
+
+
+class TestCtlCreationDedup:
+    N_THREADS = 4
+
+    def _run_concurrent_create(self, tmp_path, monkeypatch):
+        """Race N_THREADS variable threads into the ctl create path."""
+        ctl_file_path = tmp_path / 'cbofs_cu_station.ctl'
+        barrier = threading.Barrier(self.N_THREADS)
+        build_calls = []
+        parsed_sentinel = (['station'], ['metadata'])
+
+        def fake_write_obs_ctlfile(start_date, end_date, datum, path, ofs,
+                                   stationowner, var_list, logger_arg,
+                                   **kwargs):
+            build_calls.append(threading.get_ident())
+            # Widen the window a real multi-minute build would occupy so
+            # a missing lock reliably produces duplicate builds.
+            time.sleep(0.1)
+            ctl_file_path.write_text('marker', encoding='utf-8')
+
+        def fake_extract(filepath):
+            return parsed_sentinel if os.path.isfile(filepath) else None
+
+        monkeypatch.setattr(gso, 'write_obs_ctlfile',
+                            fake_write_obs_ctlfile)
+        monkeypatch.setattr(gso, 'station_ctl_file_extract', fake_extract)
+
+        def worker():
+            barrier.wait()
+            return gso._create_station_ctl_file(
+                str(ctl_file_path),
+                SimpleNamespace(currents_bins_csv=None),
+                'MLLW', '20260301', '20260308', str(tmp_path), 'cbofs',
+                ['co-ops'],
+                ['water_level', 'water_temperature', 'salinity',
+                 'currents'],
+                logger,
+            )
+
+        with ThreadPoolExecutor(max_workers=self.N_THREADS) as executor:
+            futures = [executor.submit(worker)
+                       for _ in range(self.N_THREADS)]
+            results = [f.result() for f in futures]
+        return build_calls, results, parsed_sentinel
+
+    def test_concurrent_threads_build_exactly_once(
+            self, tmp_path, monkeypatch):
+        build_calls, results, parsed = self._run_concurrent_create(
+            tmp_path, monkeypatch)
+        assert len(build_calls) == 1
+        assert results == [parsed] * self.N_THREADS
+
+    def test_existing_file_skips_build(self, tmp_path, monkeypatch):
+        ctl_file_path = tmp_path / 'cbofs_wl_station.ctl'
+        ctl_file_path.write_text('marker', encoding='utf-8')
+        parsed_sentinel = (['station'], ['metadata'])
+        build_calls = []
+
+        monkeypatch.setattr(
+            gso, 'write_obs_ctlfile',
+            lambda *args, **kwargs: build_calls.append(args))
+        monkeypatch.setattr(
+            gso, 'station_ctl_file_extract',
+            lambda filepath: parsed_sentinel
+            if os.path.isfile(filepath) else None)
+
+        result = gso._create_station_ctl_file(
+            str(ctl_file_path), SimpleNamespace(currents_bins_csv=None),
+            'MLLW', '20260301', '20260308', str(tmp_path), 'cbofs',
+            ['co-ops'], ['water_level'], logger,
+        )
+        assert result == parsed_sentinel
+        assert build_calls == []
+
+
+class TestBinDepthChangeCache:
+    SHIFTING_PAYLOAD = {'stations': [{'bins': [
+        {'deploymentId': 1, 'num': 1, 'distance': 2.0},
+        {'deploymentId': 2, 'num': 1, 'distance': 5.0},
+    ]}]}
+    STABLE_PAYLOAD = {'stations': [{'bins': [
+        {'deploymentId': 1, 'num': 1, 'distance': 2.0},
+        {'deploymentId': 2, 'num': 1, 'distance': 2.0},
+    ]}]}
+
+    def _patch_fetch(self, monkeypatch, payload):
+        calls = []
+
+        def fake_get_with_retry(url, *args, **kwargs):
+            calls.append(url)
+            return payload
+
+        monkeypatch.setattr(rtc, '_get_with_retry', fake_get_with_retry)
+        return calls
+
+    def test_second_call_served_from_cache(self, monkeypatch):
+        rtc.reset_run_counters()
+        calls = self._patch_fetch(monkeypatch, self.SHIFTING_PAYLOAD)
+        first = rtc.check_bin_depth_changes(
+            'cb0102', 'https://mdapi.invalid', logger)
+        second = rtc.check_bin_depth_changes(
+            'cb0102', 'https://mdapi.invalid', logger)
+        assert first is True
+        assert second is True
+        assert len(calls) == 1
+
+    def test_false_result_is_cached_too(self, monkeypatch):
+        rtc.reset_run_counters()
+        calls = self._patch_fetch(monkeypatch, self.STABLE_PAYLOAD)
+        assert rtc.check_bin_depth_changes(
+            'n03020', 'https://mdapi.invalid', logger) is False
+        assert rtc.check_bin_depth_changes(
+            'n03020', 'https://mdapi.invalid', logger) is False
+        assert len(calls) == 1
+
+    def test_stations_cached_independently(self, monkeypatch):
+        rtc.reset_run_counters()
+        calls = self._patch_fetch(monkeypatch, self.SHIFTING_PAYLOAD)
+        rtc.check_bin_depth_changes(
+            'cb0102', 'https://mdapi.invalid', logger)
+        rtc.check_bin_depth_changes(
+            'cb0201', 'https://mdapi.invalid', logger)
+        assert len(calls) == 2
+
+    def test_reset_run_counters_clears_cache(self, monkeypatch):
+        rtc.reset_run_counters()
+        calls = self._patch_fetch(monkeypatch, self.SHIFTING_PAYLOAD)
+        rtc.check_bin_depth_changes(
+            'cb0102', 'https://mdapi.invalid', logger)
+        rtc.reset_run_counters()
+        rtc.check_bin_depth_changes(
+            'cb0102', 'https://mdapi.invalid', logger)
+        assert len(calls) == 2

--- a/tests/model_properties_deepcopy_test.py
+++ b/tests/model_properties_deepcopy_test.py
@@ -1,0 +1,76 @@
+"""
+Tests for ModelProperties.__deepcopy__.
+
+The plotting fan-out deep-copies ``prop`` per station (twice), and the
+per-variable extraction dispatch deep-copies it per thread. When the
+cached model dataset (``prop._cached_model``, a lazy xarray/dask graph
+referencing hundreds of backing files) rode along, every copy duplicated
+the whole graph. ``__deepcopy__`` must skip the cache attributes while
+still producing fully isolated copies of everything else.
+"""
+
+import copy
+
+from ofs_skill.model_processing.model_properties import ModelProperties
+
+
+class _ExpensiveToCopy:
+    """Stand-in for the cached xarray dataset: raises if deep-copied."""
+
+    def __deepcopy__(self, memo):
+        raise AssertionError(
+            'cached model dataset must not be deep-copied')
+
+
+def _make_prop():
+    prop = ModelProperties()
+    prop.ofs = 'necofs'
+    prop.whichcast = 'nowcast'
+    prop.var_list = ['water_level', 'currents']
+    prop.start_date_full = '2026-02-16T00:00:00Z'
+    return prop
+
+
+def test_deepcopy_skips_cached_model():
+    prop = _make_prop()
+    prop._cached_model = _ExpensiveToCopy()
+    prop._cached_model_key = ('necofs', 'nowcast')
+
+    clone = copy.deepcopy(prop)
+
+    assert not hasattr(clone, '_cached_model')
+    assert not hasattr(clone, '_cached_model_key')
+    # The original keeps its cache untouched.
+    assert isinstance(prop._cached_model, _ExpensiveToCopy)
+
+
+def test_deepcopy_isolates_mutable_attributes():
+    prop = _make_prop()
+    clone = copy.deepcopy(prop)
+
+    assert clone.var_list == ['water_level', 'currents']
+    clone.var_list.append('salinity')
+    assert prop.var_list == ['water_level', 'currents']
+
+    clone.ofs = 'cbofs'
+    assert prop.ofs == 'necofs'
+
+
+def test_deepcopy_without_cache_attributes():
+    """Props that never had a cached model copy cleanly."""
+    prop = _make_prop()
+    clone = copy.deepcopy(prop)
+    assert clone.ofs == prop.ofs
+    assert not hasattr(clone, '_cached_model')
+
+
+def test_deepcopy_inside_container():
+    """deepcopy of a structure holding the prop honors the guard."""
+    prop = _make_prop()
+    prop._cached_model = _ExpensiveToCopy()
+    holder = {'prop': prop}
+
+    clone_holder = copy.deepcopy(holder)
+
+    assert not hasattr(clone_holder['prop'], '_cached_model')
+    assert clone_holder['prop'].ofs == 'necofs'

--- a/tests/obs_currents_only_bins_test.py
+++ b/tests/obs_currents_only_bins_test.py
@@ -1,0 +1,116 @@
+"""
+Tests for the CO-OPS currents ``only_bins`` restriction in
+``_fetch_and_format_station``.
+
+The station ctl file carries one row per virtual ADCP bin
+(``{parent}_b{NN}``). The obs fetch for such a row must restrict the
+CO-OPS retrieval to that one bin (``only_bins={NN}``) instead of
+fetching every bin of the parent station and discarding all but one —
+K bins per station previously meant K× the CO-OPS requests per row.
+"""
+
+import importlib
+from unittest.mock import patch
+
+import pandas as pd
+
+# The package __init__ re-exports the function under the same name as
+# its module, so attribute-style imports resolve to the function.
+gso = importlib.import_module(
+    'ofs_skill.obs_retrieval.get_station_observations')
+
+
+class _MockLogger:
+    def info(self, *a, **k):
+        pass
+
+    def warning(self, *a, **k):
+        pass
+
+    def error(self, *a, **k):
+        pass
+
+
+def _bin_df(value):
+    return pd.DataFrame({
+        'DateTime': pd.date_range('2026-02-16', periods=3, freq='6min'),
+        'DEP01': [4.0, 4.0, 4.0],
+        'OBS': [value, value, value],
+    })
+
+
+def _call(station_id, variable='currents', retrieve_mock=None,
+          tmp_path=None):
+    """Invoke _fetch_and_format_station with retrieval + formatting mocked."""
+    with patch.object(gso, 'retrieve_t_and_c_station',
+                      side_effect=retrieve_mock) as mock_retrieve, \
+            patch.object(gso, '_format_timeseries',
+                         return_value=['formatted-line']):
+        result = gso._fetch_and_format_station(
+            station_info=[station_id, 'x', 'y', 'CO-OPS', 'z'],
+            station_metadata=['MLLW', 0.0, 0.0],
+            variable=variable,
+            name_var='cu' if variable == 'currents' else 'wl',
+            datum='MLLW',
+            datum_list=['MLLW'],
+            start_date='20260216',
+            end_date='20260218',
+            start_date_full='2026-02-16-00:00:00',
+            end_date_full='2026-02-18-00:00:00',
+            ofs='necofs',
+            data_observations_1d_station_path=str(tmp_path),
+            logger=_MockLogger(),
+            control_files_path=str(tmp_path),
+        )
+    return result, mock_retrieve
+
+
+def test_virtual_bin_row_restricts_fetch(tmp_path):
+    """A ``{parent}_b{NN}`` row passes only_bins={NN} and fetches once."""
+    calls = []
+
+    def fake_retrieve(retrieve_input, logger, control_files_path,
+                      config_file=None, only_bins=None):
+        calls.append(only_bins)
+        return {3: _bin_df(1.0)}
+
+    result, _ = _call('1234567_b03', retrieve_mock=fake_retrieve,
+                      tmp_path=tmp_path)
+
+    assert result == '1234567_b03'
+    assert calls == [{3}]
+
+
+def test_missing_bin_retries_unrestricted(tmp_path):
+    """Empty restricted fetch falls back to the legacy all-bins fetch."""
+    calls = []
+
+    def fake_retrieve(retrieve_input, logger, control_files_path,
+                      config_file=None, only_bins=None):
+        calls.append(only_bins)
+        if only_bins is not None:
+            return {}
+        return {5: _bin_df(2.0)}
+
+    result, _ = _call('1234567_b03', retrieve_mock=fake_retrieve,
+                      tmp_path=tmp_path)
+
+    # Restricted first, unrestricted retry second, fallback bin used.
+    assert calls == [{3}, None]
+    assert result == '1234567_b03'
+
+
+def test_legacy_id_fetches_all_bins(tmp_path):
+    """A non-virtual station ID keeps the unrestricted fetch."""
+    calls = []
+
+    def fake_retrieve(retrieve_input, logger, control_files_path,
+                      config_file=None, only_bins=None):
+        calls.append(only_bins)
+        return {1: _bin_df(3.0)}
+
+    result, _ = _call('1234567', retrieve_mock=fake_retrieve,
+                      tmp_path=tmp_path)
+
+    assert calls == [None]
+    assert result == '1234567'

--- a/tests/obs_currents_only_bins_test.py
+++ b/tests/obs_currents_only_bins_test.py
@@ -82,7 +82,7 @@ def test_virtual_bin_row_restricts_fetch(tmp_path):
 
 
 def test_missing_bin_retries_unrestricted(tmp_path):
-    """Empty restricted fetch falls back to the legacy all-bins fetch."""
+    """Empty restricted fetch triggers the unrestricted all-bins retry."""
     calls = []
 
     def fake_retrieve(retrieve_input, logger, control_files_path,
@@ -95,9 +95,10 @@ def test_missing_bin_retries_unrestricted(tmp_path):
     result, _ = _call('1234567_b03', retrieve_mock=fake_retrieve,
                       tmp_path=tmp_path)
 
-    # Restricted first, unrestricted retry second, fallback bin used.
+    # Restricted first, unrestricted retry second. The retry still lacks
+    # bin 3, so the virtual row is skipped rather than fed bin 5's data.
     assert calls == [{3}, None]
-    assert result == '1234567_b03'
+    assert result is None
 
 
 def test_legacy_id_fetches_all_bins(tmp_path):

--- a/tests/obs_virtual_bin_fallback_test.py
+++ b/tests/obs_virtual_bin_fallback_test.py
@@ -1,0 +1,141 @@
+"""
+Tests for the virtual-bin fallback hardening in
+``_fetch_and_format_station``.
+
+A ctl row with a virtual bin ID (``{parent}_b{NN}``) pins its depth and
+identity to bin NN. When the CO-OPS retrieval — including the
+unrestricted all-bins retry — still lacks that exact bin, the old code
+substituted the first available bin's data under bin NN's virtual ID
+and depth, silently corrupting skill statistics. Virtual rows must now
+skip the station with an ERROR instead; legacy non-virtual IDs (no
+``_b`` suffix) keep the first-available-bin fallback.
+"""
+
+import importlib
+import logging
+from unittest.mock import patch
+
+import pandas as pd
+
+gso = importlib.import_module(
+    'ofs_skill.obs_retrieval.get_station_observations')
+
+_LOGGER_NAME = 'obs_virtual_bin_fallback_test'
+
+
+def _bin_df(value):
+    return pd.DataFrame({
+        'DateTime': pd.date_range('2026-02-16', periods=3, freq='6min'),
+        'DEP01': [4.0, 4.0, 4.0],
+        'OBS': [value, value, value],
+    })
+
+
+def _call(station_id, retrieve_mock, tmp_path):
+    """Invoke _fetch_and_format_station with retrieval + formatting mocked."""
+    with patch.object(gso, 'retrieve_t_and_c_station',
+                      side_effect=retrieve_mock) as mock_retrieve, \
+            patch.object(gso, '_format_timeseries',
+                         return_value=['formatted-line']) as mock_format:
+        result = gso._fetch_and_format_station(
+            station_info=[station_id, 'x', 'y', 'CO-OPS', 'z'],
+            station_metadata=['MLLW', 0.0, 0.0],
+            variable='currents',
+            name_var='cu',
+            datum='MLLW',
+            datum_list=['MLLW'],
+            start_date='20260216',
+            end_date='20260218',
+            start_date_full='2026-02-16-00:00:00',
+            end_date_full='2026-02-18-00:00:00',
+            ofs='necofs',
+            data_observations_1d_station_path=str(tmp_path),
+            logger=logging.getLogger(_LOGGER_NAME),
+            control_files_path=str(tmp_path),
+        )
+    return result, mock_retrieve, mock_format
+
+
+def test_virtual_row_missing_bin_skips_with_error(tmp_path, caplog):
+    """Bin absent even after the retry -> ERROR log, no .obs, no substitute."""
+    def fake_retrieve(retrieve_input, logger, control_files_path,
+                      config_file=None, only_bins=None):
+        # Neither the restricted fetch nor the unrestricted retry has
+        # bin 3 — only bins 5 and 7 exist.
+        return {5: _bin_df(2.0), 7: _bin_df(2.5)}
+
+    with caplog.at_level(logging.ERROR, logger=_LOGGER_NAME):
+        result, _, mock_format = _call(
+            '1234567_b03', fake_retrieve, tmp_path)
+
+    assert result is None
+    mock_format.assert_not_called()
+    assert list(tmp_path.glob('*.obs')) == []
+    errors = [r for r in caplog.records if r.levelno == logging.ERROR]
+    assert len(errors) == 1
+    message = errors[0].getMessage()
+    assert '1234567_b03' in message
+    assert '[5, 7]' in message
+    assert 'skipping' in message
+
+
+def test_virtual_row_bin_present_after_retry_emits(tmp_path, caplog):
+    """Bin found by the unrestricted retry -> station emits normally."""
+    calls = []
+
+    def fake_retrieve(retrieve_input, logger, control_files_path,
+                      config_file=None, only_bins=None):
+        calls.append(only_bins)
+        if only_bins is not None:
+            return {}
+        return {3: _bin_df(1.0)}
+
+    with caplog.at_level(logging.DEBUG, logger=_LOGGER_NAME):
+        result, _, mock_format = _call(
+            '1234567_b03', fake_retrieve, tmp_path)
+
+    assert calls == [{3}, None]
+    assert result == '1234567_b03'
+    mock_format.assert_called_once()
+    obs_file = tmp_path / '1234567_b03_necofs_cu_station.obs'
+    assert obs_file.read_text(encoding='utf-8') == 'formatted-line\n'
+    assert not [r for r in caplog.records if r.levelno == logging.ERROR]
+
+
+def test_legacy_id_keeps_first_available_bin_fallback(tmp_path, caplog):
+    """A non-virtual ID still falls back to the first available bin."""
+    def fake_retrieve(retrieve_input, logger, control_files_path,
+                      config_file=None, only_bins=None):
+        return {7: _bin_df(3.0), 2: _bin_df(3.5)}
+
+    with caplog.at_level(logging.DEBUG, logger=_LOGGER_NAME):
+        result, mock_retrieve, mock_format = _call(
+            '1234567', fake_retrieve, tmp_path)
+
+    # Legacy rows fetch unrestricted once and use the lowest bin number.
+    assert [c.kwargs.get('only_bins')
+            for c in mock_retrieve.call_args_list] == [None]
+    assert result == '1234567'
+    mock_format.assert_called_once()
+    assert (tmp_path / '1234567_necofs_cu_station.obs').exists()
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert any('using bin 2' in r.getMessage() for r in warnings)
+    assert not [r for r in caplog.records if r.levelno == logging.ERROR]
+
+
+def test_virtual_row_empty_dict_after_retry_skips_quietly(tmp_path, caplog):
+    """No bins at all after the retry -> plain no-data skip, no ERROR."""
+    def fake_retrieve(retrieve_input, logger, control_files_path,
+                      config_file=None, only_bins=None):
+        return {}
+
+    with caplog.at_level(logging.DEBUG, logger=_LOGGER_NAME):
+        result, _, mock_format = _call(
+            '1234567_b03', fake_retrieve, tmp_path)
+
+    # An empty dict means the station is simply dead in the window —
+    # the pre-existing info-level skip applies, not the ERROR path.
+    assert result is None
+    mock_format.assert_not_called()
+    assert list(tmp_path.glob('*.obs')) == []
+    assert not [r for r in caplog.records if r.levelno == logging.ERROR]


### PR DESCRIPTION
### Description of Changes

First PR under the runtime-optimization umbrella #229, motivated by modelers running multi-month NECOFS 1D skill assessments who need faster turnaround. This bundles the three quick wins — each is small, low-risk, and behavior-preserving for existing configurations — plus the ctl-stage currents-scan work from #239 (dedup + availability probe), which timing-log analysis of the NECOFS runs showed is the single largest time sink in the whole pipeline.

Closes #230, closes #231, closes #232, closes #239.

**1. CO-OPS currents: fetch only the requested ADCP bin (#230).** The station ctl file has one row per virtual bin (`{parent}_b{NN}`), but the obs fetch for each row retrieved **every** bin of the parent ADCP and kept one — K bins per station meant K× the CO-OPS requests per row (K² per station), all funneled through the shared 2-req/s rate limiter. A 20-bin ADCP over a year was ~5,200 requests where ~260 suffice. `only_bins` was already plumbed through the retrieval stack (and used by `write_obs_ctlfile`); the obs-side caller now passes `only_bins={bin_num}` for virtual-bin rows. If the pinned bin returns no data, the fetch retries unrestricted so the legacy any-available-bin fallback still applies.

**2. Stop deep-copying the model dataset per station (#231).** `get_skill` caches the loaded model dataset on `prop._cached_model` so extraction reuses it across variables. That prop then flows into plotting, where every station's dispatch runs `copy.deepcopy(prop)` twice. With no `__deepcopy__` guard on `ModelProperties`, each copy duplicated the entire lazy dask graph — ~580 dataset deep-copies on a 290-station NECOFS run, GIL-bound work that also serializes the plot threads and inflates memory. `ModelProperties.__deepcopy__` now skips `_cached_model` / `_cached_model_key`; the original prop keeps its cache, and copies come back without the attribute, which every consumer already treats as a cache miss (`getattr(..., None)`). The issue-#104 deepcopy stays in place — it just stops dragging a dataset along.

**3. Config plumbing (#232).**
- `get_parallel_config` was called without `config_file=` in `create_1dplot` (plot dispatch + forecast-cycle dispatch), `get_model_data` (download workers), and `run_harmonic_analysis` (both dispatch sites) — so per-OFS conf parallelization settings were silently ignored there and the repo-default conf read instead. All sites now pass the active `-c` config file.
- `Utils.read_config_section` re-ran `configparser.read()` from disk on every call — per variable, per plot dispatch, and (for the datums section) per station in the obs fan-out. Parses are now cached keyed on `(path, mtime, size)`, so an edited file still reparses; the redundant per-station datums re-read is removed outright.
- New `[parallelization]` keys `coops_request_concurrency` / `coops_request_gap_sec` make the process-wide CO-OPS limiter configurable. **Defaults are unchanged** (2 concurrent / 0.5 s gap — the values tuned against CO-OPS throttling on long historical windows); the conf example documents the 403 risk of raising them, and `parallel_enabled=False` forces concurrency back to 1.

**4. Ctl-file creation deduplicated across variable threads (#239).** With `parallel_variables=True`, all four variable threads found their own ctl file missing at startup and each launched the full `write_obs_ctlfile` build (which creates ctl files for every variable) — quadruplicating the CO-OPS currents availability scan. On the NECOFS timing run that duplication alone was ~95 of the 152-minute ctl phase. The create path now runs under a module-level lock with an existence re-check, so exactly one thread builds. (Also: the `check_bin_depth_changes` MDAPI lookup is now cached per station per run — it fired 8× per station.)

**5. Availability probe for the ctl-stage currents scan (#239).** At ctl time the only download-derived fact the emitter uses is per-bin data presence — every other ctl-row field comes from MDAPI metadata — yet the scan downloaded the full window for every bin of every candidate station, and ~93% of scanned NECOFS stations have no data at all. The ctl stage now establishes presence with one no-bin full-window pass per station (30-day chunks, early stop at the first in-window row, explicit-bin retry on the API's "Wrong Bin Number" rejection) plus one short per-bin confirmation at the known-data timestamp for live stations. Negative scans always cover the whole window (short head/tail sampling would false-reject stations whose data starts mid-window), stations with cross-deployment bin-depth shifts scan inside the most recent active period (matching the full retrieval's restriction), and metadata never decides emit/reject. The obs-retrieval stage keeps full downloads. New `[settings] ctl_availability_probe` key (default `True`); `False` restores the full-download scan.

**6. No wrong-bin substitution for virtual-bin stations (#239).** A ctl row with a virtual bin ID (`{parent}_bNN`) pins its identity and depth to bin NN; when retrieval lacked that exact bin, the obs stage silently substituted the first available bin's data under NN's ID and depth, corrupting skill statistics. Virtual rows now log an ERROR and skip the station; legacy non-virtual IDs keep the fallback unchanged.

Suggested labels: enhancement.

### Expected Outcome of Changes

- CO-OPS currents observation retrieval issues one bin's worth of requests per ctl row instead of all bins — the largest obs-side runtime win for currents-heavy OFS (NECOFS has ~146 currents stations). `.obs` file contents are unchanged.
- Cold-start ctl-file creation drops from hours to minutes on currents-heavy OFS: the currents availability scan goes from `bins × window-chunks` full downloads per station (×4 under `parallel_variables`) to roughly 1-2 requests per station, with **byte-identical ctl files** (verified live for CBOFS and SFBOFS). Measured end-to-end on cold 24-hour runs vs main: **CBOFS 32m57s → 6m06s (5.4×), SFBOFS 59m58s → 7m54s (7.6×), NECOFS 4h06m → 39m25s (6.2×, ctl phase 152 min → 16 min)** — timing tables and methodology in the PR comments. The gap grows with window length (a 6-month NECOFS window projects ~741 min of ctl scan on main vs ~15-20 min here). Warm runs (ctl files present) are unchanged — they already skip the scan.
- The plotting phase no longer deep-copies the model dataset per station: lower wall time and a much smaller memory footprint on large station counts. Plots are unchanged.
- Runs using `-c <per-OFS conf>` now actually honor `parallel_plotting`, `plot_workers`, `model_download_workers`, and `ha_workers` from that conf.
- No changes to output values, file formats, or the expected set of output files. All new configuration keys default to current behavior.

### Developer Questions and Checklist

**Is this a high priority PR? If yes, why and is there a date by which it needs to be merged?**
No hard deadline; it directly supports modelers running multi-month NECOFS skill assessments, so sooner helps them.

**Are there any changes needed to how the code should be run for operational runs? (Commands, flags, job timings, etc.)**
No. Commands and flags are unchanged. Two optional `[parallelization]` keys (`coops_request_concurrency`, `coops_request_gap_sec`) are available but default to current behavior; job timings should only improve (currents obs retrieval and the plotting phase get faster).

**Does this update need to be deployed for operational runs?**
No, not required — but deploying is beneficial (faster currents obs retrieval and plotting, lower memory).

**Does this update require front end/web app changes? (If yes, provide documentation to Min)**
No.

**Does this impact code development work on adding SCHISM?**
No.

**Does this impact code development work on adding ADCIRC?**
No.

**Does this impact the expected number of output files for integration tests (i.e., will the integration test fail even though code changes result in desired change in outputs?)**
No — same outputs, same file counts.

- [x] Developer's name is removed throughout the code?
- [x] Did you add relevant labels to the PR?
- [x] Have you run pylint and is the code at an acceptable pylint score (>8)? (8.84 on the new/edited modules and tests)
- [x] Jobs contain the appropriate file checking and handle errors for any missing data? (only_bins falls back to an unrestricted fetch when the pinned bin has no data; the config cache raises/logs through the existing missing-file handling; a dead-station probe rejects with the same `None` path as an empty full scan)
- [x] Is log free of critical ERRORs or WARNINGs? For errors that are not critical and can remain in code, is there sufficient handling and logging? (new WARNING only on the rare pinned-bin-empty retry; INFO lines when a CO-OPS rate-limit override is applied and for probe scan decisions; a new deliberate ERROR when a virtual-bin station's exact bin is unavailable — previously that case silently substituted another bin's data)

### Testing Instructions

**Unit tests** (no network needed):

```bash
python -m pytest tests/model_properties_deepcopy_test.py tests/obs_currents_only_bins_test.py tests/coops_rate_limit_config_test.py tests/ctl_creation_dedup_test.py tests/ctl_availability_probe_test.py tests/obs_virtual_bin_fallback_test.py -v
```

43 new tests covering: the deepcopy guard (cache skipped, mutable attributes isolated, container copies), the `only_bins` restriction + unrestricted fallback + legacy-ID passthrough, new config key parsing/clamping/invalid-value handling, limiter reconfiguration semantics, parse-cache hit/invalidation, the concurrent ctl-create race (exactly one build), bin-depth-audit caching, the availability probe (confirmed-bin emission, dead-station request counts, Wrong-Bin-Number retry, mid-window data onset, deployment-period restriction, `only_bins` filtering, probe-disabled parity, side-looking scans, config key), and the virtual-bin fallback hardening. Full suite: `python -m pytest tests/` — **1046 passed, 1 skipped** on this branch.

**Ctl probe equivalence check** (live, already performed — replicable): regenerate ctl files with this branch into an empty directory using the same dates/datum as an existing full-scan run and diff. I did this for CBOFS and SFBOFS against references generated by the pre-probe code (window 20260213–20260220, MLLW): all currents ctl files byte-identical (including gap-heavy s09010), wl/temp/salt identical for CBOFS; the SFBOFS wl/temp/salt files differed only by USGS stations that were in a verified USGS API outage when the reference was generated.

**Live spot-checks** (optional):

1. *only_bins*: run a currents obs retrieval against an OFS with a multi-bin ADCP station, e.g. `python ./bin/visualization/create_1dplot.py -o cbofs -p ./ -s 2026-07-01T00:00:00Z -e 2026-07-03T00:00:00Z -d MLLW -ws nowcast -t stations -vs currents`. The log should show per-bin datagetter calls only for each row's own bin; resulting `.obs` files should match a pre-PR run byte-for-byte.
2. *Config plumbing*: create a per-OFS conf with `parallel_plotting=True` and `plot_workers=6` under `[parallelization]`, run with `-c <that conf>`, and confirm the log line `Plotting N stations in parallel with 6 workers` (pre-PR this silently read the default conf and plotted sequentially).
3. *Rate-limit knob*: add `coops_request_concurrency=3` / `coops_request_gap_sec=0.25` to the conf and confirm the two INFO lines announcing the override at the start of obs retrieval. Leave unset to confirm no override lines appear (defaults in force).

### Reminder checklist for PR reviewer
_Checklist for the assigned reviewer to consult and check off_
- [ ] Run PEP8 compliance tests to ensure the code follows best practices
- [ ] Check that documentation in the script is sufficient
- [ ] Validate the output values (if applicable) to make sure the calculations are correct and make scientific/physical sense; include a comment on the pull request including what validation you performed, for replicability.
- [ ] Test code both on Windows and Linux (and MacOS, if available), using several OFS as test cases
- [ ] **Test for all 'cast' options: forecast_a, forecast_b, and nowcast**
- [ ] When approving or commenting on a pull request, add information on the calls you use in case they need to be replicated or referenced.
