### PR TITLE
Fix main CI: update virtual-bin obs test for the new .obs file header

### DIFF
--- a/tests/obs_virtual_bin_fallback_test.py
+++ b/tests/obs_virtual_bin_fallback_test.py
@@ -17,6 +17,8 @@ from unittest.mock import patch
 
 import pandas as pd
 
+from ofs_skill.utils.file_headers import series_header
+
 gso = importlib.import_module(
     'ofs_skill.obs_retrieval.get_station_observations')
 
@@ -98,7 +100,8 @@ def test_virtual_row_bin_present_after_retry_emits(tmp_path, caplog):
     assert result == '1234567_b03'
     mock_format.assert_called_once()
     obs_file = tmp_path / '1234567_b03_necofs_cu_station.obs'
-    assert obs_file.read_text(encoding='utf-8') == 'formatted-line\n'
+    assert obs_file.read_text(encoding='utf-8') == (
+        series_header('cu') + 'formatted-line\n')
     assert not [r for r in caplog.records if r.levelno == logging.ERROR]
 
 


### PR DESCRIPTION
Main's CI went red after #223 merged. #238 (merged first, branched from an earlier base) added `tests/obs_virtual_bin_fallback_test.py`, which asserts the exact byte content of a written `.obs` file; #223 added a descriptive header line to `.obs` files. The two merged cleanly but the combination was never tested on either branch, so the strict equality now fails on main.

One-line fix: the test now expects the shared series header (from `ofs_skill.utils.file_headers`, the same constant the writer uses) ahead of the mocked data row. Full suite on this branch: 1049 passed, 0 failures.