### PR TITLE
Handle ADCP bins below the model seabed and normalize the paired-series elapsed-days column

### DIFF
--- a/src/ofs_skill/model_processing/do_horizon_skill_utils.py
+++ b/src/ofs_skill/model_processing/do_horizon_skill_utils.py
@@ -38,11 +38,15 @@ def pandas_merge(filepath, df, datecycle, prop):
     dataframe.
     datecycle: column name string with date and model cycle of series
     to be merged.
-    logger : logging interface.
+    prop: ModelProperties object (``prop.datecycles`` lists the model
+    cycle columns to keep from the existing dataframe).
 
     Returns
     -------
-    df: merged dataframe with existing & new model cycle series.
+    df: merged dataframe with existing & new model cycle series, merged
+    on the integer date-component columns; the julian column is taken
+    from the new cycle series (rows only present in the existing
+    dataframe carry NaN julian).
 
     '''
     # Existing dataframe with previously merged model cycle series
@@ -73,7 +77,7 @@ def pandas_merge(filepath, df, datecycle, prop):
     # the issue #200 precision fix) duplicated every row on the outer
     # merge. The fresh series' julian column is carried through.
     if 'julian' in prd.columns:
-        prd = prd.drop(columns='julian')
+        prd.drop(columns='julian', inplace=True)
     df = pd.merge(
         prd, df,
         on=[

--- a/src/ofs_skill/model_processing/do_horizon_skill_utils.py
+++ b/src/ofs_skill/model_processing/do_horizon_skill_utils.py
@@ -67,10 +67,16 @@ def pandas_merge(filepath, df, datecycle, prop):
     # This is especially relevant to server/cron runs!
     if datecycle in prd.columns:
         prd.drop(columns=datecycle, inplace=True)
+    # Merge on the integer date components only. The float julian
+    # column used to be part of the key, so a cached CSV written with
+    # a different julian rounding than the fresh series (e.g. before
+    # the issue #200 precision fix) duplicated every row on the outer
+    # merge. The fresh series' julian column is carried through.
+    if 'julian' in prd.columns:
+        prd = prd.drop(columns='julian')
     df = pd.merge(
         prd, df,
         on=[
-            'julian',
             'year',
             'month',
             'day',

--- a/src/ofs_skill/model_processing/write_ofs_ctlfile.py
+++ b/src/ofs_skill/model_processing/write_ofs_ctlfile.py
@@ -28,7 +28,6 @@ Example:
 """
 
 import os
-import re
 from logging import Logger
 from pathlib import Path
 from typing import Any
@@ -37,6 +36,9 @@ import numpy as np
 
 import ofs_skill.model_processing.indexing as indexing
 from ofs_skill.obs_retrieval import utils
+from ofs_skill.obs_retrieval.currents_bins_override import (
+    split_virtual_currents_id,
+)
 from ofs_skill.obs_retrieval.station_ctl_file_extract import station_ctl_file_extract
 from ofs_skill.utils.file_headers import MODEL_CTL_HEADER, OBS_CTL_HEADER
 
@@ -79,6 +81,14 @@ def _model_bathymetry_at_node(
             # Station-file FVCOM: ``z`` has shape (siglay, node, time) or
             # similar. Take the deepest layer as the bathy proxy.
             if 'h' in model:
+                # Normalise legacy time-replicated layouts the same way
+                # the depth indexer does, so both read the same value.
+                try:
+                    h_1d = _static_coord_1d(model, 'h')
+                    if h_1d.ndim == 1:
+                        return float(abs(h_1d[int(node_idx)]))
+                except (KeyError, ValueError, TypeError):
+                    pass
                 h = np.asarray(model['h'])
                 h = np.squeeze(h)
                 if h.ndim >= 2:
@@ -137,15 +147,9 @@ def _model_bathymetry_at_node(
     return 0.0
 
 
-# CO-OPS ADCP virtual-bin station IDs look like ``{parent}_b{NN}``
-# (e.g. ``cb0201_b08``). Non-virtual IDs (NDBC / USGS / CHS, or user
-# input locations) never match, so the below-bottom bin pruning is a
-# no-op for them.
-_VIRTUAL_BIN_ID = re.compile(r'^(?P<parent>.+)_b(?P<bin>\d+)$')
-
 # Slack applied before declaring an obs bin depth to be below the model
 # seabed, absorbing float noise in the bathymetry lookup. Kept small on
-# purpose: a bin a few centimetres past the model bottom is still a
+# purpose: a bin a few centimeters past the model bottom is still a
 # legitimate near-bottom comparison and is handled by the
 # keep-one-bottom-bin policy, not by this tolerance.
 _BIN_BELOW_BOTTOM_TOL_M = 0.01
@@ -171,21 +175,35 @@ def _drop_bins_below_model_bottom(
     against several different obs bins, duplicating ``mod_water_depth``
     rows in the skill CSVs.
 
-    Policy: per (parent station, node), bins deeper than the model
-    water depth are dropped, except the shallowest of them is kept when
-    no in-column bin already maps to the bottom layer — so the deepest
-    model level is still compared exactly once. Every drop is logged at
-    WARNING and recorded on ``prop.station_ledger`` when one is
-    attached.
+    Policy: per (parent station, node), bins reported deeper than the
+    model's static water depth (bathymetry) are dropped, except the
+    shallowest of them is kept when no other bin was already assigned
+    the same (clamped-to-bottom) model layer. Only bins outside the
+    static model water column are ever eligible for dropping:
+    in-column bins that share a model layer — e.g. near-bottom bins
+    between the deepest layer midpoint and the seabed — are always
+    kept, since layer sharing is ordinary vertical-resolution
+    behaviour and stays visible through the per-bin obs depths. The
+    threshold deliberately ignores the free surface: a bin below the
+    static seabed duplicates the kept bottom comparison regardless of
+    tide stage. Every drop is logged at WARNING and recorded on
+    ``prop.station_ledger`` when one is attached.
 
     The caller removes the returned indices from the parallel
     station/node/layer/depth lists before the ctl lines are written;
     the obs ctl file keeps the full bin list untouched.
     """
     coord_rows = extract[-1]
-    n = len(station_id)
+    n_stations = len(station_id)
     if not (len(coord_rows) == len(list_of_nearest_node)
-            == len(list_of_nearest_layer) == len(list_of_depths) == n):
+            == len(list_of_nearest_layer) == len(list_of_depths)
+            == n_stations):
+        logger.warning(
+            'Below-bottom ADCP bin pruning skipped: obs ctl coord rows '
+            'and node/layer/depth lists are misaligned (%d stations, '
+            '%d coord rows, %d nodes, %d layers, %d depths).',
+            n_stations, len(coord_rows), len(list_of_nearest_node),
+            len(list_of_nearest_layer), len(list_of_depths))
         return set()
 
     groups: dict[tuple[str, int], list[int]] = {}
@@ -194,17 +212,27 @@ def _drop_bins_below_model_bottom(
         try:
             if node is None or np.isnan(node):
                 continue
-        except TypeError:
+        except (TypeError, ValueError):
             continue
-        match = _VIRTUAL_BIN_ID.match(str(sid))
-        if not match:
+        # The node matchers emit -1 (not only NaN) for "no node found";
+        # a negative index would silently wrap to the last node's
+        # bathymetry, so reject it here.
+        node_int = int(node)
+        if node_int < 0:
             continue
-        groups.setdefault((match.group('parent'), int(node)), []).append(i)
+        parent, bin_num = split_virtual_currents_id(str(sid))
+        if bin_num is None:
+            # Non-virtual ID (NDBC / USGS / CHS, or user input
+            # locations) — pruning does not apply.
+            continue
+        groups.setdefault((parent, node_int), []).append(i)
 
     drop: set[int] = set()
     bathy_cache: dict[int, float] = {}
     ledger = getattr(prop, 'station_ledger', None)
     for (parent, node), members in groups.items():
+        # Coord token [3] is the water depth on every obs ctl line
+        # width (5-token scalar, 6/7-token currents).
         depths: dict[int, float] = {}
         for i in members:
             try:
@@ -221,18 +249,23 @@ def _drop_bins_below_model_bottom(
             # Bathymetry unknown at this node — cannot judge, keep all.
             continue
         too_deep = sorted(
-            (i for i in depths
-             if depths[i] > water_depth + _BIN_BELOW_BOTTOM_TOL_M),
-            key=lambda i: depths[i])
+            (i for i, depth in depths.items()
+             if depth > water_depth + _BIN_BELOW_BOTTOM_TOL_M),
+            key=depths.get)
         if not too_deep:
             continue
+        # Layers already represented by any other bin of this group —
+        # built from all members (a bin whose depth token failed to
+        # parse still occupies its assigned layer).
         in_column_layers = {list_of_nearest_layer[i]
-                            for i in depths if i not in too_deep}
+                            for i in members if i not in too_deep}
         kept = None
         if list_of_nearest_layer[too_deep[0]] not in in_column_layers:
             kept = too_deep[0]
         group_drops = [i for i in too_deep if i != kept]
         if not group_drops:
+            # Reachable only when too_deep == [kept], so ``kept`` is
+            # never None here.
             logger.warning(
                 'Station %s: ADCP bin %s reported depth %.2f m exceeds '
                 'the model water depth %.2f m at node %s; keeping it as '
@@ -594,6 +627,10 @@ def write_ofs_ctlfile(prop: Any, model: Any, logger: Logger) -> Any:
                 station_id = [item[0] for item in extract[0]]
 
             if extract is not None:
+                # Initialised up front so static analysis (and any
+                # future ofsfiletype value) sees a defined name; both
+                # known filetypes assign it below.
+                list_of_nearest_node = []
                 if prop.ofsfiletype == 'fields':
                     list_of_nearest_node = \
                         indexing.index_nearest_node(

--- a/src/ofs_skill/model_processing/write_ofs_ctlfile.py
+++ b/src/ofs_skill/model_processing/write_ofs_ctlfile.py
@@ -28,6 +28,7 @@ Example:
 """
 
 import os
+import re
 from logging import Logger
 from pathlib import Path
 from typing import Any
@@ -134,6 +135,138 @@ def _model_bathymetry_at_node(
         'Bathymetry lookup: no handler matched model_source=%r; '
         'returning 0.0', model_source)
     return 0.0
+
+
+# CO-OPS ADCP virtual-bin station IDs look like ``{parent}_b{NN}``
+# (e.g. ``cb0201_b08``). Non-virtual IDs (NDBC / USGS / CHS, or user
+# input locations) never match, so the below-bottom bin pruning is a
+# no-op for them.
+_VIRTUAL_BIN_ID = re.compile(r'^(?P<parent>.+)_b(?P<bin>\d+)$')
+
+# Slack applied before declaring an obs bin depth to be below the model
+# seabed, absorbing float noise in the bathymetry lookup. Kept small on
+# purpose: a bin a few centimetres past the model bottom is still a
+# legitimate near-bottom comparison and is handled by the
+# keep-one-bottom-bin policy, not by this tolerance.
+_BIN_BELOW_BOTTOM_TOL_M = 0.01
+
+
+def _drop_bins_below_model_bottom(
+    prop: Any,
+    extract: Any,
+    station_id: list,
+    list_of_nearest_node: Any,
+    list_of_nearest_layer: Any,
+    list_of_depths: Any,
+    model: Any,
+    logger: Logger,
+) -> set[int]:
+    """Return indices of redundant ADCP bins that lie below the model seabed.
+
+    The CO-OPS metadata API occasionally reports ADCP bin depths deeper
+    than the model water column at the matched node (issue #200). The
+    vertical nearest-layer search clamps every such bin to the bottom
+    model layer, which would emit several model-ctl lines identical
+    except for the virtual-bin ID — the same model series compared
+    against several different obs bins, duplicating ``mod_water_depth``
+    rows in the skill CSVs.
+
+    Policy: per (parent station, node), bins deeper than the model
+    water depth are dropped, except the shallowest of them is kept when
+    no in-column bin already maps to the bottom layer — so the deepest
+    model level is still compared exactly once. Every drop is logged at
+    WARNING and recorded on ``prop.station_ledger`` when one is
+    attached.
+
+    The caller removes the returned indices from the parallel
+    station/node/layer/depth lists before the ctl lines are written;
+    the obs ctl file keeps the full bin list untouched.
+    """
+    coord_rows = extract[-1]
+    n = len(station_id)
+    if not (len(coord_rows) == len(list_of_nearest_node)
+            == len(list_of_nearest_layer) == len(list_of_depths) == n):
+        return set()
+
+    groups: dict[tuple[str, int], list[int]] = {}
+    for i, sid in enumerate(station_id):
+        node = list_of_nearest_node[i]
+        try:
+            if node is None or np.isnan(node):
+                continue
+        except TypeError:
+            continue
+        match = _VIRTUAL_BIN_ID.match(str(sid))
+        if not match:
+            continue
+        groups.setdefault((match.group('parent'), int(node)), []).append(i)
+
+    drop: set[int] = set()
+    bathy_cache: dict[int, float] = {}
+    ledger = getattr(prop, 'station_ledger', None)
+    for (parent, node), members in groups.items():
+        depths: dict[int, float] = {}
+        for i in members:
+            try:
+                depths[i] = float(coord_rows[i][3])
+            except (TypeError, ValueError, IndexError):
+                continue
+        if not depths:
+            continue
+        if node not in bathy_cache:
+            bathy_cache[node] = _model_bathymetry_at_node(
+                node, model, prop.model_source, logger)
+        water_depth = bathy_cache[node]
+        if water_depth <= 0:
+            # Bathymetry unknown at this node — cannot judge, keep all.
+            continue
+        too_deep = sorted(
+            (i for i in depths
+             if depths[i] > water_depth + _BIN_BELOW_BOTTOM_TOL_M),
+            key=lambda i: depths[i])
+        if not too_deep:
+            continue
+        in_column_layers = {list_of_nearest_layer[i]
+                            for i in depths if i not in too_deep}
+        kept = None
+        if list_of_nearest_layer[too_deep[0]] not in in_column_layers:
+            kept = too_deep[0]
+        group_drops = [i for i in too_deep if i != kept]
+        if not group_drops:
+            logger.warning(
+                'Station %s: ADCP bin %s reported depth %.2f m exceeds '
+                'the model water depth %.2f m at node %s; keeping it as '
+                'the bottom-layer comparison.',
+                parent, station_id[kept], depths[kept], water_depth, node)
+            continue
+        drop.update(group_drops)
+        dropped_desc = ', '.join(
+            f'{station_id[i]} ({depths[i]:.2f} m)' for i in group_drops)
+        if kept is not None:
+            logger.warning(
+                'Station %s: ADCP bin(s) %s lie below the model water '
+                'depth %.2f m at node %s; keeping %s (%.2f m) as the '
+                'single bottom-layer comparison and dropping the rest '
+                'from the model ctl file.',
+                parent, dropped_desc, water_depth, node,
+                station_id[kept], depths[kept])
+        else:
+            logger.warning(
+                'Station %s: ADCP bin(s) %s lie below the model water '
+                'depth %.2f m at node %s and duplicate a bottom-layer '
+                'comparison already covered by an in-column bin; '
+                'dropped from the model ctl file.',
+                parent, dropped_desc, water_depth, node)
+        if ledger is not None:
+            for i in group_drops:
+                ledger.drop(
+                    str(station_id[i]), stage='depth_match',
+                    reason=(
+                        f'bin depth {depths[i]:.2f} m exceeds model '
+                        f'water depth {water_depth:.2f} m at node '
+                        f'{node}; bottom model layer already compared '
+                        'once'))
+    return drop
 
 
 def _resolve_side_looking_depths(
@@ -508,6 +641,32 @@ def write_ofs_ctlfile(prop: Any, model: Any, logger: Logger) -> Any:
                         prop.ofs,
                         logger,
                     )
+
+                # Prune ADCP bins reported deeper than the model water
+                # column so the bottom model layer is compared at most
+                # once per station (issue #200). Skipped for FVCOM
+                # fields files, where currents nodes are element
+                # indices (latc/lonc) and nodal bathymetry cannot be
+                # indexed with them.
+                if (name_var == 'cu'
+                        and not prop.user_input_location
+                        and not (prop.model_source == 'fvcom'
+                                 and prop.ofsfiletype == 'fields')):
+                    below_bottom = _drop_bins_below_model_bottom(
+                        prop, extract, station_id,
+                        list_of_nearest_node, list_of_nearest_layer,
+                        list_of_depths, model, logger,
+                    )
+                    if below_bottom:
+                        keep_idx = [i for i in range(len(station_id))
+                                    if i not in below_bottom]
+                        station_id = [station_id[i] for i in keep_idx]
+                        list_of_nearest_node = [
+                            list_of_nearest_node[i] for i in keep_idx]
+                        list_of_nearest_layer = [
+                            list_of_nearest_layer[i] for i in keep_idx]
+                        list_of_depths = [
+                            list_of_depths[i] for i in keep_idx]
 
                 logger.info('Extracting data found in the Model Control File')
 

--- a/src/ofs_skill/obs_retrieval/format_obs_timeseries.py
+++ b/src/ofs_skill/obs_retrieval/format_obs_timeseries.py
@@ -76,9 +76,12 @@ def format_scalar(
     )
     timeseries = timeseries.loc[mask].copy()
 
-    # Calculate Julian date
+    # Calculate Julian date. Round at the precision the fixed-width
+    # writer emits (8 decimals): the historical round(4) quantized to an
+    # 8.64 s grid, which made strictly 6-minute series show elapsed-day
+    # steps wobbling between 0.0041 and 0.0043 (issue #200).
     julian = pd.array(timeseries['DateTime']).to_julian_date()
-    julian = julian.round(4)
+    julian = julian.round(8)
 
     # Extract date components
     year = pd.to_datetime(timeseries['DateTime']).dt.strftime('%Y').to_numpy()
@@ -166,9 +169,12 @@ def format_vector(
     )
     timeseries = timeseries.loc[mask].copy()
 
-    # Calculate Julian date
+    # Calculate Julian date. Round at the precision the fixed-width
+    # writer emits (8 decimals): the historical round(4) quantized to an
+    # 8.64 s grid, which made strictly 6-minute series show elapsed-day
+    # steps wobbling between 0.0041 and 0.0043 (issue #200).
     julian = pd.array(timeseries['DateTime']).to_julian_date()
-    julian = julian.round(4)
+    julian = julian.round(8)
 
     # Extract date components
     year = pd.to_datetime(timeseries['DateTime']).dt.strftime('%Y').to_numpy()

--- a/src/ofs_skill/skill_assessment/format_paired_one_d.py
+++ b/src/ofs_skill/skill_assessment/format_paired_one_d.py
@@ -147,9 +147,8 @@ def paired_scalar(
         .reset_index()
     )
 
-    # Third we concat the observations to the ofs, group so same times
-    # are combined, drop nan, reindex. Merge on DateTime alone (as
-    # paired_vector does): the numbered date columns are redundant with
+    # Third we merge the observations onto the ofs series. Merge on
+    # DateTime alone (as paired_vector does): the numbered date columns are redundant with
     # DateTime, and using the float julian column [0] as a merge key
     # made pairing silently fail whenever the obs and model files were
     # written with different julian rounding (e.g. a cached series from
@@ -375,8 +374,7 @@ def paired_vector(
         .reset_index()
     )
 
-    # Third we concat the observations to the ofs, group so same times
-    # are combined, drop nan, reindex
+    # Third we merge the observations onto the ofs series on DateTime
     paired = pd.merge(
         paired_ofs,
         paired_obs[['DateTime', 'OBS', 'OBS_DIR', 'OBS_U', 'OBS_V']],
@@ -405,14 +403,11 @@ def paired_vector(
     # timeseries file
 
     # This is the direction bias
+    ofs_dir = paired['OFS_DIR'].to_numpy()
+    obs_dir = paired['OBS_DIR'].to_numpy()
     dir_bias = []
     for j in range(len(paired)):
-        dir_bias.append(
-            get_distance_angle(
-                paired['OFS_DIR'].to_numpy()[j],
-                paired['OBS_DIR'].to_numpy()[j]
-            )
-        )
+        dir_bias.append(get_distance_angle(ofs_dir[j], obs_dir[j]))
     paired['DIR_BIAS'] = dir_bias
     # Finally, we write the file and return the results
     paired = paired.drop(columns=['index', 'DateTime', 'OBS_U', 'OBS_V',

--- a/src/ofs_skill/skill_assessment/format_paired_one_d.py
+++ b/src/ofs_skill/skill_assessment/format_paired_one_d.py
@@ -148,11 +148,16 @@ def paired_scalar(
     )
 
     # Third we concat the observations to the ofs, group so same times
-    # are combined, drop nan, reindex
+    # are combined, drop nan, reindex. Merge on DateTime alone (as
+    # paired_vector does): the numbered date columns are redundant with
+    # DateTime, and using the float julian column [0] as a merge key
+    # made pairing silently fail whenever the obs and model files were
+    # written with different julian rounding (e.g. a cached series from
+    # before the issue #200 precision fix meeting a fresh one).
     paired = pd.merge(
             paired_ofs,
-            paired_obs[['DateTime', 'OBS', 0, 1, 2, 3, 4, 5]],
-            on=['DateTime', 0, 1, 2, 3, 4, 5],
+            paired_obs[['DateTime', 'OBS']],
+            on=['DateTime'],
             how='left'
     )
 
@@ -183,8 +188,7 @@ def paired_scalar(
 
     paired = paired.reset_index()
 
-    # Then we create the speed bias, mask for start and end time and
-    # create julian
+    # Then we create the bias and mask for start and end time
     paired['BIAS'] = paired['OFS'] - paired['OBS']
 
     # Lookback ensures overlap between consecutive casts (e.g., nowcast + forecast_a)
@@ -382,8 +386,7 @@ def paired_vector(
 
     paired = paired.reset_index()
 
-    # Then we create the speed bias, mask for start and end time and
-    # create julian
+    # Then we create the speed bias and mask for start and end time
     paired['SPD_BIAS'] = paired['OFS'] - paired['OBS']
     # Lookback ensures overlap between consecutive casts (e.g., nowcast + forecast_a)
     paired = paired.loc[
@@ -398,22 +401,12 @@ def paired_vector(
             )
         )
     ]
-    julian = (
-        pd.array(paired['DateTime']).to_julian_date()
-        - pd.Timestamp(
-            datetime.strptime(
-                str(datetime.strptime(start_date_full,
-                                      '%Y%m%d-%H:%M:%S').year), '%Y'
-            )
-        ).to_julian_date()
-    )
-
     # Here we create the numpy arrays that will be used in the paired
     # timeseries file
 
     # This is the direction bias
     dir_bias = []
-    for j in range(len(julian)):
+    for j in range(len(paired)):
         dir_bias.append(
             get_distance_angle(
                 paired['OFS_DIR'].to_numpy()[j],

--- a/src/ofs_skill/skill_assessment/get_skill.py
+++ b/src/ofs_skill/skill_assessment/get_skill.py
@@ -286,7 +286,12 @@ def _station_metadata(read_station_ctl_file, read_ofs_ctl_file, obs_idx, ofs_idx
     return {
         'station_id': read_station_ctl_file[0][obs_idx][0],
         'node': read_ofs_ctl_file[1][ofs_idx],
-        'obs_depth': read_station_ctl_file[1][obs_idx][-2],
+        # Water depth is always the 4th coord token. Scalar-variable
+        # coord lines have 5 tokens so [-2] used to land on it by
+        # coincidence, but CO-OPS ADCP currents lines carry 6-7 tokens
+        # and [-2] read height_from_bottom there, making obs_water_depth
+        # constant across a station's bins (issue #200).
+        'obs_depth': read_station_ctl_file[1][obs_idx][3],
         'mod_depth': read_ofs_ctl_file[-2][ofs_idx],
         'X': str(float(read_station_ctl_file[1][obs_idx][1])),
         'Y': read_station_ctl_file[1][obs_idx][0],

--- a/src/ofs_skill/skill_assessment/get_skill.py
+++ b/src/ofs_skill/skill_assessment/get_skill.py
@@ -286,12 +286,18 @@ def _station_metadata(read_station_ctl_file, read_ofs_ctl_file, obs_idx, ofs_idx
     return {
         'station_id': read_station_ctl_file[0][obs_idx][0],
         'node': read_ofs_ctl_file[1][ofs_idx],
-        # Water depth is always the 4th coord token. Scalar-variable
-        # coord lines have 5 tokens so [-2] used to land on it by
-        # coincidence, but CO-OPS ADCP currents lines carry 6-7 tokens
-        # and [-2] read height_from_bottom there, making obs_water_depth
-        # constant across a station's bins (issue #200).
-        'obs_depth': read_station_ctl_file[1][obs_idx][3],
+        # Every obs ctl writer emits the water depth as the 4th coord
+        # token. Scalar-variable coord lines have 5 tokens so [-2] used
+        # to land on it by coincidence, but CO-OPS ADCP currents lines
+        # carry 7 tokens ([-2] read height_from_bottom, making
+        # obs_water_depth constant across a station's bins) and
+        # NDBC/USGS/CHS currents lines carry 6 ([-2] read a literal
+        # 0.0). Issue #200. A malformed short row degrades to a blank
+        # depth rather than dropping the station via IndexError.
+        'obs_depth': (
+            read_station_ctl_file[1][obs_idx][3]
+            if len(read_station_ctl_file[1][obs_idx]) > 3 else ''
+        ),
         'mod_depth': read_ofs_ctl_file[-2][ofs_idx],
         'X': str(float(read_station_ctl_file[1][obs_idx][1])),
         'Y': read_station_ctl_file[1][obs_idx][0],

--- a/tests/bins_below_model_bottom_test.py
+++ b/tests/bins_below_model_bottom_test.py
@@ -1,0 +1,399 @@
+"""Tests for the below-model-bottom ADCP bin pruning (issue #200).
+
+The CO-OPS metadata API occasionally reports ADCP bin depths deeper
+than the model water column at the matched node (e.g. NECOFS cb0201:
+model depth 10.48 m, bins reported down to 13.41 m). The vertical
+nearest-layer search clamps every such bin to the bottom model layer,
+which used to emit several model-ctl lines identical except for the
+virtual-bin ID — the same model series compared against several obs
+bins, duplicating ``mod_water_depth`` rows in the skill CSVs.
+
+Covers the ``_drop_bins_below_model_bottom`` policy directly (keep at
+most one bottom-layer comparison per station/node, ledger accounting,
+non-virtual IDs untouched, unknown bathymetry no-op) plus an
+end-to-end FVCOM-stations run through ``write_ofs_ctlfile`` asserting
+the written ctl no longer carries duplicated bottom rows. Also pins
+the ``_station_metadata`` obs-depth read to coord token [3] — the old
+``[-2]`` read landed on ``height_from_bottom`` for 7-token CO-OPS
+currents rows, reporting the same ``obs_water_depth`` for every bin of
+a station.
+"""
+
+import logging
+import os
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+import xarray as xr
+
+from ofs_skill.model_processing.station_ledger import StationLedger
+from ofs_skill.model_processing.write_ofs_ctlfile import (
+    _drop_bins_below_model_bottom,
+    write_ofs_ctlfile,
+)
+from ofs_skill.skill_assessment.get_skill import _station_metadata
+from ofs_skill.utils.file_headers import OBS_CTL_HEADER
+
+
+@pytest.fixture()
+def logger():
+    logging.basicConfig(level=logging.DEBUG)
+    return logging.getLogger('bins_below_model_bottom_test')
+
+
+def _make_extract(rows):
+    """Build a station_ctl_file_extract-shaped (info, coords) pair.
+
+    ``rows`` is a list of (station_id, coord_tokens) tuples.
+    """
+    info = [[sid, f'{sid}_cu_x_CO-OPS', f'Station {sid}'] for sid, _ in rows]
+    coords = [list(tokens) for _, tokens in rows]
+    return [info, coords]
+
+
+def _cu_coords(depth, hfb=0.0, mounting='up'):
+    return ['41.000', '-71.000', '0.0', f'{depth:.2f}', '0.0',
+            f'{hfb:.2f}', mounting]
+
+
+def _run_drop(rows, nodes, layers, depths, h, logger, ledger=None,
+              model_source='fvcom'):
+    extract = _make_extract(rows)
+    station_id = [sid for sid, _ in rows]
+    prop = SimpleNamespace(model_source=model_source,
+                           station_ledger=ledger)
+    model = {'h': np.asarray(h, dtype=float)}
+    return _drop_bins_below_model_bottom(
+        prop, extract, station_id, list(nodes), list(layers),
+        list(depths), model, logger)
+
+
+def test_drops_all_when_bottom_layer_already_covered(logger):
+    """In-column bin already at the bottom layer -> every too-deep bin drops."""
+    # Node 0 water depth 10.48 m; layer 0 is the bottom layer.
+    rows = [
+        ('cb0201_b07', _cu_coords(9.0)),    # in-column, argmin -> bottom
+        ('cb0201_b08', _cu_coords(11.10)),
+        ('cb0201_b09', _cu_coords(12.64)),
+        ('cb0201_b10', _cu_coords(13.41)),
+    ]
+    drop = _run_drop(rows, nodes=[0, 0, 0, 0], layers=[0, 0, 0, 0],
+                     depths=[10.48, 10.48, 10.48, 10.48], h=[10.48, 50.0],
+                     logger=logger)
+    assert drop == {1, 2, 3}
+
+
+def test_keeps_shallowest_when_bottom_layer_uncovered(logger):
+    """No in-column bin at the bottom layer -> shallowest too-deep bin kept."""
+    rows = [
+        ('cb0201_b02', _cu_coords(2.0)),    # surface layer
+        ('cb0201_b08', _cu_coords(11.10)),
+        ('cb0201_b09', _cu_coords(12.64)),
+        ('cb0201_b10', _cu_coords(13.41)),
+    ]
+    drop = _run_drop(rows, nodes=[0, 0, 0, 0], layers=[2, 0, 0, 0],
+                     depths=[0.0, 10.48, 10.48, 10.48], h=[10.48, 50.0],
+                     logger=logger)
+    # b08 (shallowest too-deep) survives as the bottom-layer comparison.
+    assert drop == {2, 3}
+
+
+def test_single_near_bottom_bin_is_kept(logger):
+    """A lone bin slightly past the model bottom stays (cb1301-style)."""
+    rows = [('cb1301_b10', _cu_coords(10.52, hfb=0.18, mounting='side'))]
+    drop = _run_drop(rows, nodes=[0], layers=[0], depths=[10.48],
+                     h=[10.48, 50.0], logger=logger)
+    assert drop == set()
+
+
+def test_in_column_bins_never_drop(logger):
+    rows = [
+        ('cb0201_b01', _cu_coords(1.5)),
+        ('cb0201_b05', _cu_coords(6.0)),
+        ('cb0201_b07', _cu_coords(9.0)),
+    ]
+    drop = _run_drop(rows, nodes=[0, 0, 0], layers=[2, 1, 0],
+                     depths=[0.0, 5.24, 10.48], h=[10.48, 50.0], logger=logger)
+    assert drop == set()
+
+
+def test_non_virtual_ids_ignored(logger):
+    """NDBC/USGS-style IDs (no _bNN suffix) are never pruned."""
+    rows = [
+        ('46237', ['41.0', '-71.0', '0.0', '15.0', '0.0', '0.0']),
+        ('0158964', ['41.0', '-71.0', '0.0', '20.0', '0.0', '0.0']),
+    ]
+    drop = _run_drop(rows, nodes=[0, 0], layers=[0, 0],
+                     depths=[10.48, 10.48], h=[10.48, 50.0], logger=logger)
+    assert drop == set()
+
+
+def test_unknown_bathymetry_is_a_noop(logger):
+    """Bathymetry lookup failure (no h/z) -> keep everything."""
+    rows = [
+        ('cb0201_b08', _cu_coords(11.10)),
+        ('cb0201_b09', _cu_coords(12.64)),
+    ]
+    extract = _make_extract(rows)
+    prop = SimpleNamespace(model_source='fvcom', station_ledger=None)
+    drop = _drop_bins_below_model_bottom(
+        prop, extract, [sid for sid, _ in rows], [0, 0], [0, 0],
+        [10.48, 10.48], {}, logger)
+    assert drop == set()
+
+
+def test_nan_nodes_are_skipped(logger):
+    rows = [
+        ('cb0201_b08', _cu_coords(11.10)),
+        ('cb0201_b09', _cu_coords(12.64)),
+    ]
+    drop = _run_drop(rows, nodes=[np.nan, np.nan], layers=[0, 0],
+                     depths=[np.nan, np.nan], h=[10.48, 50.0], logger=logger)
+    assert drop == set()
+
+
+def test_groups_are_per_parent_station(logger):
+    """Each parent keeps its own bottom-layer comparison."""
+    rows = [
+        ('aa0001_b05', _cu_coords(11.0)),
+        ('aa0001_b06', _cu_coords(12.0)),
+        ('bb0002_b03', _cu_coords(11.5)),
+        ('bb0002_b04', _cu_coords(12.5)),
+    ]
+    drop = _run_drop(rows, nodes=[0, 0, 1, 1], layers=[0, 0, 0, 0],
+                     depths=[10.48, 10.48, 9.9, 9.9], h=[10.48, 9.9],
+                     logger=logger)
+    # Shallowest too-deep bin of each parent survives.
+    assert drop == {1, 3}
+
+
+def test_mismatched_list_lengths_bail_out(logger):
+    rows = [('cb0201_b08', _cu_coords(11.10))]
+    extract = _make_extract(rows)
+    prop = SimpleNamespace(model_source='fvcom', station_ledger=None)
+    drop = _drop_bins_below_model_bottom(
+        prop, extract, ['cb0201_b08'], [0, 0], [0], [10.48],
+        {'h': np.asarray([10.48])}, logger)
+    assert drop == set()
+
+
+def test_ledger_records_each_drop(logger):
+    ledger = StationLedger(ofs='necofs', variable='currents',
+                           whichcast='hindcast', filetype='stations')
+    rows = [
+        ('cb0201_b07', _cu_coords(9.0)),
+        ('cb0201_b08', _cu_coords(11.10)),
+        ('cb0201_b09', _cu_coords(12.64)),
+    ]
+    drop = _run_drop(rows, nodes=[0, 0, 0], layers=[0, 0, 0],
+                     depths=[10.48, 10.48, 10.48], h=[10.48, 50.0],
+                     logger=logger, ledger=ledger)
+    assert drop == {1, 2}
+    dropped_ids = {d.station_id for d in ledger.drops}
+    assert dropped_ids == {'cb0201_b08', 'cb0201_b09'}
+    assert all(d.stage == 'depth_match' for d in ledger.drops)
+    assert all('exceeds model water depth' in d.reason
+               for d in ledger.drops)
+
+
+def test_warning_names_station_and_depths(logger, caplog):
+    rows = [
+        ('cb0201_b02', _cu_coords(2.0)),
+        ('cb0201_b08', _cu_coords(11.10)),
+        ('cb0201_b09', _cu_coords(13.41)),
+    ]
+    with caplog.at_level(logging.WARNING):
+        drop = _run_drop(rows, nodes=[0, 0, 0], layers=[2, 0, 0],
+                         depths=[0.0, 10.48, 10.48], h=[10.48, 50.0],
+                         logger=logger)
+    assert drop == {2}
+    text = ' '.join(rec.getMessage() for rec in caplog.records)
+    assert 'cb0201' in text
+    assert 'cb0201_b09 (13.41 m)' in text
+    assert 'cb0201_b08' in text  # named as the kept bottom-layer bin
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: FVCOM stations currents run through write_ofs_ctlfile
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def fvcom_stations_dataset(tmp_path):
+    """Small FVCOM stations dataset with one shallow node (10.48 m)."""
+    n_station = 4
+    n_siglay = 3
+
+    lon_1d = np.linspace(-71.0, -68.0, n_station, dtype=np.float64)
+    lat_1d = np.linspace(41.0, 44.0, n_station, dtype=np.float64)
+    h_1d = np.asarray([10.48, 20.0, 25.0, 30.0], dtype=np.float64)
+    siglay = np.tile(
+        np.linspace(-1.0, 0.0, n_siglay, dtype=np.float64)[:, None],
+        (1, n_station),
+    )
+    ds = xr.Dataset(
+        data_vars={
+            'lon': (('station',), lon_1d),
+            'lat': (('station',), lat_1d),
+            'h': (('station',), h_1d),
+            'siglay': (('siglay', 'station'), siglay),
+            'u': (
+                ('time', 'siglay', 'station'),
+                np.zeros((2, n_siglay, n_station), dtype=np.float64),
+            ),
+        },
+        coords={
+            'time': (
+                np.datetime64('2026-02-16T00')
+                + np.arange(2) * np.timedelta64(1, 'h')
+            ),
+        },
+    )
+    path = tmp_path / 'fvcom_stations.nc'
+    ds.to_netcdf(path)
+    ds.close()
+    return xr.open_dataset(path), lat_1d, lon_1d
+
+
+def _write_minimal_config(tmp_path):
+    cfg_path = tmp_path / 'ofs_dps.conf'
+    cfg_path.write_text(
+        '[directories]\n'
+        f'home={tmp_path.as_posix()}\n'
+        'model_historical_dir=%(home)s/example_data\n'
+        'netcdf_dir=netcdf\n'
+    )
+    return cfg_path
+
+
+def test_write_ofs_ctlfile_prunes_below_bottom_bins(
+    tmp_path, fvcom_stations_dataset, logger,
+):
+    """Bins deeper than the model water column collapse to one ctl row."""
+    model, lat_1d, lon_1d = fvcom_stations_dataset
+    cfg_path = _write_minimal_config(tmp_path)
+    control_dir = tmp_path / 'control_files'
+    control_dir.mkdir()
+
+    # Six virtual bins at the shallow node (h=10.48): three in-column,
+    # three reported below the model seabed. One NDBC-style station at
+    # a deep node as a control.
+    lat0, lon0 = float(lat_1d[0]), float(lon_1d[0])
+    lat1, lon1 = float(lat_1d[1]), float(lon_1d[1])
+    lines = []
+    bins = [(1, 2.0), (4, 6.0), (7, 9.0),
+            (8, 11.10), (9, 12.64), (10, 13.41)]
+    for num, depth in bins:
+        sid = f'cb0201_b{num:02d}'
+        lines.append(f'{sid} {sid}_cu_tbofs_CO-OPS "Test ADCP (bin {num})"')
+        lines.append(f'  {lat0:.3f} {lon0:.3f} 0.0 {depth:.2f} 0.0 0.00 up')
+    lines.append('46237 46237_cu_tbofs_NDBC "NDBC control"')
+    lines.append(f'  {lat1:.3f} {lon1:.3f} 0.0 15.00 0.0 0.0')
+    obs_ctl = control_dir / 'tbofs_cu_station.ctl'
+    obs_ctl.write_text(OBS_CTL_HEADER + '\n'.join(lines) + '\n')
+
+    prop = SimpleNamespace(
+        config_file=str(cfg_path),
+        ofs='tbofs',
+        var_list=['currents'],
+        ofsfiletype='stations',
+        user_input_location=False,
+        model_source='fvcom',
+        control_files_path=str(control_dir),
+        datum='MLLW',
+        station_ledger=None,
+    )
+
+    write_ofs_ctlfile(prop, model, logger)
+
+    out_path = control_dir / 'tbofs_cu_model_station.ctl'
+    assert out_path.exists()
+    assert os.path.getsize(out_path) > 0
+
+    rows = [ln.split() for ln in out_path.read_text().splitlines()[1:]
+            if ln.strip()]
+    ids = [r[4] for r in rows]
+
+    # The three below-bottom duplicates are gone; everything else stays.
+    assert 'cb0201_b09' not in ids
+    assert 'cb0201_b10' not in ids
+    # b07 (9 m) argmins to the bottom layer of the 3-layer column
+    # (0 / -5.24 / -10.48), so the bottom is already covered in-column
+    # and b08 drops too.
+    assert 'cb0201_b08' not in ids
+    assert ids == ['cb0201_b01', 'cb0201_b04', 'cb0201_b07', '46237']
+
+    # No two rows for the same node may share a layer + depth (the
+    # issue #200 duplication signature).
+    cb_rows = [r for r in rows if r[4].startswith('cb0201')]
+    node_layer = [(r[0], r[1]) for r in cb_rows]
+    assert len(node_layer) == len(set(node_layer))
+
+
+def test_write_ofs_ctlfile_keeps_lone_below_bottom_bin(
+    tmp_path, fvcom_stations_dataset, logger,
+):
+    """A station whose only bins are below-bottom keeps exactly one row."""
+    model, lat_1d, lon_1d = fvcom_stations_dataset
+    cfg_path = _write_minimal_config(tmp_path)
+    control_dir = tmp_path / 'control_files'
+    control_dir.mkdir()
+
+    lat0, lon0 = float(lat_1d[0]), float(lon_1d[0])
+    lines = []
+    for num, depth in [(8, 11.10), (9, 12.64)]:
+        sid = f'cb0201_b{num:02d}'
+        lines.append(f'{sid} {sid}_cu_tbofs_CO-OPS "Test ADCP (bin {num})"')
+        lines.append(f'  {lat0:.3f} {lon0:.3f} 0.0 {depth:.2f} 0.0 0.00 up')
+    (control_dir / 'tbofs_cu_station.ctl').write_text(
+        OBS_CTL_HEADER + '\n'.join(lines) + '\n')
+
+    prop = SimpleNamespace(
+        config_file=str(cfg_path),
+        ofs='tbofs',
+        var_list=['currents'],
+        ofsfiletype='stations',
+        user_input_location=False,
+        model_source='fvcom',
+        control_files_path=str(control_dir),
+        datum='MLLW',
+        station_ledger=None,
+    )
+
+    write_ofs_ctlfile(prop, model, logger)
+
+    rows = [ln.split() for ln in
+            (control_dir / 'tbofs_cu_model_station.ctl')
+            .read_text().splitlines()[1:] if ln.strip()]
+    ids = [r[4] for r in rows]
+    # Shallowest below-bottom bin survives as the bottom-layer pairing.
+    assert ids == ['cb0201_b08']
+
+
+# ---------------------------------------------------------------------------
+# obs_water_depth metadata read (coord token [3], not [-2])
+# ---------------------------------------------------------------------------
+
+
+def test_station_metadata_obs_depth_currents_seven_tokens():
+    """7-token CO-OPS currents row: obs_depth must be the bin depth."""
+    station_ctl = [
+        [['cb0201_b08', 'cb0201_b08_cu_x_CO-OPS', 'Test (bin 8)']],
+        [['41.000', '-71.000', '0.0', '11.10', '0.0', '3.50', 'up']],
+    ]
+    ofs_ctl = [None, ['0'], None, None, ['cb0201_b08'], [10.5]]
+    meta = _station_metadata(station_ctl, ofs_ctl, 0, 0)
+    # Pre-fix this returned '3.50' (height_from_bottom, token [-2]).
+    assert meta['obs_depth'] == '11.10'
+
+
+def test_station_metadata_obs_depth_scalar_five_tokens():
+    """5-token scalar row: token [3] and legacy [-2] coincide."""
+    station_ctl = [
+        [['8638610', '8638610_wl_x_CO-OPS', 'Test WL']],
+        [['36.850', '-76.012', '0.12', '5.0', 'MLLW']],
+    ]
+    ofs_ctl = [None, ['0'], None, None, ['8638610'], [0.0]]
+    meta = _station_metadata(station_ctl, ofs_ctl, 0, 0)
+    assert meta['obs_depth'] == '5.0'

--- a/tests/bins_below_model_bottom_test.py
+++ b/tests/bins_below_model_bottom_test.py
@@ -20,7 +20,6 @@ a station.
 """
 
 import logging
-import os
 from types import SimpleNamespace
 
 import numpy as np
@@ -53,6 +52,7 @@ def _make_extract(rows):
 
 
 def _cu_coords(depth, hfb=0.0, mounting='up'):
+    """Build a 7-token CO-OPS currents coord line (hfb = height_from_bottom)."""
     return ['41.000', '-71.000', '0.0', f'{depth:.2f}', '0.0',
             f'{hfb:.2f}', mounting]
 
@@ -108,6 +108,7 @@ def test_single_near_bottom_bin_is_kept(logger):
 
 
 def test_in_column_bins_never_drop(logger):
+    """Bins within the model water column are always kept."""
     rows = [
         ('cb0201_b01', _cu_coords(1.5)),
         ('cb0201_b05', _cu_coords(6.0)),
@@ -144,6 +145,7 @@ def test_unknown_bathymetry_is_a_noop(logger):
 
 
 def test_nan_nodes_are_skipped(logger):
+    """Unmatched (NaN-node) stations are ignored by the pruner."""
     rows = [
         ('cb0201_b08', _cu_coords(11.10)),
         ('cb0201_b09', _cu_coords(12.64)),
@@ -169,6 +171,7 @@ def test_groups_are_per_parent_station(logger):
 
 
 def test_mismatched_list_lengths_bail_out(logger):
+    """Misaligned parallel lists disable pruning instead of mis-indexing."""
     rows = [('cb0201_b08', _cu_coords(11.10))]
     extract = _make_extract(rows)
     prop = SimpleNamespace(model_source='fvcom', station_ledger=None)
@@ -179,6 +182,7 @@ def test_mismatched_list_lengths_bail_out(logger):
 
 
 def test_ledger_records_each_drop(logger):
+    """Every pruned bin lands on the station ledger with stage depth_match."""
     ledger = StationLedger(ofs='necofs', variable='currents',
                            whichcast='hindcast', filetype='stations')
     rows = [
@@ -198,6 +202,7 @@ def test_ledger_records_each_drop(logger):
 
 
 def test_warning_names_station_and_depths(logger, caplog):
+    """The drop warning names the parent, dropped bins, and kept bin."""
     rows = [
         ('cb0201_b02', _cu_coords(2.0)),
         ('cb0201_b08', _cu_coords(11.10)),
@@ -228,10 +233,12 @@ def fvcom_stations_dataset(tmp_path):
     lon_1d = np.linspace(-71.0, -68.0, n_station, dtype=np.float64)
     lat_1d = np.linspace(41.0, 44.0, n_station, dtype=np.float64)
     h_1d = np.asarray([10.48, 20.0, 25.0, 30.0], dtype=np.float64)
-    siglay = np.tile(
-        np.linspace(-1.0, 0.0, n_siglay, dtype=np.float64)[:, None],
-        (1, n_station),
-    )
+    # Realistic FVCOM sigma-layer CENTERS (not levels): the deepest
+    # layer midpoint sits h/(2N) above the seabed, as in production
+    # grids, so the fixture exercises the same clamping geometry.
+    centers = -(2.0 * np.arange(n_siglay, dtype=np.float64) + 1.0) \
+        / (2.0 * n_siglay)
+    siglay = np.tile(centers[::-1][:, None], (1, n_station))
     ds = xr.Dataset(
         data_vars={
             'lon': (('station',), lon_1d),
@@ -309,7 +316,7 @@ def test_write_ofs_ctlfile_prunes_below_bottom_bins(
 
     out_path = control_dir / 'tbofs_cu_model_station.ctl'
     assert out_path.exists()
-    assert os.path.getsize(out_path) > 0
+    assert out_path.stat().st_size > 0
 
     rows = [ln.split() for ln in out_path.read_text().splitlines()[1:]
             if ln.strip()]

--- a/tests/julian_precision_test.py
+++ b/tests/julian_precision_test.py
@@ -12,6 +12,7 @@ against fresh ones.
 """
 
 import logging
+from types import SimpleNamespace
 
 import numpy as np
 import pandas as pd
@@ -37,6 +38,7 @@ def _six_minute_frame(n=240, value_col='OBS'):
 
 
 def test_format_scalar_uniform_six_minute_steps():
+    """format_scalar 6-min steps are uniform to within 1e-8 day (~1 ms)."""
     ts = _six_minute_frame()
     lines = format_scalar(ts, '20170301-00:00:00', '20170302-00:00:00',
                           lookback_hours=0)
@@ -50,6 +52,7 @@ def test_format_scalar_uniform_six_minute_steps():
 
 
 def test_format_vector_uniform_six_minute_steps():
+    """format_vector 6-min steps are uniform to within 1e-8 day (~1 ms)."""
     ts = _six_minute_frame()
     ts['DIR'] = 90.0
     lines = format_vector(ts, '20170301-00:00:00', '20170302-00:00:00',
@@ -133,8 +136,8 @@ def test_pandas_merge_mixed_precision_does_not_duplicate_rows(tmp_path):
                               3: 'day', 4: 'hour', 5: 'minute',
                               6: '20170301-00z_hr'})
 
-    prop_stub = type('P', (), {'datecycles':
-                               ['20170228-00z_hr', '20170301-00z_hr']})()
+    prop_stub = SimpleNamespace(
+        datecycles=['20170228-00z_hr', '20170301-00z_hr'])
     merged = pandas_merge(str(csv_path), new, '20170301-00z_hr', prop_stub)
 
     # Pre-fix: julian was a float merge key, so the rounding mismatch
@@ -145,6 +148,7 @@ def test_pandas_merge_mixed_precision_does_not_duplicate_rows(tmp_path):
 
 
 def test_pandas_merge_same_precision_still_merges(tmp_path):
+    """The component-column merge stays a clean 1:1 on same-precision data."""
     times = pd.date_range('2017-03-01 00:00', periods=24, freq='6min')
     old = _series_df(times, julian_decimals=8, value=1.0)
     old = old.rename(columns={0: 'julian', 1: 'year', 2: 'month',
@@ -158,8 +162,8 @@ def test_pandas_merge_same_precision_still_merges(tmp_path):
                               3: 'day', 4: 'hour', 5: 'minute',
                               6: '20170301-00z_hr'})
 
-    prop_stub = type('P', (), {'datecycles':
-                               ['20170228-00z_hr', '20170301-00z_hr']})()
+    prop_stub = SimpleNamespace(
+        datecycles=['20170228-00z_hr', '20170301-00z_hr'])
     merged = pandas_merge(str(csv_path), new, '20170301-00z_hr', prop_stub)
     assert len(merged) == len(times)
     assert 'julian' in merged.columns

--- a/tests/julian_precision_test.py
+++ b/tests/julian_precision_test.py
@@ -1,0 +1,165 @@
+"""Tests for the elapsed-days (julian) column precision fix (issue #200).
+
+The ``.obs`` / ``.prd`` series writers rounded the absolute Julian
+date to 4 decimals (an 8.64 s grid), so strictly 6-minute series
+showed consecutive elapsed-day steps wobbling between 0.0041, 0.0042,
+and 0.0043 in the paired ``.int`` files. The writers now round at the
+8 decimals the fixed-width format emits, and the two merges that used
+the float julian column as a key (``paired_scalar`` and the
+forecast-horizon CSV accumulator) merge on timestamps/date components
+instead — so cached series written at the old precision still pair
+against fresh ones.
+"""
+
+import logging
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from ofs_skill.model_processing.do_horizon_skill_utils import pandas_merge
+from ofs_skill.obs_retrieval.format_obs_timeseries import (
+    format_scalar,
+    format_vector,
+)
+from ofs_skill.skill_assessment import format_paired_one_d
+
+
+@pytest.fixture()
+def logger():
+    logging.basicConfig(level=logging.DEBUG)
+    return logging.getLogger('julian_precision_test')
+
+
+def _six_minute_frame(n=240, value_col='OBS'):
+    times = pd.date_range('2017-03-01 00:00', periods=n, freq='6min')
+    return pd.DataFrame({'DateTime': times, value_col: np.ones(n)})
+
+
+def test_format_scalar_uniform_six_minute_steps():
+    ts = _six_minute_frame()
+    lines = format_scalar(ts, '20170301-00:00:00', '20170302-00:00:00',
+                          lookback_hours=0)
+    julian = np.asarray([float(ln.split()[0]) for ln in lines])
+    diffs = np.diff(julian)
+    # Every step must be 1/240 day to within the 8-decimal write grid.
+    assert np.all(np.abs(diffs - 1.0 / 240.0) < 2e-8)
+    # Regression: at the old 4-decimal rounding the steps collapsed to
+    # an 8.64 s grid and wobbled between 0.0041 and 0.0043.
+    assert len({round(d, 6) for d in diffs}) == 1
+
+
+def test_format_vector_uniform_six_minute_steps():
+    ts = _six_minute_frame()
+    ts['DIR'] = 90.0
+    lines = format_vector(ts, '20170301-00:00:00', '20170302-00:00:00',
+                          lookback_hours=0)
+    julian = np.asarray([float(ln.split()[0]) for ln in lines])
+    diffs = np.diff(julian)
+    assert np.all(np.abs(diffs - 1.0 / 240.0) < 2e-8)
+    assert len({round(d, 6) for d in diffs}) == 1
+
+
+def _series_df(times, julian_decimals, value=1.0, vector=False):
+    """Build an obs/model dataframe shaped like the .obs/.prd readers'."""
+    julian = pd.array(pd.Series(times)).to_julian_date()
+    julian = np.round(np.asarray(julian, dtype=float), julian_decimals)
+    data = {
+        0: julian,
+        1: times.year,
+        2: times.month,
+        3: times.day,
+        4: times.hour,
+        5: times.minute,
+        6: np.full(len(times), value),
+    }
+    if vector:
+        data[7] = np.full(len(times), 90.0)
+        data[8] = np.full(len(times), value)
+        data[9] = np.full(len(times), 0.0)
+    return pd.DataFrame(data)
+
+
+def test_paired_scalar_tolerates_mixed_julian_precision(logger):
+    """Cached 4-decimal obs vs fresh 8-decimal model must still pair.
+
+    Pre-fix the merge used the float julian column as a key, so any
+    rounding mismatch between the two files silently produced all-NaN
+    OBS and a spurious temporal-overlap drop.
+    """
+    times = pd.date_range('2017-03-01 00:00', periods=100, freq='6min')
+    obs_df = _series_df(times, julian_decimals=4, value=1.5)
+    ofs_df = _series_df(times, julian_decimals=8, value=2.0)
+
+    result = format_paired_one_d.paired_scalar(
+        obs_df, ofs_df, '20170301-00:00:00', '20170301-09:54:00', logger,
+        lookback_hours=0)
+    assert result is not None
+    assert not isinstance(result, format_paired_one_d.PairingStatus)
+    _, paired = result
+    assert paired['OBS'].notna().all()
+    assert paired['OFS'].notna().all()
+    assert np.allclose(paired['BIAS'], 0.5)
+
+
+def test_paired_vector_still_pairs(logger):
+    """Vector pairing (already DateTime-keyed) keeps working end to end."""
+    times = pd.date_range('2017-03-01 00:00', periods=100, freq='6min')
+    obs_df = _series_df(times, julian_decimals=4, value=1.0, vector=True)
+    ofs_df = _series_df(times, julian_decimals=8, value=1.0, vector=True)
+
+    result = format_paired_one_d.paired_vector(
+        obs_df, ofs_df, '20170301-00:00:00', '20170301-09:54:00', logger,
+        lookback_hours=0)
+    assert result is not None
+    _, paired = result
+    assert paired['OBS'].notna().all()
+    assert len(paired) == 100
+
+
+def test_pandas_merge_mixed_precision_does_not_duplicate_rows(tmp_path):
+    """Old 4-decimal horizons CSV + fresh 8-decimal cycle: no row fan-out."""
+    times = pd.date_range('2017-03-01 00:00', periods=48, freq='6min')
+
+    old = _series_df(times, julian_decimals=4, value=1.0)
+    old = old.rename(columns={0: 'julian', 1: 'year', 2: 'month',
+                              3: 'day', 4: 'hour', 5: 'minute',
+                              6: '20170228-00z_hr'})
+    csv_path = tmp_path / 'station_cu_fcst_horizons.csv'
+    old.to_csv(csv_path, index=False)
+
+    new = _series_df(times, julian_decimals=8, value=2.0)
+    new = new.rename(columns={0: 'julian', 1: 'year', 2: 'month',
+                              3: 'day', 4: 'hour', 5: 'minute',
+                              6: '20170301-00z_hr'})
+
+    prop_stub = type('P', (), {'datecycles':
+                               ['20170228-00z_hr', '20170301-00z_hr']})()
+    merged = pandas_merge(str(csv_path), new, '20170301-00z_hr', prop_stub)
+
+    # Pre-fix: julian was a float merge key, so the rounding mismatch
+    # made every timestamp appear twice in the outer merge.
+    assert len(merged) == len(times)
+    assert merged['20170228-00z_hr'].notna().all()
+    assert merged['20170301-00z_hr'].notna().all()
+
+
+def test_pandas_merge_same_precision_still_merges(tmp_path):
+    times = pd.date_range('2017-03-01 00:00', periods=24, freq='6min')
+    old = _series_df(times, julian_decimals=8, value=1.0)
+    old = old.rename(columns={0: 'julian', 1: 'year', 2: 'month',
+                              3: 'day', 4: 'hour', 5: 'minute',
+                              6: '20170228-00z_hr'})
+    csv_path = tmp_path / 'station_cu_fcst_horizons.csv'
+    old.to_csv(csv_path, index=False)
+
+    new = _series_df(times, julian_decimals=8, value=2.0)
+    new = new.rename(columns={0: 'julian', 1: 'year', 2: 'month',
+                              3: 'day', 4: 'hour', 5: 'minute',
+                              6: '20170301-00z_hr'})
+
+    prop_stub = type('P', (), {'datecycles':
+                               ['20170228-00z_hr', '20170301-00z_hr']})()
+    merged = pandas_merge(str(csv_path), new, '20170301-00z_hr', prop_stub)
+    assert len(merged) == len(times)
+    assert 'julian' in merged.columns


### PR DESCRIPTION
### Description of Changes

Closes #200 (items 2 and 3; item 1 — inconsistent station matching — was already addressed by the station-matching / drop-accounting work in #204).

**Item 2 — ADCP bins reported below the model seabed.** The CO-OPS metadata API sometimes reports ADCP bin depths deeper than the model water column at the matched node (the issue's example: model depth ~10.5 m with bins down to 13.41 m). The vertical nearest-layer search clamps every such bin to the bottom model layer, so the model ctl file carried several rows identical except for the virtual-bin ID — the same model series compared against several different obs bins, with duplicated `mod_water_depth` values in the skill CSVs. The model-ctl writer now prunes these per (parent station, node): bins reported deeper than the model's static water depth are dropped, keeping the shallowest of them only when no other bin already occupies the bottom model layer, so the deepest model level is still compared once. Only bins outside the static model water column are ever eligible for dropping — in-column bins that share a layer (ordinary vertical-resolution behavior) are always kept. Every drop is logged at WARNING (station, bin depths, model water depth, node) and recorded on the station accounting ledger (#204) under stage `depth_match`. The obs ctl file keeps the full bin list; only the model-side comparison is dropped. FVCOM `fields` files are excluded (currents locations there are element indices, which cannot index nodal bathymetry).

While in the same CSV: `obs_water_depth` was read from coord token `[-2]`, which lands on the water depth only for 5-token scalar lines — on 7-token CO-OPS ADCP currents lines it read `height_from_bottom` (same value for every bin of a station), and on 6-token NDBC/USGS/CHS currents lines it read a literal `0.0`. It now reads token `[3]` (the water depth on every line width), so the per-bin obs depths in `skill_{ofs}_currents*_stations.csv` are finally correct.

**Item 3 — "Days elapsed" column wobble.** The `.obs`/`.prd` series writers rounded the Julian-date column to 4 decimals — an 8.64-second grid — so strictly 6-minute data showed consecutive elapsed-day steps fluctuating between 0.0041, 0.0042, and 0.0043 in the paired `.int` files. The writers now round at the 8 decimals the fixed-width format already emits; steps come out at a constant 0.004167 (residual wobble ~1e-8 day, sub-millisecond). Because the float `julian` column was also used as a merge key in two places, those merges are hardened so cached series written at the old precision still combine cleanly with fresh ones: `paired_scalar` now merges obs onto the model series on `DateTime` (exactly what `paired_vector` has always done), and the forecast-horizon CSV accumulator merges on the integer date-component columns.

Suggested labels: bug, user troubleshooting.

### Expected Outcome of Changes

* `{ofs}_cu_model_station.ctl` / `{ofs}_cu_model.ctl` no longer contain rows that differ only in the virtual-bin ID; affected bins are dropped with a WARNING and a `depth_match` row in `station_ledger_{ofs}_*.csv`. Plot count drops accordingly for the pruned bins.
* `skill_{ofs}_currents*_stations.csv`: `mod_water_depth` no longer repeats the bottom value across a station's deepest bins, and `obs_water_depth` now varies per bin (CO-OPS) and is non-zero (NDBC/USGS/CHS). **This is an intentional value change in the currents skill CSVs.**
* Paired `.int` files: the first column advances in uniform 0.004167-day steps for 6-minute data. (The column header `DNUM_JAN1` still holds absolute Julian dates as before — this PR normalizes the rounding, not the column's meaning.)
* **Intentional behavior change in scalar pairing:** `paired_scalar` previously discarded most interpolated obs rows as a side effect of using the julian/date columns as merge keys — for hourly-cadence obs (NDBC/USGS/CHS) against 6-minute model output, only the on-the-hour rows survived. Merging on `DateTime` keeps the interpolated rows (interp limit 3 steps, ffill/bfill limit 1, unchanged), so paired sample counts and skill statistics for stations whose obs cadence is coarser than the model cadence will change. This aligns the scalar path with the currents path, which has always paired this way.
* Runs that reuse cached artifacts: a pre-existing `{ofs}_cu_model_station.ctl` is not rewritten, so the pruning takes effect the first time the model ctl is (re)created — delete the cu model ctl once to adopt it. Old 4-decimal `.obs`/`.prd`/horizon-CSV files pair cleanly with new 8-decimal ones (that is what the merge-key hardening is for); rows only present in an old horizons CSV keep a blank `julian` cell after the next merge (no consumer reads that value).

### Developer Questions and Checklist

**Is this a high priority PR? If yes, why and is there a date by which it needs to be merged?**
No.

**Are there any changes needed to how the code should be run for operational runs? (Commands, flags, job timings, etc.)**
No command changes. One-time note: delete existing `{ofs}_cu_model_station.ctl` / `{ofs}_cu_model.ctl` files so they are regenerated with the pruning applied; runs with fresh control files need no action.

**Does this update need to be deployed for operational runs?**
Yes — it corrects output values in the currents skill CSVs and the paired-file time column.

**Does this update require front end/web app changes? (If yes, provide documentation to Min)**
No.

**Does this impact code development work on adding SCHISM?**
No. The pruning is model-agnostic (the bathymetry lookup already handles ROMS/FVCOM/SCHISM); on STOFS-3D station files, where every layer index is 0, below-bottom bins are simply dropped against the already-surface-only comparison.

**Does this impact code development work on adding ADCIRC?**
No (STOFS-2D-Global has no depth-resolved currents).

**Does this impact the expected number of output files for integration tests (i.e., will the integration test fail even though code changes result in desired change in outputs?)**
Yes, for currents: stations whose reported bin depths exceed the model water depth produce fewer model-ctl rows, paired files, and plots (e.g. CBOFS 2026-07-30 nowcast: 76 → 70 cu ctl rows; SFBOFS same window: 2 bins pruned at s08010). Water level / temperature / salinity file counts are unchanged.

- [x] Developer's name is removed throughout the code?
- [x] Did you add relevant labels to the PR?
- [x] Have you run pylint and is the code at an acceptable pylint score (>8)? (changed files: 9.1/10 aggregate; `write_ofs_ctlfile.py` improved 8.54 → 8.80)
- [x] Jobs contain the appropriate file checking and handle errors for any missing data? (bathymetry lookup failures, unmatched nodes, malformed ctl rows all degrade to keep-everything with a warning)
- [x] Is log free of critical ERRORs or WARNINGs? For errors that are not critical and can remain in code, is there sufficient handling and logging? (new WARNINGs are the intended drop notifications, each mirrored in the station ledger CSV)

### Testing Instructions

Unit tests (30 new across two files, full suite 1190 passed):

```
python -m pytest tests/bins_below_model_bottom_test.py tests/julian_precision_test.py -v
python -m pytest tests/
```

End-to-end (verified on CBOFS/ROMS and SFBOFS/FVCOM, both `-t stations` nowcast). From a workdir with fresh control files (or after `rm control_files/{ofs}_cu_model_station.ctl data/skill/1d_pair/*cu*`):

```
python ./bin/visualization/create_1dplot.py -o cbofs -p ./ -s 2026-07-30T00:00:00Z -e 2026-07-31T00:00:00Z -d MLLW -ws nowcast -t stations -vs water_level,currents
python ./bin/visualization/create_1dplot.py -o sfbofs -p ./ -s 2026-07-30T00:00:00Z -e 2026-07-31T00:00:00Z -d MLLW -ws nowcast -t stations -vs currents,water_temperature
```

What to look for:

1. Run log: `... lie below the model water depth ... dropped from the model ctl file` WARNINGs. On CBOFS this fires for cb0102, cb0201 (the issue's example station), cb0301, cb0402, cb0601; on SFBOFS for s08010 (bins b09 11.70 m / b10 12.71 m vs 11.05 m water depth).
2. `control_files/{ofs}_cu_model_station.ctl`: no two rows for the same parent station share (node, layer, depth). CBOFS cb0201 goes from bins clamped at a repeated bottom depth to six distinct-depth bins.
3. `data/skill/stats/skill_{ofs}_currents*_stations.csv`: `obs_water_depth` varies per bin; `mod_water_depth` has no repeated bottom values.
4. `control_files/station_ledger_{ofs}_cu_*.csv`: pruned bins appear with stage `depth_match` and a reason naming the bin depth, water depth, and node. (In a multi-variable run the ctl files for all variables are created during the first variable's pass, so the `depth_match` rows can land in that variable's ledger CSV — pre-existing ledger scoping, noted for follow-up.)
5. `data/skill/1d_pair/*_pair.int`: first-column steps are a constant 0.004167 for 6-minute data (previously 0.0041/0.0042/0.0043).
6. Temperature/water level: skill CSVs populate with non-NaN metrics; NDBC/USGS station sample counts are higher than pre-PR (see intentional behavior change above).

### Reminder checklist for PR reviewer

- [ ] Run PEP8 compliance tests to ensure the code follows best practices
- [ ] Check that documentation in the script is sufficient
- [ ] Validate the output values (if applicable) to make sure the calculations are correct and make scientific/physical sense; include a comment on the pull request including what validation you performed, for replicability.
- [ ] Test code both on Windows and Linux (and MacOS, if available), using several OFS as test cases
- [ ] **Test for all 'cast' options: forecast_a, forecast_b, and nowcast**
- [ ] When approving or commenting on a pull request, add information on the calls you use in case they need to be replicated or referenced.

### Post-merge follow-up

- [ ] Update the dev-wiki page "E. CO-OPS ADCP current processing" to document the below-bottom bin pruning step (it sits between `index_nearest_depth` and the model-ctl write, with drops logged and recorded on the station ledger under stage `depth_match`).
