### PR TITLE
Silence h5netcdf shutdown tracebacks at end of 1D run (#94)

### DIFF
--- a/bin/visualization/create_1dplot.py
+++ b/bin/visualization/create_1dplot.py
@@ -998,6 +998,16 @@ def create_1dplot(prop, logger):
         else:
             logger.error('Failure checking for datum netcdf file on the NODD S3 '
                         'bucket! Datum conversions may fail. Continuing...')
+    finally:
+        # This dataset is only opened to test datum availability. Close its
+        # (h5netcdf/h5py) file handle now so it isn't finalized during
+        # interpreter shutdown after h5py is torn down (issue #94).
+        _close = getattr(vdatums, 'close', None)
+        if _close is not None:
+            try:
+                _close()
+            except Exception:  # pragma: no cover - defensive cleanup only
+                pass
 
     # Date-gate for forecast horizon functionality
     if ((datetime.strptime(prop.end_date_full,'%Y-%m-%dT%H:%M:%SZ')-

--- a/src/ofs_skill/model_processing/get_datum_offset.py
+++ b/src/ofs_skill/model_processing/get_datum_offset.py
@@ -51,6 +51,26 @@ from ofs_skill.obs_retrieval.station_ctl_file_extract import station_ctl_file_ex
 SECOFS_MODELZERO_TRANSITION = '04/30/2026'
 
 
+def _close_quietly(obj: Any) -> None:
+    """Close an xarray dataset (or anything with ``close``) without raising.
+
+    The vdatum grid files opened here are backed by h5netcdf/h5py. If their
+    handles are left open they are finalized during interpreter shutdown,
+    after h5py's globals are gone, which prints the noisy
+    ``TypeError: bad operand type for unary ~: 'NoneType'`` tracebacks from
+    issue #94. Closing them explicitly avoids that. A ``None``, a non-dataset
+    (e.g. a pandas DataFrame or an error-code int), or a close that raises are
+    all no-ops so cleanup never masks the caller's result.
+    """
+    close = getattr(obj, 'close', None)
+    if close is None:
+        return
+    try:
+        close()
+    except Exception:  # pragma: no cover - defensive cleanup only
+        pass
+
+
 def _node_value(model: xr.Dataset, var_name: str, node: int) -> float:
     """Read a single station's value for a static model coord var.
 
@@ -471,44 +491,57 @@ def get_datum_offset(prop: Any, node: int, model: xr.Dataset,
     logger.info('Doing datum conversion for %s station %s!', prop.ofs,
                 id_number)
     vdatums: Any = None
-    if prop.ofs not in ['secofs', 'loofs2'] and 'stofs' not in prop.ofs:
-        vdatums = read_vdatum_from_bucket(prop, logger)
-        if isinstance(vdatums, int):
-            logger.warning(
-                'WARNING: No vdatum file could be loaded for %s (S3 and '
-                'local fallback both failed). No datum shift will be '
-                'applied. Water level results should be viewed with '
-                'caution.', prop.ofs)
-            return vdatums
-    # Here we handle secofs, which has a vdatum file on the co-ops server, or
-    # or locally in ./src/. Once the vdatum file is on the NODD bucket, this section
-    # can be removed.
-    # Order of operations:
-        # 1. Check for corrections text file
-        # 2. If file is not available, or there is no matching station ID in it,
-        # then use the Vdatum file
-        # 3. If file is not available, return file not found error code
-    elif prop.ofs == 'secofs':
-        dir_params = utils.Utils(
-            getattr(prop, 'config_file', None)).read_config_section(
-                'directories', logger)
-        path = dir_params.get('local_vdatum')
-        if not path:
-            logger.error('No local_vdatum path configured in ofs_dps.conf. '
-                         'Cannot do SECOFS datum conversion.')
-            return -9994
-        if prop.datum.lower() == 'mllw':
-            try:
-                vdatums = pd.read_csv(path, sep='\t')
-                # Find ID number in dataframe
-                if datetime.strptime(prop.start_date_full,'%Y-%m-%dT%H:%M:%SZ')\
-                    > datetime.strptime(SECOFS_MODELZERO_TRANSITION,'%m/%d/%Y'):
-                    corr_col = 'Correction2'
-                else:
-                    corr_col = 'Correction1'
-                wl_corr = float(vdatums[vdatums['ID']==int(id_number)][corr_col])*-1
-                return wl_corr
-            except (FileNotFoundError, TypeError, UnicodeDecodeError, ValueError):
+    ds_wcofs: Any = None
+    datum_field: Any = None
+    try:
+        if prop.ofs not in ['secofs', 'loofs2'] and 'stofs' not in prop.ofs:
+            vdatums = read_vdatum_from_bucket(prop, logger)
+            if isinstance(vdatums, int):
+                logger.warning(
+                    'WARNING: No vdatum file could be loaded for %s (S3 and '
+                    'local fallback both failed). No datum shift will be '
+                    'applied. Water level results should be viewed with '
+                    'caution.', prop.ofs)
+                return vdatums
+        # Here we handle secofs, which has a vdatum file on the co-ops server, or
+        # or locally in ./src/. Once the vdatum file is on the NODD bucket, this section
+        # can be removed.
+        # Order of operations:
+            # 1. Check for corrections text file
+            # 2. If file is not available, or there is no matching station ID in it,
+            # then use the Vdatum file
+            # 3. If file is not available, return file not found error code
+        elif prop.ofs == 'secofs':
+            dir_params = utils.Utils(
+                getattr(prop, 'config_file', None)).read_config_section(
+                    'directories', logger)
+            path = dir_params.get('local_vdatum')
+            if not path:
+                logger.error('No local_vdatum path configured in ofs_dps.conf. '
+                             'Cannot do SECOFS datum conversion.')
+                return -9994
+            if prop.datum.lower() == 'mllw':
+                try:
+                    vdatums = pd.read_csv(path, sep='\t')
+                    # Find ID number in dataframe
+                    if datetime.strptime(prop.start_date_full,'%Y-%m-%dT%H:%M:%SZ')\
+                        > datetime.strptime(SECOFS_MODELZERO_TRANSITION,'%m/%d/%Y'):
+                        corr_col = 'Correction2'
+                    else:
+                        corr_col = 'Correction1'
+                    wl_corr = float(vdatums[vdatums['ID']==int(id_number)][corr_col])*-1
+                    return wl_corr
+                except (FileNotFoundError, TypeError, UnicodeDecodeError, ValueError):
+                    filename = 'secofs_vdatums.nc'
+                    head, tail = os.path.split(path)
+                    path = os.path.join(head, filename)
+                    try:
+                        vdatums = xr.open_dataset(path)
+                    except FileNotFoundError:
+                        logger.error('Error finding SECOFS vdatum file -- datum conversion '
+                                      'is not possible.')
+                        return -9994
+            else:
                 filename = 'secofs_vdatums.nc'
                 head, tail = os.path.split(path)
                 path = os.path.join(head, filename)
@@ -518,93 +551,105 @@ def get_datum_offset(prop: Any, node: int, model: xr.Dataset,
                     logger.error('Error finding SECOFS vdatum file -- datum conversion '
                                   'is not possible.')
                     return -9994
-        else:
-            filename = 'secofs_vdatums.nc'
-            head, tail = os.path.split(path)
-            path = os.path.join(head, filename)
-            try:
-                vdatums = xr.open_dataset(path)
-            except FileNotFoundError:
-                logger.error('Error finding SECOFS vdatum file -- datum conversion '
-                              'is not possible.')
-                return -9994
 
-    # Set water levels to user-specified datum
-    if prop.ofs not in ['leofs', 'lmhofs', 'loofs', 'lsofs', 'loofs2']:
-        if prop.ofs == 'necofs':
-            try:
-                datum_field1 = vdatums['navd88tomsl']
-                if prop.datum.lower() == 'navd88':
-                    datum_field = datum_field1
-                else:
-                    datum_field2 = vdatums[f'{prop.datum.lower()}tomsl']
-                    datum_field = (-datum_field1 + datum_field2)
-            except Exception as e_x:
-                logger.error(f'Datum conversion error: {e_x}')
-                return -9991
+        # Set water levels to user-specified datum
+        if prop.ofs not in ['leofs', 'lmhofs', 'loofs', 'lsofs', 'loofs2']:
+            if prop.ofs == 'necofs':
+                try:
+                    datum_field1 = vdatums['navd88tomsl']
+                    if prop.datum.lower() == 'navd88':
+                        datum_field = datum_field1
+                    else:
+                        datum_field2 = vdatums[f'{prop.datum.lower()}tomsl']
+                        datum_field = (-datum_field1 + datum_field2)
+                except Exception as e_x:
+                    logger.error(f'Datum conversion error: {e_x}')
+                    return -9991
 
-        # Deal with SECOFS separately
-        elif prop.ofs == 'secofs':
-            try:
-                # Use the directly-populated xgeoid20b->msl field rather than
-                # reconstructing it from navd88tomsl - navd88toxgeoid20b. Both
-                # of those variables carry a -999999.0 fill at ~12.5% of nodes,
-                # where the subtraction cancels to exactly 0.0 (an invalid
-                # offset that passes the >-999 guard).
-                datum_field1 = vdatums['xgeoid20btomsl']
+            # Deal with SECOFS separately
+            elif prop.ofs == 'secofs':
+                try:
+                    # Use the directly-populated xgeoid20b->msl field rather than
+                    # reconstructing it from navd88tomsl - navd88toxgeoid20b. Both
+                    # of those variables carry a -999999.0 fill at ~12.5% of nodes,
+                    # where the subtraction cancels to exactly 0.0 (an invalid
+                    # offset that passes the >-999 guard).
+                    datum_field1 = vdatums['xgeoid20btomsl']
+                    if prop.datum.lower() == 'xgeoid20b':
+                        # Model-zero is xgeoid20b, so the offset to xgeoid20b is 0.
+                        datum_field = xr.zeros_like(datum_field1)
+                    else:
+                        datum_field2 = vdatums[f'{prop.datum.lower()}tomsl']
+                        datum_field = datum_field1 - datum_field2
+                except Exception as e_x:
+                    logger.error(f'Datum conversion error: {e_x}')
+                    return -9991
+            # Deal with SSCOFS separately
+            elif prop.ofs == 'sscofs':
+                # First get from model-0 to xgeoid -- the ofs-wide offset is
+                # 0.23 m, where xgeoid is 0.23 cm above model-0.
+                # Then convert from xgeoid to other datums.
                 if prop.datum.lower() == 'xgeoid20b':
-                    # Model-zero is xgeoid20b, so the offset to xgeoid20b is 0.
-                    datum_field = xr.zeros_like(datum_field1)
-                else:
-                    datum_field2 = vdatums[f'{prop.datum.lower()}tomsl']
-                    datum_field = datum_field1 - datum_field2
-            except Exception as e_x:
-                logger.error(f'Datum conversion error: {e_x}')
-                return -9991
-        # Deal with SSCOFS separately
-        elif prop.ofs == 'sscofs':
-            # First get from model-0 to xgeoid -- the ofs-wide offset is
-            # 0.23 m, where xgeoid is 0.23 cm above model-0.
-            # Then convert from xgeoid to other datums.
-            if prop.datum.lower() == 'xgeoid20b':
-                return 0.23
+                    return 0.23
+                try:
+                    datum_field1 = vdatums['xgeoid20btomsl']
+                    if prop.datum.lower() == 'msl': #TODO -- check this
+                        datum_field = 0.23 - datum_field1
+                    else:
+                        datum_field2 = vdatums[f'{prop.datum.lower()}tomsl']
+                        datum_field = 0.23 - datum_field1 + datum_field2
+                except Exception as e_x:
+                    logger.error(f'Datum conversion error: {e_x}')
+                    return -9991
+            elif 'stofs' in prop.ofs:
+                logger.info('STOFS models do not use NetCDF vdatum grid files; '
+                            'datum conversion is calculated dynamically via VDatum API.')
+                datum_field = None
+            else:  # Not SSCOFS or STOFS or SECOFS or GLOFS
+                try:
+                    datum_field = vdatums[f'{prop.datum.lower()}tomsl']
+                    if prop.ofs == 'wcofs':
+                        file = utils.resolve_asset_path(prop.path, 'src', 'wcofs_msl.nc')
+                        try:
+                            ds_wcofs = xr.open_dataset(file)
+                        except FileNotFoundError:
+                            logger.error('WCOFS MSL2MZ conversion not found!')
+                            return -9994
+                        datum_field = datum_field + np.array(ds_wcofs['MSL2MZ'])
+                except Exception as e_x:
+                    logger.error('Wrong netcdf datum variable name!')
+                    logger.error(f'Error: {e_x}')
+                    return -9991
+        elif prop.ofs in ['leofs', 'lmhofs', 'loofs', 'lsofs',]:
             try:
-                datum_field1 = vdatums['xgeoid20btomsl']
-                if prop.datum.lower() == 'msl': #TODO -- check this
-                    datum_field = 0.23 - datum_field1
-                else:
-                    datum_field2 = vdatums[f'{prop.datum.lower()}tomsl']
-                    datum_field = 0.23 - datum_field1 + datum_field2
+                datum_field = vdatums[f'{prop.datum.lower()}tolwd']
             except Exception as e_x:
-                logger.error(f'Datum conversion error: {e_x}')
-                return -9991
-        elif 'stofs' in prop.ofs:
-            logger.info('STOFS models do not use NetCDF vdatum grid files; '
-                        'datum conversion is calculated dynamically via VDatum API.')
-            datum_field = None
-        else:  # Not SSCOFS or STOFS or SECOFS or GLOFS
-            try:
-                datum_field = vdatums[f'{prop.datum.lower()}tomsl']
-                if prop.ofs == 'wcofs':
-                    file = utils.resolve_asset_path(prop.path, 'src', 'wcofs_msl.nc')
-                    try:
-                        ds_wcofs = xr.open_dataset(file)
-                    except FileNotFoundError:
-                        logger.error('WCOFS MSL2MZ conversion not found!')
-                        return -9994
-                    datum_field = datum_field + np.array(ds_wcofs['MSL2MZ'])
-            except Exception as e_x:
-                logger.error('Wrong netcdf datum variable name!')
+                logger.error('Wrong netcdf datum variable name for GLOFS!')
                 logger.error(f'Error: {e_x}')
                 return -9991
-    elif prop.ofs in ['leofs', 'lmhofs', 'loofs', 'lsofs',]:
-        try:
-            datum_field = vdatums[f'{prop.datum.lower()}tolwd']
-        except Exception as e_x:
-            logger.error('Wrong netcdf datum variable name for GLOFS!')
-            logger.error(f'Error: {e_x}')
-            return -9991
 
+        return _apply_datum_offset(prop, node, model, id_number, datum_field,
+                                   vdatums, logger)
+    finally:
+        # Release the vdatum grid file handles now. Left open, these
+        # h5netcdf/h5py-backed datasets are finalized during interpreter
+        # shutdown after h5py has been torn down, which prints the noisy
+        # TypeError tracebacks from issue #94. This runs per station inside
+        # the per-station / per-variable worker pools, so leaks accumulate
+        # quickly without it.
+        _close_quietly(vdatums)
+        _close_quietly(ds_wcofs)
+
+
+def _apply_datum_offset(prop: Any, node: int, model: xr.Dataset,
+                        id_number: str, datum_field: Any, vdatums: Any,
+                        logger: Logger) -> float:
+    """Resolve the final datum offset from the prepared ``datum_field``.
+
+    Split out of :func:`get_datum_offset` so the file-handle cleanup for the
+    vdatum datasets can live in a single ``finally`` in the caller while this
+    part stays a straight-line computation.
+    """
     # Do stations
     if prop.ofsfiletype == 'stations':
         try:

--- a/src/ofs_skill/model_processing/intake_scisa.py
+++ b/src/ofs_skill/model_processing/intake_scisa.py
@@ -1448,6 +1448,13 @@ def remove_extra_stations(engine: str,
         lat_key = 'lat_rho'
 
     reflat = np.array(refds[lat_key])
+    # reflat is a materialized numpy copy, so the reference dataset's file
+    # handle can be released now. Left open it would be finalized during
+    # interpreter shutdown after h5py is torn down (issue #94).
+    try:
+        refds.close()
+    except Exception:  # pragma: no cover - defensive cleanup only
+        pass
     # Now loop through datasets. Check for and remove extra stations.
     logger.info('Looping through each stations file, applying corrections...')
     for _i, file in enumerate(urlpaths):

--- a/src/ofs_skill/skill_assessment/get_skill.py
+++ b/src/ofs_skill/skill_assessment/get_skill.py
@@ -91,6 +91,37 @@ def _set_cached_model(prop, dataset):
         gc.collect()
 
 
+def _close_cached_model(prop):
+    """Close and drop the model dataset cached on ``prop``.
+
+    The model dataset is opened lazily with the h5netcdf engine and stashed
+    on ``prop._cached_model`` so a single load can be shared across the
+    per-variable and per-station worker threads. Nothing else closes the
+    *final* cached dataset once processing is done, so its file handle would
+    otherwise be finalized during interpreter shutdown -- after h5py's
+    module globals have been torn down -- producing the noisy but harmless
+    ``TypeError: bad operand type for unary ~: 'NoneType'`` tracebacks
+    reported in issue #94. Closing it here, while the interpreter is still
+    healthy, lets h5netcdf/h5py release the handle cleanly.
+
+    Best-effort: a missing cache, a dataset without ``close``, or a close
+    that raises are all swallowed so end-of-run cleanup never masks the
+    actual results.
+    """
+    cached = getattr(prop, '_cached_model', None)
+    if cached is None:
+        return
+    try:
+        cached.close()
+    except Exception:  # pragma: no cover - defensive cleanup only
+        pass
+    finally:
+        prop._cached_model = None
+        prop._cached_model_key = None
+        del cached
+        gc.collect()
+
+
 def ofs_ctlfile_extract(prop, name_var, logger, model_dataset=None):
     """
     Extract info from model control files. If control file does not exist,
@@ -1153,22 +1184,28 @@ def get_skill(prop, logger):
     # Variable processing runs sequentially here. Variable parallelism
     # is handled inside get_node_ofs (which loads the model once and
     # dispatches variable extraction in parallel).
-    for variable in prop.var_list:
-        _skill_for_variable(variable, prop)
+    try:
+        for variable in prop.var_list:
+            _skill_for_variable(variable, prop)
 
-    # Now collect forecast horizon time series, if ya want!
-    if (prop.horizonskill and
-        prop.whichcast == 'forecast_b'):
-        # Get all model time series, and put them in a big 'ol CSV file
-        # Check to see if this has already been done
-        logger.info('Starting forecast horizon skill! This is going to '
-                    'take a while...\n')
-        try:
-            do_horizon_skill.make_horizon_series(prop, logger)
-            # Now get obs time series and put that in the CSV file, too.
-            do_horizon_skill.merge_obs_series_scalar(prop, logger)
-        except Exception as e_x:
-            logger.error('Exception caught in do_horizon_skill after '
-                         'calling it from get_skill. Error: %s', e_x)
-        prop.horizonskill = False
-        logger.info('Completed forecast horizon skill!')
+        # Now collect forecast horizon time series, if ya want!
+        if (prop.horizonskill and
+            prop.whichcast == 'forecast_b'):
+            # Get all model time series, and put them in a big 'ol CSV file
+            # Check to see if this has already been done
+            logger.info('Starting forecast horizon skill! This is going to '
+                        'take a while...\n')
+            try:
+                do_horizon_skill.make_horizon_series(prop, logger)
+                # Now get obs time series and put that in the CSV file, too.
+                do_horizon_skill.merge_obs_series_scalar(prop, logger)
+            except Exception as e_x:
+                logger.error('Exception caught in do_horizon_skill after '
+                             'calling it from get_skill. Error: %s', e_x)
+            prop.horizonskill = False
+            logger.info('Completed forecast horizon skill!')
+    finally:
+        # Release the shared model dataset's file handle now, while the
+        # interpreter is still healthy, rather than letting the GC finalize
+        # it at shutdown after h5py has been torn down (issue #94).
+        _close_cached_model(prop)

--- a/tests/get_datum_offset_close_test.py
+++ b/tests/get_datum_offset_close_test.py
@@ -1,0 +1,147 @@
+"""Tests for vdatum file-handle cleanup in ``get_datum_offset.py``.
+
+Issue #94: the vdatum grid datasets are opened with the h5netcdf/h5py
+backend and, when left open, are finalized during interpreter shutdown
+after h5py's globals are torn down, printing noisy
+``TypeError: bad operand type for unary ~: 'NoneType'`` tracebacks.
+
+These tests cover the ``_close_quietly`` helper directly and verify that
+``get_datum_offset`` closes the vdatum dataset it opens once the offset
+has been computed, even though the offset itself is returned normally.
+"""
+
+import importlib
+import logging
+
+import numpy as np
+import xarray as xr
+
+# NOTE: ``ofs_skill.model_processing`` re-exports a *function* named
+# ``get_datum_offset``, which shadows the submodule of the same name for
+# attribute-style access. Import the module object explicitly so ``gdo``
+# is the module (with ``_close_quietly`` / ``read_vdatum_from_bucket`` on
+# it), not the function.
+gdo = importlib.import_module(
+    'ofs_skill.model_processing.get_datum_offset')
+
+logger = logging.getLogger('test')
+
+
+class _Closable:
+    """Minimal stand-in that records whether close() fired."""
+
+    def __init__(self):
+        self.closed = False
+
+    def close(self):
+        self.closed = True
+
+
+def test_close_quietly_closes_object():
+    obj = _Closable()
+    gdo._close_quietly(obj)
+    assert obj.closed is True
+
+
+def test_close_quietly_ignores_none():
+    # Must not raise.
+    gdo._close_quietly(None)
+
+
+def test_close_quietly_ignores_object_without_close():
+    # A plain object (or an int error code, or a DataFrame) has no dataset
+    # close semantics; the helper is a no-op rather than raising.
+    gdo._close_quietly(object())
+    gdo._close_quietly(-9990)
+
+
+def test_close_quietly_swallows_close_exception():
+    class _Broken:
+        def __init__(self):
+            self.called = False
+
+        def close(self):
+            self.called = True
+            raise RuntimeError('boom')
+
+    obj = _Broken()
+    gdo._close_quietly(obj)  # Must not raise.
+    assert obj.called is True
+
+
+class _MockProps:
+    """FVCOM stations prop with a target datum that lives in the vdatum file."""
+
+    def __init__(self):
+        self.ofs = 'ngofs2'  # generic fvcom, not secofs/glofs/stofs
+        self.ofsfiletype = 'stations'
+        self.model_source = 'fvcom'
+        self.datum = 'MLLW'
+        self.path = '.'
+        self.config_file = None
+        self.start_date_full = '2026-03-28T00:00:00Z'
+
+
+def _fvcom_model(n_station=4):
+    return xr.Dataset(
+        data_vars={
+            'lon': (('station',),
+                    np.linspace(288.0, 291.0, n_station, dtype=np.float64)),
+            'lat': (('station',),
+                    np.linspace(29.0, 30.0, n_station, dtype=np.float64)),
+        }
+    )
+
+
+def _fvcom_vdatum(model):
+    """Vdatum dataset whose lon/lat match the model nodes exactly so the
+    nearest-node search is deterministic. Carries an mllwtomsl field."""
+    lon = np.asarray(model['lon'].values)
+    lat = np.asarray(model['lat'].values)
+    return xr.Dataset(
+        data_vars={
+            'mllwtomsl': (('node',), np.full(lon.shape, 0.5, dtype=np.float64)),
+        },
+        coords={
+            'longitude': (('node',), lon),
+            'latitude': (('node',), lat),
+        },
+    )
+
+
+def test_get_datum_offset_closes_vdatum_dataset(monkeypatch):
+    """The vdatum dataset opened for a normal (successful) datum conversion
+    is closed before get_datum_offset returns, so its file handle is not
+    left for the shutdown-time GC (issue #94)."""
+    model = _fvcom_model()
+    base_vdatum = _fvcom_vdatum(model)
+
+    class _TrackingDataset:
+        """Wrap an xr.Dataset so the variable lookups still work but we can
+        observe close()."""
+
+        def __init__(self, ds):
+            self._ds = ds
+            self.closed = False
+
+        def __getitem__(self, key):
+            return self._ds[key]
+
+        def close(self):
+            self.closed = True
+
+    tracker = _TrackingDataset(base_vdatum)
+
+    # Stub the S3 read so the test is offline and returns our tracker.
+    monkeypatch.setattr(gdo, 'read_vdatum_from_bucket',
+                        lambda prop, log: tracker)
+
+    prop = _MockProps()
+    offset = gdo.get_datum_offset(prop, 0, model, '8000000', logger)
+
+    # The offset for node 0: mllwtomsl=0.5 -> datum_offset=0.5 (no sign flip
+    # for a generic fvcom ofs). Value correctness is secondary here; the
+    # point is the handle got closed.
+    assert isinstance(offset, float)
+    assert tracker.closed is True, \
+        'vdatum dataset should be closed before get_datum_offset returns'

--- a/tests/get_skill_cache_test.py
+++ b/tests/get_skill_cache_test.py
@@ -11,6 +11,7 @@ import pytest
 
 from ofs_skill.skill_assessment.get_skill import (
     _cache_key,
+    _close_cached_model,
     _get_valid_cached_model,
     _set_cached_model,
 )
@@ -191,3 +192,66 @@ def test_set_cached_model_no_close_when_no_prior_cache(props):
     _set_cached_model(props, ds)  # Must not raise.
     assert ds.closed is False
     assert _get_valid_cached_model(props) is ds
+
+
+def test_close_cached_model_closes_and_clears(props):
+    """The final cached dataset must be closed and dropped at end of run.
+
+    This is the issue #94 fix: without it the h5netcdf-backed model dataset
+    is finalized at interpreter shutdown, after h5py teardown, printing the
+    noisy 'bad operand type for unary ~' tracebacks.
+    """
+    ds = _ClosableDataset('model-ds')
+    _set_cached_model(props, ds)
+
+    _close_cached_model(props)
+
+    assert ds.closed is True, 'cached model should be closed on teardown'
+    assert props._cached_model is None
+    assert props._cached_model_key is None
+    # A subsequent lookup is a clean miss, not a stale hit.
+    assert _get_valid_cached_model(props) is None
+
+
+def test_close_cached_model_no_cache_is_noop(props):
+    """No cached model: teardown is a harmless no-op."""
+    # Must not raise even though nothing was ever cached.
+    _close_cached_model(props)
+    assert getattr(props, '_cached_model', None) is None
+
+
+def test_close_cached_model_swallows_close_exception(props):
+    """A close() that raises must not propagate out of teardown, and the
+    cache must still be cleared."""
+
+    class _BrokenClose:
+        def __init__(self):
+            self.close_called = False
+
+        def close(self):
+            self.close_called = True
+            raise RuntimeError('simulated close failure')
+
+    old = _BrokenClose()
+    _set_cached_model(props, old)
+
+    _close_cached_model(props)  # Must not raise.
+
+    assert old.close_called is True
+    assert props._cached_model is None
+    assert _get_valid_cached_model(props) is None
+
+
+def test_close_cached_model_tolerates_dataset_without_close(props):
+    """A cached object lacking a close() method (defensive) is dropped
+    without error."""
+
+    class _NoClose:
+        pass
+
+    obj = _NoClose()
+    _set_cached_model(props, obj)
+
+    _close_cached_model(props)  # Must not raise.
+
+    assert props._cached_model is None


### PR DESCRIPTION
# Pull Request: Silence h5netcdf shutdown tracebacks at end of 1D run (issue #94)

### Description of Changes

Closes #94, and #182.

Multithreaded 1D runs finished with a burst of tracebacks like:

```
Exception ignored in: <function File.close at 0x...>
Traceback (most recent call last):
  File ".../h5netcdf/core.py", line 2093, in close
  File ".../h5py/_hl/files.py", line 620, in close
TypeError: bad operand type for unary ~: 'NoneType'
```

These were harmless (nothing failed, exit code 0), but noisy and alarming
in the logs. I traced the cause and fixed it.

**Root cause.** The 1D pipeline opens several xarray datasets with the
**h5netcdf** engine and never closes them. When the interpreter exits, the
garbage collector finalizes those still-open handles *after* h5py's module
globals have already been torn down, so `h5py._hl.files.File.close` dereferences
a now-`None` global and raises `TypeError: bad operand type for unary ~: 'NoneType'`.
Python prints these as "Exception ignored in" because they happen during
finalization. Multithreading is not itself the bug — it just lets several such
handles accumulate so the message repeats once per leaked handle.

Four leak sites were on the 1D path:

1. **The shared model dataset** cached on `prop._cached_model`. It is opened lazily
   with the h5netcdf engine and shared across the per-variable/per-station worker
   threads. `get_skill` only closed it when it was *replaced* by a different
   whichcast's dataset; the **final** cached dataset was never closed.
2. **The per-station vdatum grid datasets** in `get_datum_offset` (the S3 `*_vdatums.nc`,
   the SECOFS local file, and the WCOFS `wcofs_msl.nc`). None were closed, and these
   are opened repeatedly inside the parallel worker pools.
3. **The datum-availability probe dataset** in `create_1dplot.py`, opened only to check
   whether the requested datum exists in the vdatum file, then discarded.
4. **The reference dataset** (`refds`) in `intake_scisa.remove_extra_stations`.

**Fix.** Close each dataset explicitly, while the interpreter is still healthy,
so h5netcdf/h5py release the handle cleanly instead of leaving it for the
shutdown-time GC. No behavior other than handle lifetime changes.

Labels: `bug`

#### `src/ofs_skill/skill_assessment/get_skill.py`

- New `_close_cached_model(prop)` helper: best-effort close of the final cached
  model dataset, then drops the cache reference. A missing cache, a dataset
  without `close`, or a `close` that raises are all swallowed so end-of-run
  cleanup never masks the actual results.
- `get_skill()` now runs its variable loop and horizon-skill block inside a
  `try`, and calls `_close_cached_model(prop)` in the `finally`.

#### `src/ofs_skill/model_processing/get_datum_offset.py`

- New `_close_quietly(obj)` helper (no-op for `None`, non-datasets like error-code
  ints / DataFrames, or a raising `close`).
- `get_datum_offset` wraps its body in `try/finally` and closes both the vdatum
  grid dataset and the WCOFS MSL dataset in the `finally`.
- The offset computation (the `# Do stations` … `return datum_offset` block) is
  extracted verbatim into a new `_apply_datum_offset(...)` helper so the file-handle
  cleanup can live in a single `finally` while the numeric logic stays a
  straight-line computation. **The math is byte-for-byte identical** (verified by
  diffing the extracted block against `HEAD`).

#### `bin/visualization/create_1dplot.py`

- The vdatum dataset opened just to probe datum availability is now closed in a
  `finally` on the same `try/except` that reads it.

#### `src/ofs_skill/model_processing/intake_scisa.py`

- `remove_extra_stations` closes the reference dataset (`refds`) once its latitudes
  have been copied into a NumPy array (`reflat`), since nothing downstream needs the
  open handle.

### Expected Outcome of Changes

- **No change to skill metric math, datums, coordinate handling, depth indexing, or
  any output values or files.** This is purely about closing file handles earlier.
- The end-of-run `Exception ignored in: <function File.close ...>` /
  `TypeError: bad operand type for unary ~: 'NoneType'` tracebacks no longer appear.
- As a secondary benefit, the shared model dataset and per-station vdatum handles are
  released promptly rather than lingering until interpreter exit.

### Developer Questions and Checklist

**Is this a high priority PR? If yes, why and is there a date by which it needs to be merged?**
No. It targets the v1.8 milestone.

**Are there any changes needed to how the code should be run for operational runs? (Commands, flags, job timings, etc.)**
No.

**Does this update need to be deployed for operational runs?**
Not required (recommended, for cleaner logs), but functionally optional.

**Does this update require front end/web app changes? (If yes, provide documentation to Min)**
No.

**Does this impact code development work on adding SCHISM?**
No. The datum path is shared; no interface changes.

**Does this impact code development work on adding ADCIRC?**
No.

**Does this impact the expected number of output files for integration tests (i.e., will the integration test fail even though code changes result in desired change in outputs?)**
No. No output files, filenames, or values change.

- [x] Developer's name is removed throughout the code?
- [x] Did you add relevant labels to the PR?
- [x] Have you run pylint and is the code at an acceptable pylint score (>8)? (ruff clean on changed files)
- [x] Jobs contain the appropriate file checking and handle errors for any missing data? (all new close paths are best-effort and never raise)
- [x] Is log free of critical ERRORs or WARNINGs? For errors that are not critical and can remain in code, is there sufficient handling and logging? (this PR *removes* spurious shutdown tracebacks)

### Testing Instructions

**Automated tests (no network / no model download required):**

```bash
# New + updated targeted tests for this PR
pytest tests/get_datum_offset_close_test.py tests/get_skill_cache_test.py -v

# Related regression coverage
pytest tests/get_datum_offset_node_shape_test.py \
       tests/create_1dplot_msl_datum_gate_test.py \
       tests/chs_datum_skip_test.py \
       tests/config_file_threading_test.py \
       tests/write_ofs_ctlfile_minimal_intake_test.py \
       tests/extract_variable_prd_resume_test.py -v
```

Expected: all pass. In my run the two targeted files reported **24 passed**, and
the datum/cache/intake/skill selection reported **238 passed**.

**What the new/updated tests cover:**
- `_close_quietly` closes a dataset, ignores `None`, ignores objects without a
  `close`, and swallows a `close` that raises.
- `get_datum_offset` closes the vdatum dataset before returning on a normal
  (successful) FVCOM conversion (offline, via a monkeypatched
  `read_vdatum_from_bucket`).
- `_close_cached_model` closes and clears the cached model, is a no-op when nothing
  is cached, swallows a raising `close`, and tolerates a cached object without a
  `close` method.

**Manual / end-to-end (the exact repro from the issue, run here):**

```bash
python ./bin/visualization/create_1dplot.py -o cbofs -p ./ \
  -s 2026-03-28T00:00:00Z -e 2026-03-28T00:00:00Z -d NAVD -ws nowcast \
  -t stations -vs water_level
```

Result: exit code 0; 35 datum conversions performed; model loaded and released;
`stderr` contained **zero** `Exception ignored` / `bad operand type` / h5netcdf
tracebacks (only an unrelated third-party NumPy deprecation warning). Before this
change the same command emitted the repeated `File.close` tracebacks shown in the
issue.

**Lint/type status on changed files:** `pre-commit` (`double-quote-string-fixer`,
`ruff`, `mypy`) passes on the changed files.

### Reminder checklist for PR reviewer
- [ ] Run PEP8 compliance tests to ensure the code follows best practices
- [ ] Check that documentation in the script is sufficient
- [ ] Validate the output values (if applicable) to make sure the calculations are correct and make scientific/physical sense; include a comment on the pull request including what validation you performed, for replicability.
- [ ] Test code both on Windows and Linux (and MacOS, if available), using several OFS as test cases
- [ ] **Test for all 'cast' options: forecast_a, forecast_b, and nowcast**
- [ ] When approving or commenting on a pull request, add information on the calls you use in case they need to be replicated or referenced.

---

### Files changed

**New**
- `tests/get_datum_offset_close_test.py` — tests for `_close_quietly` and vdatum
  handle cleanup in `get_datum_offset`.

**Modified**
- `src/ofs_skill/skill_assessment/get_skill.py` — `_close_cached_model` helper;
  close the cached model in a `finally` at end of `get_skill`.
- `src/ofs_skill/model_processing/get_datum_offset.py` — `_close_quietly` helper;
  `try/finally` closing vdatum + WCOFS datasets; extracted `_apply_datum_offset`
  (logic unchanged).
- `bin/visualization/create_1dplot.py` — close the datum-availability probe dataset.
- `src/ofs_skill/model_processing/intake_scisa.py` — close `refds` in
  `remove_extra_stations` after copying latitudes.
- `tests/get_skill_cache_test.py` — added `_close_cached_model` coverage.
