### PR TITLE
Prefer USGS NAVD88 water-level codes, led by the new 63160 series

### DIFF
--- a/src/ofs_skill/obs_retrieval/get_station_observations.py
+++ b/src/ofs_skill/obs_retrieval/get_station_observations.py
@@ -537,6 +537,7 @@ def _fetch_and_format_station(
                 retrieve_input.start_date = start_date
                 retrieve_input.end_date = end_date
                 retrieve_input.variable = variable
+                retrieve_input.datum = datum
                 timeseries = retrieve_usgs_station(
                     retrieve_input, logger
                 )

--- a/src/ofs_skill/obs_retrieval/retrieve_usgs_station.py
+++ b/src/ofs_skill/obs_retrieval/retrieve_usgs_station.py
@@ -39,9 +39,22 @@ _FEET_TO_METERS_CODES = {
     '63158',
 }
 
-# Datum assignment by code
-_IGLD_CODES = {'72214', '72215'}
-_NGVD_CODES = {'62616', '62614', '63161', '62617', '63158'}
+# Water-level code preference within each datum family. USGS is migrating
+# stream gages to 63160 "Stream level, NAVD88" (new time series per station,
+# target Dec 2026 — issue #133), so true-datum elevation codes must win over
+# legacy gage height (00065) whenever a station serves both.
+_NAVD88_WL_CODES = ['63160', '62620', '72279', '62615', '63161', '62622',
+                    '62617']
+_NGVD_WL_CODES = ['63158', '62614', '62616']
+_IGLD_WL_CODES = ['72214', '72215']
+# Gage height: referenced to the local gage datum, not a vertical datum.
+# Kept as a last resort and assumed ~NAVD88 (historical behavior).
+_GAGE_HEIGHT_WL_CODES = ['00065']
+
+# Datum assignment by code (62617 and 63161 are NAVD88 per the USGS
+# parameter-code dictionary; anything not IGLD/NGVD is labeled NAVD88)
+_IGLD_CODES = set(_IGLD_WL_CODES)
+_NGVD_CODES = set(_NGVD_WL_CODES)
 
 # Temperature codes in Fahrenheit
 _FAHRENHEIT_CODES = {'00011'}
@@ -58,6 +71,26 @@ _SPECIFIC_CONDUCTANCE_CODES = {'00095'}
 
 # Preferred salinity codes (actual salinity, not conductance)
 _PREFERRED_SALINITY_CODES = {'00480', '72401', '90860', '90862', '00096', '70305'}
+
+
+def _water_level_code_priority(requested_datum: str) -> list:
+    """Return water-level parameter codes in preference order.
+
+    Codes in the family matching the requested datum come first (a direct
+    match avoids a vdatum conversion downstream), then the remaining
+    families with NAVD88 leading (vdatum-convertible to tidal datums).
+    Gage height (00065) is always last: it is referenced to the local gage
+    datum, not a true vertical datum.
+    """
+    datum_upper = (requested_datum or '').upper()
+    if 'IGLD' in datum_upper or 'LWD' in datum_upper:
+        families = [_IGLD_WL_CODES, _NAVD88_WL_CODES, _NGVD_WL_CODES]
+    elif 'NGVD' in datum_upper:
+        families = [_NGVD_WL_CODES, _NAVD88_WL_CODES, _IGLD_WL_CODES]
+    else:
+        families = [_NAVD88_WL_CODES, _NGVD_WL_CODES, _IGLD_WL_CODES]
+    return [code for family in families for code in family] + \
+        _GAGE_HEIGHT_WL_CODES
 
 
 def retrieve_usgs_station(
@@ -166,8 +199,27 @@ def retrieve_usgs_station(
         if not preferred.empty:
             data_filtered = preferred
 
-    # Use the first available code that has data
-    first_code = data_filtered['code'].iloc[0]
+    if variable == 'water_level':
+        # Pick the best available code rather than the first one the API
+        # happens to return: stations transitioning to 63160 (issue #133)
+        # serve both the new NAVD88 series and legacy gage height.
+        priority = _water_level_code_priority(
+            getattr(retrieve_input, 'datum', '')
+        )
+        codes_present = set(data_filtered['code'])
+        first_code = next(
+            (code for code in priority if code in codes_present),
+            data_filtered['code'].iloc[0],
+        )
+        if first_code in _GAGE_HEIGHT_WL_CODES:
+            logger.info(
+                'USGS station %s water level uses gage height (00065), '
+                'which is referenced to the local gage datum; assuming '
+                'NAVD88.', station
+            )
+    else:
+        # Use the first available code that has data
+        first_code = data_filtered['code'].iloc[0]
     data_for_code = data_filtered[data_filtered['code'] == first_code].copy()
 
     # Filter to a single time series to avoid duplicate timestamps.

--- a/src/ofs_skill/obs_retrieval/retrieve_usgs_station.py
+++ b/src/ofs_skill/obs_retrieval/retrieve_usgs_station.py
@@ -47,9 +47,16 @@ _NAVD88_WL_CODES = ['63160', '62620', '72279', '62615', '63161', '62622',
                     '62617']
 _NGVD_WL_CODES = ['63158', '62614', '62616']
 _IGLD_WL_CODES = ['72214', '72215']
-# Gage height: referenced to the local gage datum, not a vertical datum.
-# Kept as a last resort and assumed ~NAVD88 (historical behavior).
+# Gage height: referenced to the local gage datum, not a true vertical
+# datum. Assumed ~NAVD88 (historical behavior).
 _GAGE_HEIGHT_WL_CODES = ['00065']
+
+# A higher-priority code is only selected when it has at least this
+# fraction of the valid samples of the best-covered candidate. During the
+# 63160 migration a just-activated series can cover a sliver of the
+# requested window while the legacy series covers all of it; without this
+# guard the sparse series would silently win on priority alone.
+_MIN_RELATIVE_COVERAGE = 0.5
 
 # Datum assignment by code (62617 and 63161 are NAVD88 per the USGS
 # parameter-code dictionary; anything not IGLD/NGVD is labeled NAVD88)
@@ -77,20 +84,56 @@ def _water_level_code_priority(requested_datum: str) -> list:
     """Return water-level parameter codes in preference order.
 
     Codes in the family matching the requested datum come first (a direct
-    match avoids a vdatum conversion downstream), then the remaining
-    families with NAVD88 leading (vdatum-convertible to tidal datums).
-    Gage height (00065) is always last: it is referenced to the local gage
-    datum, not a true vertical datum.
+    match needs no datum conversion downstream), then NAVD88 codes (the
+    only family with a vdatum conversion path to the tidal datums), then
+    gage height (assumed ~NAVD88, so it also converts). NGVD and IGLD
+    series rank last for non-matching requests: the pipeline has no
+    conversion path for them, so selecting one would leave the station
+    with an unusable UNKNOWN datum offset.
     """
     datum_upper = (requested_datum or '').upper()
     if 'IGLD' in datum_upper or 'LWD' in datum_upper:
-        families = [_IGLD_WL_CODES, _NAVD88_WL_CODES, _NGVD_WL_CODES]
+        preferred = _IGLD_WL_CODES
     elif 'NGVD' in datum_upper:
-        families = [_NGVD_WL_CODES, _NAVD88_WL_CODES, _IGLD_WL_CODES]
+        preferred = _NGVD_WL_CODES
     else:
-        families = [_NAVD88_WL_CODES, _NGVD_WL_CODES, _IGLD_WL_CODES]
-    return [code for family in families for code in family] + \
-        _GAGE_HEIGHT_WL_CODES
+        preferred = []
+    base = (_NAVD88_WL_CODES + _GAGE_HEIGHT_WL_CODES + _NGVD_WL_CODES
+            + _IGLD_WL_CODES)
+    return preferred + [code for code in base if code not in preferred]
+
+
+def _select_water_level_code(
+    data_filtered: pd.DataFrame,
+    requested_datum: str,
+    station: str,
+    logger: Logger
+) -> str:
+    """Select the water-level parameter code to use for a station.
+
+    Walks the datum-aware priority order, skipping codes whose in-window
+    coverage falls below ``_MIN_RELATIVE_COVERAGE`` of the best-covered
+    candidate. Falls back to the first code in API order if no priority
+    code is present (future-proofing for new searvey water-level codes).
+    """
+    coverage = (
+        data_filtered.dropna(subset=['value'])
+        .groupby('code')['datetime'].nunique()
+    )
+    best_coverage = coverage.max() if not coverage.empty else 0
+    for code in _water_level_code_priority(requested_datum):
+        if code not in set(data_filtered['code']):
+            continue
+        code_coverage = coverage.get(code, 0)
+        if code_coverage >= _MIN_RELATIVE_COVERAGE * best_coverage:
+            return code
+        logger.info(
+            'USGS station %s: skipping water-level code %s (%d valid '
+            'samples vs %d for the best-covered code) — likely a '
+            'newly established series with partial coverage.',
+            station, code, code_coverage, best_coverage
+        )
+    return data_filtered['code'].iloc[0]
 
 
 def retrieve_usgs_station(
@@ -203,13 +246,11 @@ def retrieve_usgs_station(
         # Pick the best available code rather than the first one the API
         # happens to return: stations transitioning to 63160 (issue #133)
         # serve both the new NAVD88 series and legacy gage height.
-        priority = _water_level_code_priority(
-            getattr(retrieve_input, 'datum', '')
-        )
-        codes_present = set(data_filtered['code'])
-        first_code = next(
-            (code for code in priority if code in codes_present),
-            data_filtered['code'].iloc[0],
+        first_code = _select_water_level_code(
+            data_filtered,
+            getattr(retrieve_input, 'datum', ''),
+            station,
+            logger,
         )
         if first_code in _GAGE_HEIGHT_WL_CODES:
             logger.info(

--- a/src/ofs_skill/obs_retrieval/retrieve_usgs_station.py
+++ b/src/ofs_skill/obs_retrieval/retrieve_usgs_station.py
@@ -51,15 +51,18 @@ _IGLD_WL_CODES = ['72214', '72215']
 # datum. Assumed ~NAVD88 (historical behavior).
 _GAGE_HEIGHT_WL_CODES = ['00065']
 
-# A higher-priority code is only selected when it has at least this
-# fraction of the valid samples of the best-covered candidate. During the
-# 63160 migration a just-activated series can cover a sliver of the
-# requested window while the legacy series covers all of it; without this
-# guard the sparse series would silently win on priority alone.
+# A higher-priority code is only selected when its best sensor series
+# spans at least this fraction of the time span of the best-covered
+# candidate. During the 63160 migration a just-activated series can cover
+# a sliver of the requested window while the legacy series covers all of
+# it; without this guard the sparse series would silently win on
+# priority alone.
 _MIN_RELATIVE_COVERAGE = 0.5
 
-# Datum assignment by code (62617 and 63161 are NAVD88 per the USGS
-# parameter-code dictionary; anything not IGLD/NGVD is labeled NAVD88)
+# Datum label by parameter-code family. Codes in neither set are labeled
+# NAVD88: per the USGS parameter-code dictionary every remaining
+# elevation code is NAVD88-referenced, and gage height (00065) is
+# assumed ~NAVD88 as a last resort.
 _IGLD_CODES = set(_IGLD_WL_CODES)
 _NGVD_CODES = set(_NGVD_WL_CODES)
 
@@ -80,7 +83,7 @@ _SPECIFIC_CONDUCTANCE_CODES = {'00095'}
 _PREFERRED_SALINITY_CODES = {'00480', '72401', '90860', '90862', '00096', '70305'}
 
 
-def _water_level_code_priority(requested_datum: str) -> list:
+def _water_level_code_priority(requested_datum: str) -> list[str]:
     """Return water-level parameter codes in preference order.
 
     Codes in the family matching the requested datum come first (a direct
@@ -103,37 +106,94 @@ def _water_level_code_priority(requested_datum: str) -> list:
     return preferred + [code for code in base if code not in preferred]
 
 
-def _select_water_level_code(
+def _series_key_column(data_filtered: pd.DataFrame) -> Optional[str]:
+    """Column distinguishing sensor series within a parameter code.
+
+    The new Water Data API uses time_series_id; the legacy NWIS API
+    used option.
+    """
+    if 'time_series_id' in data_filtered.columns:
+        return 'time_series_id'
+    if 'option' in data_filtered.columns:
+        return 'option'
+    return None
+
+
+def _select_water_level_series(
     data_filtered: pd.DataFrame,
     requested_datum: str,
     station: str,
     logger: Logger
-) -> str:
-    """Select the water-level parameter code to use for a station.
+) -> tuple[str, pd.DataFrame]:
+    """Select the parameter code and single sensor series to use.
 
-    Walks the datum-aware priority order, skipping codes whose in-window
-    coverage falls below ``_MIN_RELATIVE_COVERAGE`` of the best-covered
-    candidate. Falls back to the first code in API order if no priority
-    code is present (future-proofing for new searvey water-level codes).
+    Coverage is measured as the time span of a series' valid samples, on
+    the exact single-sensor series the caller would receive: a code can
+    carry several sensors, and an aggregate count would overstate what a
+    single series delivers. Span rather than sample count, so a
+    lower-rate series covering the window is not beaten by a high-rate
+    one (USGS sensors report at 6, 15, or 60 minute intervals).
+
+    Walks the datum-aware priority order, skipping codes whose best
+    series spans less than ``_MIN_RELATIVE_COVERAGE`` of the
+    best-covered candidate. Falls back to the first code in API order if
+    no priority code is present (future-proofing for new searvey
+    water-level codes).
+
+    Returns the selected code and its best-covered series, not yet
+    deduplicated on timestamps.
     """
-    coverage = (
-        data_filtered.dropna(subset=['value'])
-        .groupby('code')['datetime'].nunique()
-    )
-    best_coverage = coverage.max() if not coverage.empty else 0
+    key_col = _series_key_column(data_filtered)
+    valid = data_filtered.dropna(subset=['value'])
+    group_cols = ['code', key_col] if key_col else ['code']
+    spans = valid.groupby(group_cols)['datetime'].agg(['min', 'max'])
+    spans['span'] = spans['max'] - spans['min']
+
+    if key_col and not spans.empty:
+        code_span = spans['span'].groupby(level='code').max()
+        best_series_key = spans['span'].groupby(level='code').idxmax()
+    else:
+        code_span = spans['span']
+        best_series_key = None
+    best_span = code_span.max() if not code_span.empty else pd.Timedelta(0)
+
+    codes_present = set(data_filtered['code'])
+    selected = None
     for code in _water_level_code_priority(requested_datum):
-        if code not in set(data_filtered['code']):
+        if code not in codes_present:
             continue
-        code_coverage = coverage.get(code, 0)
-        if code_coverage >= _MIN_RELATIVE_COVERAGE * best_coverage:
-            return code
+        span = code_span.get(code, pd.Timedelta(0))
+        if span >= _MIN_RELATIVE_COVERAGE * best_span:
+            selected = code
+            break
         logger.info(
-            'USGS station %s: skipping water-level code %s (%d valid '
-            'samples vs %d for the best-covered code) — likely a '
-            'newly established series with partial coverage.',
-            station, code, code_coverage, best_coverage
+            'USGS station %s: skipping water-level code %s (best series '
+            'spans %s vs %s for the best-covered code) — likely a newly '
+            'established series with partial coverage.',
+            station, code, span, best_span
         )
-    return data_filtered['code'].iloc[0]
+    if selected is None:
+        selected = data_filtered['code'].iloc[0]
+        logger.info(
+            'USGS station %s: no known water-level code present; falling '
+            'back to code %s (first in API order).', station, selected
+        )
+
+    series = data_filtered[data_filtered['code'] == selected].copy()
+    if key_col is not None:
+        if best_series_key is not None and selected in best_series_key.index:
+            series_id = best_series_key[selected][1]
+        else:
+            # No valid samples for this code: keep the first series
+            series_id = series[key_col].iloc[0]
+        series = series[series[key_col] == series_id]
+
+    logger.info(
+        'USGS station %s: selected water-level code %s (series spanning '
+        '%s).', station, selected,
+        code_span.get(selected, pd.Timedelta(0))
+    )
+    return selected, series
 
 
 def retrieve_usgs_station(
@@ -153,6 +213,8 @@ def retrieve_usgs_station(
             - end_date: End date in YYYYMMDD format
             - variable: Variable type ('water_level', 'water_temperature',
                        'salinity', 'currents')
+            - datum: Requested vertical datum (optional; drives
+                     water-level parameter-code preference)
         logger: Logger instance for logging messages
 
     Returns:
@@ -246,32 +308,38 @@ def retrieve_usgs_station(
         # Pick the best available code rather than the first one the API
         # happens to return: stations transitioning to 63160 (issue #133)
         # serve both the new NAVD88 series and legacy gage height.
-        first_code = _select_water_level_code(
+        selected_code, data_for_code = _select_water_level_series(
             data_filtered,
             getattr(retrieve_input, 'datum', ''),
             station,
             logger,
         )
-        if first_code in _GAGE_HEIGHT_WL_CODES:
-            logger.info(
+        if selected_code in _GAGE_HEIGHT_WL_CODES:
+            logger.warning(
                 'USGS station %s water level uses gage height (00065), '
                 'which is referenced to the local gage datum; assuming '
                 'NAVD88.', station
             )
     else:
         # Use the first available code that has data
-        first_code = data_filtered['code'].iloc[0]
-    data_for_code = data_filtered[data_filtered['code'] == first_code].copy()
+        selected_code = data_filtered['code'].iloc[0]
+        data_for_code = (
+            data_filtered[data_filtered['code'] == selected_code].copy()
+        )
 
-    # Filter to a single time series to avoid duplicate timestamps.
-    # The new Water Data API uses time_series_id to distinguish sensors;
-    # the legacy NWIS API used option. Try both.
-    if 'time_series_id' in data_for_code.columns:
-        first_ts = data_for_code['time_series_id'].iloc[0]
-        data_for_code = data_for_code[data_for_code['time_series_id'] == first_ts]
-    elif 'option' in data_for_code.columns:
-        first_option = data_for_code['option'].iloc[0]
-        data_for_code = data_for_code[data_for_code['option'] == first_option]
+        # Filter to a single time series to avoid duplicate timestamps.
+        # The new Water Data API uses time_series_id to distinguish
+        # sensors; the legacy NWIS API used option. Try both.
+        if 'time_series_id' in data_for_code.columns:
+            first_ts = data_for_code['time_series_id'].iloc[0]
+            data_for_code = data_for_code[
+                data_for_code['time_series_id'] == first_ts
+            ]
+        elif 'option' in data_for_code.columns:
+            first_option = data_for_code['option'].iloc[0]
+            data_for_code = data_for_code[
+                data_for_code['option'] == first_option
+            ]
 
     # Drop any remaining duplicate timestamps, keeping first value
     data_for_code = data_for_code.drop_duplicates(subset='datetime', keep='first')
@@ -285,34 +353,34 @@ def retrieve_usgs_station(
 
     # Apply unit conversions and set metadata based on variable
     if variable == 'water_level':
-        if first_code in _FEET_TO_METERS_CODES:
+        if selected_code in _FEET_TO_METERS_CODES:
             obs['OBS'] = obs['OBS'] * 0.3048
 
-        if first_code in _IGLD_CODES:
+        if selected_code in _IGLD_CODES:
             obs['Datum'] = 'IGLD'
-        elif first_code in _NGVD_CODES:
+        elif selected_code in _NGVD_CODES:
             obs['Datum'] = 'NGVD'
         else:
             obs['Datum'] = 'NAVD88'
 
     elif variable == 'water_temperature':
-        if first_code in _FAHRENHEIT_CODES:
+        if selected_code in _FAHRENHEIT_CODES:
             obs['OBS'] = (obs['OBS'] - 32) * (5 / 9)
 
     elif variable == 'salinity':
-        if first_code in _SPECIFIC_CONDUCTANCE_CODES:
+        if selected_code in _SPECIFIC_CONDUCTANCE_CODES:
             logger.info(
                 'Station %s reports specific conductance at 25 Celsius (code %s) — '
-                'converting to salinity PSU', station, first_code
+                'converting to salinity PSU', station, selected_code
             )
             obs['OBS'] = obs['OBS'] * 0.00064
 
     elif variable == 'currents':
-        if first_code in _FT_PER_SEC_CODES:
+        if selected_code in _FT_PER_SEC_CODES:
             obs['OBS'] = obs['OBS'] * 0.3048
-        elif first_code in _KNOT_CODES:
+        elif selected_code in _KNOT_CODES:
             obs['OBS'] = obs['OBS'] * 0.5144
-        elif first_code in _MPH_CODES:
+        elif selected_code in _MPH_CODES:
             obs['OBS'] = obs['OBS'] * 0.44704
         obs['DIR'] = 0.0
 

--- a/src/ofs_skill/obs_retrieval/write_obs_ctlfile.py
+++ b/src/ofs_skill/obs_retrieval/write_obs_ctlfile.py
@@ -505,7 +505,7 @@ def _process_usgs_station(
             )
 
             if variable == 'water_level':
-                ts_datum = str(timeseries['Datum'][1])
+                ts_datum = str(timeseries['Datum'].iloc[0])
                 ts_datum_upper = ts_datum.upper()
 
                 ofs_base_offsets = {
@@ -562,7 +562,7 @@ def _process_usgs_station(
                         f'{str(id_number)}_{name_var}_'
                         f'{ofs}_USGS "{name}"\n  {y_value:.3f} '
                         f'{x_value:.3f} '
-                        f'{zdiff}  0.0  {str(timeseries["Datum"][1])}\n'
+                        f'{zdiff}  0.0  {ts_datum}\n'
                     )
                 ]
 

--- a/src/ofs_skill/obs_retrieval/write_obs_ctlfile.py
+++ b/src/ofs_skill/obs_retrieval/write_obs_ctlfile.py
@@ -493,6 +493,7 @@ def _process_usgs_station(
         retrieve_input.start_date = start_date
         retrieve_input.end_date = end_date
         retrieve_input.variable = variable
+        retrieve_input.datum = datum
         timeseries = retrieve_usgs_station(retrieve_input, logger)
         if isinstance(timeseries, pd.DataFrame) is False:
             logger.info(

--- a/src/ofs_skill/obs_retrieval/write_obs_ctlfile.py
+++ b/src/ofs_skill/obs_retrieval/write_obs_ctlfile.py
@@ -572,7 +572,7 @@ def _process_usgs_station(
                         f'{str(id_number)} {str(id_number)}_'
                         f'{name_var}_{ofs}_USGS "{name}"\n  '
                         f'{y_value:.3f} {x_value:.3f} 0.0  '
-                        f'{timeseries["DEP01"][1]:.2f}  0.0\n'
+                        f'{timeseries["DEP01"].iloc[0]:.2f}  0.0\n'
                     )
                 ]
             elif variable == 'currents':
@@ -581,7 +581,7 @@ def _process_usgs_station(
                         f'{str(id_number)} {str(id_number)}_'
                         f'{name_var}_{ofs}_USGS "{name}"\n  '
                         f'{y_value:.3f} {x_value:.3f} 0.0  '
-                        f'{timeseries["DEP01"][1]:.2f}  0.0  0.00\n'
+                        f'{timeseries["DEP01"].iloc[0]:.2f}  0.0  0.00\n'
                     )
                 ]
     except Exception as ex:

--- a/tests/usgs_retrieval_test.py
+++ b/tests/usgs_retrieval_test.py
@@ -36,12 +36,14 @@ class MockRetrieveInput:
         station: str,
         start_date: str,
         end_date: str,
-        variable: str = 'water_level'
+        variable: str = 'water_level',
+        datum: str = ''
     ):
         self.station = station
         self.start_date = start_date
         self.end_date = end_date
         self.variable = variable
+        self.datum = datum
 
 
 class TestUSGSImports:
@@ -507,6 +509,182 @@ class TestSalinityCodePreference:
 
         assert result is not None
         assert result['OBS'].iloc[0] == pytest.approx(0.64)
+
+
+class TestWaterLevelCodePriority:
+    """Test datum-aware water-level parameter code selection (issue #133).
+
+    USGS is migrating stream gages to parameter code 63160 (Stream level,
+    NAVD88). Stations in transition serve both the new 63160 series and
+    legacy gage height (00065); the true-datum series must win.
+    """
+
+    def test_63160_preferred_over_gage_height(self, logger):
+        """When both 00065 and 63160 exist, 63160 is used (issue #133)."""
+        mock_data = _make_usgs_multiindex_df([
+            # Legacy gage height listed first (API order must not matter)
+            {'site_no': '11162765', 'datetime': '2024-01-01 00:00',
+             'code': '00065', 'option': '00000', 'value': 10.0},
+            {'site_no': '11162765', 'datetime': '2024-01-01 00:15',
+             'code': '00065', 'option': '00000', 'value': 11.0},
+            # New NAVD88 stream level series
+            {'site_no': '11162765', 'datetime': '2024-01-01 00:00',
+             'code': '63160', 'option': '00000', 'value': 2.0},
+            {'site_no': '11162765', 'datetime': '2024-01-01 00:15',
+             'code': '63160', 'option': '00000', 'value': 2.5},
+        ])
+
+        inp = MockRetrieveInput(
+            '11162765', '20240101', '20240102', 'water_level', datum='MLLW'
+        )
+
+        with patch(
+            'ofs_skill.obs_retrieval.retrieve_usgs_station.get_usgs_station_data',
+            return_value=mock_data,
+        ):
+            result = retrieve_usgs_station(inp, logger)
+
+        assert result is not None
+        # Values from 63160 (feet converted to meters), labeled NAVD88
+        assert list(result['OBS']) == pytest.approx(
+            [2.0 * 0.3048, 2.5 * 0.3048]
+        )
+        assert result['Datum'].iloc[0] == 'NAVD88'
+
+    def test_requested_igld_prefers_igld_code(self, logger):
+        """Requested IGLD datum picks 72214 over 63160 (no vdatum trip)."""
+        mock_data = _make_usgs_multiindex_df([
+            {'site_no': '04092750', 'datetime': '2024-01-01 00:00',
+             'code': '63160', 'option': '00000', 'value': 2.0},
+            {'site_no': '04092750', 'datetime': '2024-01-01 00:00',
+             'code': '72214', 'option': '00000', 'value': 577.0},
+        ])
+
+        inp = MockRetrieveInput(
+            '04092750', '20240101', '20240102', 'water_level', datum='IGLD'
+        )
+
+        with patch(
+            'ofs_skill.obs_retrieval.retrieve_usgs_station.get_usgs_station_data',
+            return_value=mock_data,
+        ):
+            result = retrieve_usgs_station(inp, logger)
+
+        assert result is not None
+        assert result['OBS'].iloc[0] == pytest.approx(577.0 * 0.3048)
+        assert result['Datum'].iloc[0] == 'IGLD'
+
+    def test_gage_height_fallback_still_works(self, logger):
+        """A station with only 00065 keeps the historical NAVD88 label."""
+        mock_data = _make_usgs_multiindex_df([
+            {'site_no': '01646500', 'datetime': '2024-01-01 00:00',
+             'code': '00065', 'option': '00000', 'value': 3.0},
+        ])
+
+        inp = MockRetrieveInput(
+            '01646500', '20240101', '20240102', 'water_level', datum='NAVD88'
+        )
+
+        with patch(
+            'ofs_skill.obs_retrieval.retrieve_usgs_station.get_usgs_station_data',
+            return_value=mock_data,
+        ):
+            result = retrieve_usgs_station(inp, logger)
+
+        assert result is not None
+        assert result['OBS'].iloc[0] == pytest.approx(3.0 * 0.3048)
+        assert result['Datum'].iloc[0] == 'NAVD88'
+
+    def test_missing_datum_attribute_defaults_to_navd88_order(self, logger):
+        """Inputs without a datum attribute still work (NAVD88 first)."""
+        mock_data = _make_usgs_multiindex_df([
+            {'site_no': '11162765', 'datetime': '2024-01-01 00:00',
+             'code': '00065', 'option': '00000', 'value': 10.0},
+            {'site_no': '11162765', 'datetime': '2024-01-01 00:00',
+             'code': '63160', 'option': '00000', 'value': 2.0},
+        ])
+
+        inp = MockRetrieveInput(
+            '11162765', '20240101', '20240102', 'water_level'
+        )
+        del inp.datum
+
+        with patch(
+            'ofs_skill.obs_retrieval.retrieve_usgs_station.get_usgs_station_data',
+            return_value=mock_data,
+        ):
+            result = retrieve_usgs_station(inp, logger)
+
+        assert result is not None
+        assert result['OBS'].iloc[0] == pytest.approx(2.0 * 0.3048)
+        assert result['Datum'].iloc[0] == 'NAVD88'
+
+
+class TestWaterLevelDatumLabels:
+    """Test datum labels against the USGS parameter-code dictionary."""
+
+    def test_63161_meters_navd88(self, logger):
+        """63161 (Stream level, NAVD88, meters): no ft conversion, NAVD88."""
+        mock_data = _make_usgs_multiindex_df([
+            {'site_no': '11162765', 'datetime': '2024-01-01 00:00',
+             'code': '63161', 'option': '00000', 'value': 1.5},
+        ])
+
+        inp = MockRetrieveInput(
+            '11162765', '20240101', '20240102', 'water_level'
+        )
+
+        with patch(
+            'ofs_skill.obs_retrieval.retrieve_usgs_station.get_usgs_station_data',
+            return_value=mock_data,
+        ):
+            result = retrieve_usgs_station(inp, logger)
+
+        assert result is not None
+        assert result['OBS'].iloc[0] == pytest.approx(1.5)
+        assert result['Datum'].iloc[0] == 'NAVD88'
+
+    def test_62617_meters_navd88(self, logger):
+        """62617 (Elevation lake/res, NAVD88, meters) is labeled NAVD88."""
+        mock_data = _make_usgs_multiindex_df([
+            {'site_no': '04092750', 'datetime': '2024-01-01 00:00',
+             'code': '62617', 'option': '00000', 'value': 176.0},
+        ])
+
+        inp = MockRetrieveInput(
+            '04092750', '20240101', '20240102', 'water_level'
+        )
+
+        with patch(
+            'ofs_skill.obs_retrieval.retrieve_usgs_station.get_usgs_station_data',
+            return_value=mock_data,
+        ):
+            result = retrieve_usgs_station(inp, logger)
+
+        assert result is not None
+        assert result['OBS'].iloc[0] == pytest.approx(176.0)
+        assert result['Datum'].iloc[0] == 'NAVD88'
+
+    def test_63158_feet_ngvd(self, logger):
+        """63158 (Stream level, NGVD29, feet): ft conversion, NGVD label."""
+        mock_data = _make_usgs_multiindex_df([
+            {'site_no': '01646500', 'datetime': '2024-01-01 00:00',
+             'code': '63158', 'option': '00000', 'value': 4.0},
+        ])
+
+        inp = MockRetrieveInput(
+            '01646500', '20240101', '20240102', 'water_level'
+        )
+
+        with patch(
+            'ofs_skill.obs_retrieval.retrieve_usgs_station.get_usgs_station_data',
+            return_value=mock_data,
+        ):
+            result = retrieve_usgs_station(inp, logger)
+
+        assert result is not None
+        assert result['OBS'].iloc[0] == pytest.approx(4.0 * 0.3048)
+        assert result['Datum'].iloc[0] == 'NGVD'
 
 
 if __name__ == '__main__':

--- a/tests/usgs_retrieval_test.py
+++ b/tests/usgs_retrieval_test.py
@@ -574,6 +574,178 @@ class TestWaterLevelCodePriority:
         assert result['OBS'].iloc[0] == pytest.approx(577.0 * 0.3048)
         assert result['Datum'].iloc[0] == 'IGLD'
 
+    def test_ngvd_requested_prefers_ngvd_code(self, logger):
+        """Requested NGVD datum picks 63158 over 63160 (direct match)."""
+        mock_data = _make_usgs_multiindex_df([
+            {'site_no': '01646500', 'datetime': '2024-01-01 00:00',
+             'code': '63160', 'option': '00000', 'value': 2.0},
+            {'site_no': '01646500', 'datetime': '2024-01-01 00:00',
+             'code': '63158', 'option': '00000', 'value': 4.0},
+        ])
+
+        inp = MockRetrieveInput(
+            '01646500', '20240101', '20240102', 'water_level', datum='NGVD29'
+        )
+
+        with patch(
+            'ofs_skill.obs_retrieval.retrieve_usgs_station.get_usgs_station_data',
+            return_value=mock_data,
+        ):
+            result = retrieve_usgs_station(inp, logger)
+
+        assert result is not None
+        assert result['OBS'].iloc[0] == pytest.approx(4.0 * 0.3048)
+        assert result['Datum'].iloc[0] == 'NGVD'
+
+    def test_lwd_requested_prefers_igld_code(self, logger):
+        """Requested LWD datum (Great Lakes) picks the IGLD family."""
+        mock_data = _make_usgs_multiindex_df([
+            {'site_no': '04092750', 'datetime': '2024-01-01 00:00',
+             'code': '63160', 'option': '00000', 'value': 2.0},
+            {'site_no': '04092750', 'datetime': '2024-01-01 00:00',
+             'code': '72214', 'option': '00000', 'value': 577.0},
+        ])
+
+        inp = MockRetrieveInput(
+            '04092750', '20240101', '20240102', 'water_level', datum='LWD'
+        )
+
+        with patch(
+            'ofs_skill.obs_retrieval.retrieve_usgs_station.get_usgs_station_data',
+            return_value=mock_data,
+        ):
+            result = retrieve_usgs_station(inp, logger)
+
+        assert result is not None
+        assert result['OBS'].iloc[0] == pytest.approx(577.0 * 0.3048)
+        assert result['Datum'].iloc[0] == 'IGLD'
+
+    def test_63160_leads_navd88_family(self, logger):
+        """63160 outranks legacy 62620 within the NAVD88 family."""
+        mock_data = _make_usgs_multiindex_df([
+            {'site_no': '11162765', 'datetime': '2024-01-01 00:00',
+             'code': '62620', 'option': '00000', 'value': 1.0},
+            {'site_no': '11162765', 'datetime': '2024-01-01 00:00',
+             'code': '63160', 'option': '00000', 'value': 2.0},
+        ])
+
+        inp = MockRetrieveInput(
+            '11162765', '20240101', '20240102', 'water_level', datum='MLLW'
+        )
+
+        with patch(
+            'ofs_skill.obs_retrieval.retrieve_usgs_station.get_usgs_station_data',
+            return_value=mock_data,
+        ):
+            result = retrieve_usgs_station(inp, logger)
+
+        assert result is not None
+        assert result['OBS'].iloc[0] == pytest.approx(2.0 * 0.3048)
+
+    def test_gage_height_stays_below_ngvd_free_stations(self, logger):
+        """00065 outranks NGVD codes: NGVD has no downstream conversion."""
+        mock_data = _make_usgs_multiindex_df([
+            {'site_no': '02257750', 'datetime': '2024-01-01 00:00',
+             'code': '63158', 'option': '00000', 'value': 4.0},
+            {'site_no': '02257750', 'datetime': '2024-01-01 00:00',
+             'code': '00065', 'option': '00000', 'value': 3.0},
+        ])
+
+        inp = MockRetrieveInput(
+            '02257750', '20240101', '20240102', 'water_level', datum='MLLW'
+        )
+
+        with patch(
+            'ofs_skill.obs_retrieval.retrieve_usgs_station.get_usgs_station_data',
+            return_value=mock_data,
+        ):
+            result = retrieve_usgs_station(inp, logger)
+
+        assert result is not None
+        assert result['OBS'].iloc[0] == pytest.approx(3.0 * 0.3048)
+        assert result['Datum'].iloc[0] == 'NAVD88'
+
+    def test_sparse_new_series_falls_back_to_dense_legacy(self, logger):
+        """A just-activated 63160 stub loses to a full-window 00065."""
+        rows = [
+            {'site_no': '11162765', 'datetime': f'2024-01-01 {h:02d}:00',
+             'code': '00065', 'option': '00000', 'value': 10.0 + h}
+            for h in range(10)
+        ]
+        rows.append(
+            {'site_no': '11162765', 'datetime': '2024-01-01 09:00',
+             'code': '63160', 'option': '00000', 'value': 2.0}
+        )
+        mock_data = _make_usgs_multiindex_df(rows)
+
+        inp = MockRetrieveInput(
+            '11162765', '20240101', '20240102', 'water_level', datum='MLLW'
+        )
+
+        with patch(
+            'ofs_skill.obs_retrieval.retrieve_usgs_station.get_usgs_station_data',
+            return_value=mock_data,
+        ):
+            result = retrieve_usgs_station(inp, logger)
+
+        assert result is not None
+        # 63160 covers 1/10 of the window (< 50%): use the dense 00065
+        assert len(result) == 10
+        assert result['OBS'].iloc[0] == pytest.approx(10.0 * 0.3048)
+
+    def test_adequate_coverage_new_series_wins(self, logger):
+        """A 63160 series covering >= 50% of the best candidate is used."""
+        rows = [
+            {'site_no': '11162765', 'datetime': f'2024-01-01 {h:02d}:00',
+             'code': '00065', 'option': '00000', 'value': 10.0 + h}
+            for h in range(10)
+        ]
+        rows += [
+            {'site_no': '11162765', 'datetime': f'2024-01-01 {h:02d}:00',
+             'code': '63160', 'option': '00000', 'value': 2.0}
+            for h in range(4, 10)
+        ]
+        mock_data = _make_usgs_multiindex_df(rows)
+
+        inp = MockRetrieveInput(
+            '11162765', '20240101', '20240102', 'water_level', datum='MLLW'
+        )
+
+        with patch(
+            'ofs_skill.obs_retrieval.retrieve_usgs_station.get_usgs_station_data',
+            return_value=mock_data,
+        ):
+            result = retrieve_usgs_station(inp, logger)
+
+        assert result is not None
+        assert len(result) == 6
+        assert result['OBS'].iloc[0] == pytest.approx(2.0 * 0.3048)
+        assert result['Datum'].iloc[0] == 'NAVD88'
+
+    def test_unknown_code_falls_back_to_api_order(self, logger):
+        """A future searvey code outside the families still returns data."""
+        mock_data = _make_usgs_multiindex_df([
+            {'site_no': '01646500', 'datetime': '2024-01-01 00:00',
+             'code': '99999', 'option': '00000', 'value': 1.5},
+        ])
+
+        inp = MockRetrieveInput(
+            '01646500', '20240101', '20240102', 'water_level', datum='MLLW'
+        )
+
+        with patch(
+            'ofs_skill.obs_retrieval.retrieve_usgs_station.get_usgs_station_data',
+            return_value=mock_data,
+        ), patch(
+            'ofs_skill.obs_retrieval.retrieve_usgs_station.USGS_WATER_LEVEL_CODES',
+            {'99999'},
+        ):
+            result = retrieve_usgs_station(inp, logger)
+
+        assert result is not None
+        assert result['OBS'].iloc[0] == pytest.approx(1.5)
+        assert result['Datum'].iloc[0] == 'NAVD88'
+
     def test_gage_height_fallback_still_works(self, logger):
         """A station with only 00065 keeps the historical NAVD88 label."""
         mock_data = _make_usgs_multiindex_df([

--- a/tests/usgs_retrieval_test.py
+++ b/tests/usgs_retrieval_test.py
@@ -722,6 +722,102 @@ class TestWaterLevelCodePriority:
         assert result['OBS'].iloc[0] == pytest.approx(2.0 * 0.3048)
         assert result['Datum'].iloc[0] == 'NAVD88'
 
+    def test_multisensor_aggregate_does_not_defeat_guard(self, logger):
+        """Coverage is judged per sensor series, not per-code aggregate.
+
+        Two disjoint short 63160 sensors must not pool their spans to
+        outrank a dense full-window legacy series.
+        """
+        rows = [
+            {'site_no': '11162765', 'datetime': f'2024-01-01 {h:02d}:00',
+             'code': '00065', 'option': '00000', 'value': 10.0 + h}
+            for h in range(10)
+        ]
+        rows += [
+            {'site_no': '11162765', 'datetime': f'2024-01-01 {h:02d}:00',
+             'code': '63160', 'option': '00000', 'value': 2.0}
+            for h in range(0, 3)
+        ]
+        rows += [
+            {'site_no': '11162765', 'datetime': f'2024-01-01 {h:02d}:00',
+             'code': '63160', 'option': '00001', 'value': 3.0}
+            for h in range(7, 10)
+        ]
+        mock_data = _make_usgs_multiindex_df(rows)
+
+        inp = MockRetrieveInput(
+            '11162765', '20240101', '20240102', 'water_level', datum='MLLW'
+        )
+
+        with patch(
+            'ofs_skill.obs_retrieval.retrieve_usgs_station.get_usgs_station_data',
+            return_value=mock_data,
+        ):
+            result = retrieve_usgs_station(inp, logger)
+
+        assert result is not None
+        # Each 63160 sensor spans 2h (< 50% of the 9h legacy span):
+        # fall back to the dense 00065 series
+        assert len(result) == 10
+        assert result['OBS'].iloc[0] == pytest.approx(10.0 * 0.3048)
+
+    def test_best_series_of_selected_code_used(self, logger):
+        """Within the winning code, the best-covered sensor is returned
+        (not whichever the API listed first)."""
+        rows = [
+            {'site_no': '11162765', 'datetime': '2024-01-01 00:00',
+             'code': '63160', 'option': '00000', 'value': 9.0},
+        ]
+        rows += [
+            {'site_no': '11162765', 'datetime': f'2024-01-01 {h:02d}:00',
+             'code': '63160', 'option': '00001', 'value': 2.0}
+            for h in range(10)
+        ]
+        mock_data = _make_usgs_multiindex_df(rows)
+
+        inp = MockRetrieveInput(
+            '11162765', '20240101', '20240102', 'water_level', datum='MLLW'
+        )
+
+        with patch(
+            'ofs_skill.obs_retrieval.retrieve_usgs_station.get_usgs_station_data',
+            return_value=mock_data,
+        ):
+            result = retrieve_usgs_station(inp, logger)
+
+        assert result is not None
+        assert len(result) == 10
+        assert result['OBS'].iloc[0] == pytest.approx(2.0 * 0.3048)
+
+    def test_low_rate_full_span_series_not_penalized(self, logger):
+        """A lower-rate 63160 series spanning the window beats a
+        higher-rate legacy series: coverage is span, not sample count."""
+        rows = [
+            {'site_no': '11162765', 'datetime': f'2024-01-01 {h:02d}:00',
+             'code': '00065', 'option': '00000', 'value': 10.0 + h}
+            for h in range(10)
+        ]
+        rows += [
+            {'site_no': '11162765', 'datetime': f'2024-01-01 {h:02d}:00',
+             'code': '63160', 'option': '00000', 'value': 2.0}
+            for h in (0, 3, 6, 9)
+        ]
+        mock_data = _make_usgs_multiindex_df(rows)
+
+        inp = MockRetrieveInput(
+            '11162765', '20240101', '20240102', 'water_level', datum='MLLW'
+        )
+
+        with patch(
+            'ofs_skill.obs_retrieval.retrieve_usgs_station.get_usgs_station_data',
+            return_value=mock_data,
+        ):
+            result = retrieve_usgs_station(inp, logger)
+
+        assert result is not None
+        assert len(result) == 4
+        assert result['OBS'].iloc[0] == pytest.approx(2.0 * 0.3048)
+
     def test_unknown_code_falls_back_to_api_order(self, logger):
         """A future searvey code outside the families still returns data."""
         mock_data = _make_usgs_multiindex_df([


### PR DESCRIPTION
### Description of Changes
Closes #133.

USGS is migrating its stream gages to parameter code **63160 "Stream level, NAVD88"** — a new time series per station, with the SF Bay office (sfbofs) targeting Dec 31, 2026 for its remaining gages. During and after this transition a station serves both the new NAVD88 series and the legacy gage-height series (00065, referenced to the local gage datum). Our water-level retrieval picked whichever parameter code the API happened to return first, so the series feeding the skill assessment was arbitrary — and at a station like 11455420 (Sacramento R. at Rio Vista) the two series differ by a published 9.96 ft (~3 m) gage-datum offset.

Changes in `src/ofs_skill/obs_retrieval/`:

- **`retrieve_usgs_station.py`** — water-level parameter-code selection is now deliberate instead of API-order:
  - Datum-aware priority: codes matching the requested datum first (e.g. IGLD codes for Great Lakes IGLD85/LWD runs, avoiding a vdatum round trip), then NAVD88 codes with **63160 leading**, then gage height (00065, assumed ~NAVD88 as before), then NGVD/IGLD codes last for non-matching requests (the pipeline has no NGVD conversion path, so selecting one would strand the station on an UNKNOWN datum offset).
  - A coverage guard for the migration period: a higher-priority code is only selected when its best sensor series spans ≥ 50% of the best-covered candidate's span, so a just-activated 63160 series covering a sliver of the run window cannot silently displace a full-window legacy series. Coverage is measured per sensor series (a code can carry several sensors) and as time span rather than sample count (sensor rates vary between 6, 15, and 60 minutes). Every selection and skip is logged.
  - Within the winning code, the best-covered sensor series is returned instead of whichever the API listed first.
  - **Datum-label bug fix**: 62617 (lake/res elevation, NAVD88, m) and 63161 (stream level, NAVD88, m) were mislabeled NGVD. Verified all 13 searvey water-level codes against the USGS parameter-code dictionary; the four family lists now partition them exactly, and the ft→m conversion set matches the dictionary units.
  - Falling back to gage height now logs a **warning** naming the NAVD88 assumption.
- **`write_obs_ctlfile.py` / `get_station_observations.py`** — both USGS call sites now pass the requested datum into retrieval; the `Datum`/`DEP01` first-row lookups in `_process_usgs_station` use positional `iloc[0]` instead of a label lookup that raises `KeyError` on a one-row series (which the surrounding handler silently swallowed, dropping the station).
- **`tests/usgs_retrieval_test.py`** — 17 new tests: 63160-over-00065 preference, datum-matched preference for IGLD/LWD and NGVD requests, within-family 63160 precedence, both sides of the coverage guard including the multi-sensor and low-sample-rate cases, best-series selection, datum labels for 63161/62617/63158, gage-height fallback, missing-datum input, and the unknown-code fallback.

Known limitations, deliberately out of scope (candidates for follow-up issues):
- Gage height is still assumed ≈ NAVD88 when it is the only series. USGS publishes the true offset (`alt_va`/`alt_datum_cd` in the site service); applying it would remove a station-dependent bias of up to a few meters.
- The selected parameter code is not recorded in the ctl file, so a station whose best code changes between ctl generation and a later run window keeps the ctl's zdiff (pre-existing behavior; the new selection logging makes such changes visible). Related to the continuation-runs design in #211.
- Requesting MSL with an NAVD88-labeled series still fails inside vdatum (`msl` vs `lmsl` vocabulary, pre-existing).

_Labels: bug, enhancement_

### Expected Outcome of Changes
- At stations already serving 63160 (spreading through the network now), water-level skill runs use the true NAVD88 series instead of an API-order coin flip. Example: USGS 03453000 serves 00065 (~2.3 ft gage height) and 63160 (~1702.5 ft NAVD88) — the assessment now always compares the model against the NAVD88 series with a proper datum conversion.
- At stations serving an NGVD elevation code plus gage height (live examples inside the secofs and ngofs2 domains: 02257750, 08013500), selection now lands on the convertible series deterministically instead of sometimes stranding the station on `zdiff=UNKNOWN`.
- Water-level values, CSV skill statistics, and 1D plots can therefore change at USGS stations where the selected series changes — this is the intended correction, not a regression. Output file counts and formats are unchanged.
- New log lines record the selected code and its coverage span for every USGS water-level station.

### Developer Questions and Checklist
**Is this a high priority PR? If yes, why and is there a date by which it needs to be merged?**
No hard deadline, but the USGS migration is underway with a Dec 31, 2026 target — merging before then means transitioning stations are handled correctly as they cut over.

**Are there any changes needed to how the code should be run for operational runs? (Commands, flags, job timings, etc.)**
No. Commands and flags are unchanged.

**Does this update need to be deployed for operational runs?**
Yes, with the next regular release; no special deployment steps.

**Does this update require front end/web app changes? (If yes, provide documentation to Min)**
No.

**Does this impact code development work on adding SCHISM?**
No.

**Does this impact code development work on adding ADCIRC?**
No.

**Does this impact the expected number of output files for integration tests (i.e., will the integration test fail even though code changes result in desired change in outputs?)**
No — file counts are unchanged. Water-level *values* at USGS stations can change where the selected series changes (intended).

- [x] Developer's name is removed throughout the code?
- [x] Did you add relevant labels to the PR?
- [x] Have you run pylint and is the code at an acceptable pylint score (>8)? — `retrieve_usgs_station.py` scores 9.53/10; the only remaining messages are pre-existing complexity warnings on the module-level function.
- [x] Jobs contain the appropriate file checking and handle errors for any missing data? — no-data, all-NaN, one-row, and unknown-code cases are covered by tests.
- [x] Is log free of critical ERRORs or WARNINGs? For errors that are not critical and can remain in code, is there sufficient handling and logging? — the one new WARNING is deliberate: it flags the gage-height≈NAVD88 assumption at stations lacking a true NAVD88 series.

### Testing Instructions
1. Unit tests (no network):
   ```
   python -m pytest tests/usgs_retrieval_test.py -m "not network" -q
   ```
   Expect **34 passed**. The full suite (`python -m pytest tests/ -m "not network"`) passes 1183.
2. Live retrieval spot checks (each uses one USGS API request; the unkeyed limit is 50/hour — set `API_USGS_PAT` if running many):
   ```python
   import logging; logging.basicConfig(level=logging.INFO)
   from ofs_skill.obs_retrieval.retrieve_usgs_station import retrieve_usgs_station
   class Inp: pass
   inp = Inp(); inp.station='03453000'; inp.start_date='20260701'
   inp.end_date='20260702'; inp.variable='water_level'; inp.datum='MLLW'
   r = retrieve_usgs_station(inp, logging.getLogger())
   print(len(r), r['Datum'].iloc[0], r['OBS'].mean())
   ```
   - `03453000` (serves 00065 + 63160): expect the log `selected water-level code 63160`, ~97 rows, Datum `NAVD88`, mean ≈ **518.91 m** (1702.5 ft NAVD88 — the station sits at ~1700 ft elevation near Asheville, NC). The legacy gage-height series would have given ~0.7 m.
   - `02257750` or `08013500` (serve 63158 NGVD + 00065, no NAVD88 code): expect the gage-height WARNING and Datum `NAVD88` (assumed), not an NGVD selection.
3. Ctl-file path: a trimmed run of `write_obs_ctlfile` for a cbofs-area USGS water-level station list produces entries with numeric `zdiff` (or documented `UNKNOWN`/`RANGE` where vdatum has no coverage); I verified `03453000` + two Chesapeake-area stations end-to-end, including a one-row series which previously crashed into a silent station drop.
4. Datum plumbing: run any `-t stations -vs water_level` assessment for an OFS with USGS stations (e.g. cbofs, sfbofs) with `-d MLLW` and `-d NAVD88`; behavior differences at stations serving multiple codes are logged with the selected code and span.

### Reminder checklist for PR reviewer
_Checklist for the assigned reviewer to consult and check off_
- [ ] Run PEP8 compliance tests to ensure the code follows best practices
- [ ] Check that documentation in the script is sufficient
- [ ] Validate the output values (if applicable) to make sure the calculations are correct and make scientific/physical sense; include a comment on the pull request including what validation you performed, for replicability.
- [ ] Test code both on Windows and Linux (and MacOS, if available), using several OFS as test cases
- [ ] **Test for all 'cast' options: forecast_a, forecast_b, and nowcast**
- [ ] When approving or commenting on a pull request, add information on the calls you use in case they need to be replicated or referenced.
