### PR TITLE
Document S3 streaming alternative in README quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ conda activate ofs_dps
 cp conf/ofs_dps.conf.example conf/ofs_dps.conf
 #    ...then edit conf/ofs_dps.conf and set home=/path/to/working_directory
 
-# 3a. Ensure use_s3_fallback=True is set in conf/ofs_dps.conf, and the skill
+# 3a. (Preferred) Ensure use_s3_fallback=True is set in conf/ofs_dps.conf, and the skill
 #     assessment routine will read and stream model files from the
 #     NODD S3 bucket on demand when local files are missing.
  

--- a/README.md
+++ b/README.md
@@ -27,14 +27,14 @@ conda activate ofs_dps
 cp conf/ofs_dps.conf.example conf/ofs_dps.conf
 #    ...then edit conf/ofs_dps.conf and set home=/path/to/working_directory
 
-# 3. Download model data for your OFS and date range
+# 3. Ensure use_s3_fallback=True is set in conf/ofs_dps.conf, and the skill
+#     assessment routine will read and stream model files from the
+#     NODD S3 bucket on demand when local files are missing.
+ 
+# 3a. (Alternate) If you prefer to download model data locally: 
+#     Download model data for your OFS and date range
 python ./bin/utils/get_model_data.py -p ./ -o cbofs -s 2025-07-01T00:00:00Z -e 2025-07-02T00:00:00Z -ws nowcast -t stations
 python ./bin/utils/get_model_data.py -p ./ -o cbofs -s 2025-07-01T00:00:00Z -e 2025-07-02T00:00:00Z -ws forecast_b -t stations
-
-# 3a. (Alternative) Skip the get_model_data.py calls above by streaming OFS data
-#     directly from the NODD S3 bucket. Ensure use_s3_fallback=True is set in
-#     conf/ofs_dps.conf, and the skill assessment will read model files from the
-#     NODD S3 bucket on demand when local files are missing.
 
 # 4. Run the 1D skill assessment
 python ./bin/visualization/create_1dplot.py -p ./ -o cbofs -s 2025-07-01T00:00:00Z -e 2025-07-02T00:00:00Z -d MLLW -ws nowcast,forecast_b

--- a/README.md
+++ b/README.md
@@ -27,11 +27,11 @@ conda activate ofs_dps
 cp conf/ofs_dps.conf.example conf/ofs_dps.conf
 #    ...then edit conf/ofs_dps.conf and set home=/path/to/working_directory
 
-# 3. Ensure use_s3_fallback=True is set in conf/ofs_dps.conf, and the skill
+# 3a. Ensure use_s3_fallback=True is set in conf/ofs_dps.conf, and the skill
 #     assessment routine will read and stream model files from the
 #     NODD S3 bucket on demand when local files are missing.
  
-# 3a. (Alternate) If you prefer to download model data locally: 
+# 3b. (Alternate) If you prefer to download model data locally: 
 #     Download model data for your OFS and date range
 python ./bin/utils/get_model_data.py -p ./ -o cbofs -s 2025-07-01T00:00:00Z -e 2025-07-02T00:00:00Z -ws nowcast -t stations
 python ./bin/utils/get_model_data.py -p ./ -o cbofs -s 2025-07-01T00:00:00Z -e 2025-07-02T00:00:00Z -ws forecast_b -t stations

--- a/README.md
+++ b/README.md
@@ -31,6 +31,11 @@ cp conf/ofs_dps.conf.example conf/ofs_dps.conf
 python ./bin/utils/get_model_data.py -p ./ -o cbofs -s 2025-07-01T00:00:00Z -e 2025-07-02T00:00:00Z -ws nowcast -t stations
 python ./bin/utils/get_model_data.py -p ./ -o cbofs -s 2025-07-01T00:00:00Z -e 2025-07-02T00:00:00Z -ws forecast_b -t stations
 
+# 3a. (Alternative) Skip the get_model_data.py calls above by streaming OFS data
+#     directly from the NODD S3 bucket. Ensure use_s3_fallback=True is set in
+#     conf/ofs_dps.conf, and the skill assessment will read model files from the
+#     NODD S3 bucket on demand when local files are missing.
+
 # 4. Run the 1D skill assessment
 python ./bin/visualization/create_1dplot.py -p ./ -o cbofs -s 2025-07-01T00:00:00Z -e 2025-07-02T00:00:00Z -d MLLW -ws nowcast,forecast_b
 ```


### PR DESCRIPTION
### Description of Changes

This PR adds an alternative step (3a) to the Quick start section of the README. It documents that users can skip the `get_model_data.py` download calls by setting `use_s3_fallback=True` in `conf/ofs_dps.conf`, which streams OFS model data directly from the NODD S3 bucket on demand when local files are missing. This is a documentation-only change intended to make the streaming workflow more discoverable to new users.

### Expected Outcome of Changes

No impact on the web application, output files, or code behavior. The only change is added guidance text in the README Quick start section.

### Developer Questions and Checklist

**Is this a high priority PR? If yes, why and is there a date by which it needs to be merged?** No

**Are there any changes needed to how the code should be run for operational runs? (Commands, flags, job timings, etc.)** No

**Does this update need to be deployed for operational runs?** No

**Does this update require front end/web app changes? (If yes, provide documentation to Min)** No

**Does this impact code development work on adding SCHISM?** No

**Does this impact code development work on adding ADCIRC?** No

**Does this impact the expected number of output files for integration tests (i.e., will the integration test fail even though code changes result in desired change in outputs?)** No

- [x] Developer's name is removed throughout the code?
- [x] Did you add relevant labels to the PR?
- [x] Have you run pylint and is the code at an acceptable pylint score (>8)? N/A - documentation only
- [x] Jobs contain the appropriate file checking and handle errors for any missing data? N/A - documentation only
- [x] Is log free of critical ERRORs or WARNINGs? N/A - documentation only

### Testing Instructions

No code to test. To verify the documentation:
1. Open `README.md` and confirm the new step 3a appears in the Quick start section.
2. Confirm the guidance matches the `use_s3_fallback` setting described in `conf/ofs_dps.conf.example`.

### Reminder checklist for PR reviewer

- [ ] Run PEP8 compliance tests to ensure the code follows best practices
- [ ] Check that documentation in the script is sufficient
- [ ] Validate the output values (if applicable) to make sure the calculations are correct and make scientific/physical sense; include a comment on the pull request including what validation you performed, for replicability.
- [ ] Test code both on Windows and Linux (and MacOS, if available), using several OFS as test cases
- [ ] **Test for all 'cast' options: forecast_a, forecast_b, and nowcast**
- [ ] When approving or commenting on a pull request, add information on the calls you use in case they need to be replicated or referenced.
