### PR TITLE
Echo the invoking python command in the log file for 1D and 2D runs

### DIFF
--- a/bin/visualization/create_1dplot.py
+++ b/bin/visualization/create_1dplot.py
@@ -71,6 +71,7 @@ import glob
 import logging
 import logging.config
 import os
+import shlex
 import sys
 import time
 import warnings
@@ -99,6 +100,16 @@ from ofs_skill.utils.timeseries_coverage import (
 from ofs_skill.visualization import create_gui, plotting_scalar, plotting_vector, summary_barplots
 
 warnings.filterwarnings('ignore')
+
+
+def _format_run_command():
+    """Reconstruct the exact python command used to launch this run.
+
+    Echoing this into the log lets us debug a user's run from the log file
+    alone, without asking them to also send the command they invoked.
+    """
+    return shlex.join([sys.executable, *sys.argv])
+
 
 def parameter_validation(prop, logger):
     """ Parameter validation """
@@ -839,6 +850,7 @@ def create_1dplot(prop, logger):
         # Creater logger
         logging.config.fileConfig(log_config_file)
         logger = logging.getLogger('root')
+        logger.info('Run command: %s', _format_run_command())
         logger.info('Using config %s', config_file)
         logger.info('Using log config %s', log_config_file)
 

--- a/bin/visualization/create_2dplot.py
+++ b/bin/visualization/create_2dplot.py
@@ -48,6 +48,7 @@ import json
 import logging
 import logging.config
 import os
+import shlex
 import sys
 from datetime import datetime
 from pathlib import Path
@@ -65,6 +66,15 @@ from ofs_skill.model_processing import (
 )
 from ofs_skill.obs_retrieval import utils
 from ofs_skill.visualization import plotting_2d
+
+
+def _format_run_command():
+    """Reconstruct the exact python command used to launch this run.
+
+    Echoing this into the log lets us debug a user's run from the log file
+    alone, without asking them to also send the command they invoked.
+    """
+    return shlex.join([sys.executable, *sys.argv])
 
 
 def validate_and_initialize_parameters(prop):
@@ -88,6 +98,7 @@ def validate_and_initialize_parameters(prop):
 
     logging.config.fileConfig(log_config_file)
     logger = logging.getLogger('root')
+    logger.info('Run command: %s', _format_run_command())
     logger.info('Using config %s', config_file)
     logger.info('Using log config %s', log_config_file)
     logger.info('--- Starting Visualization Process ---')


### PR DESCRIPTION
### Description of Changes

Closes #249.

When debugging a user's run we currently need two things: their log file **and** the exact python command they used to launch it. Users often send only the log file, or misremember the command they actually ran. This adds an echo of the exact python invocation as one of the first entries in the log for both the 1D and 2D pipelines, so a run can be debugged from the log file alone.

Both visualization entry points now log the reconstructed command right after the root logger is configured, before the existing `Using config` lines:

- `create_1dplot.py`: added `_format_run_command()` and log it in `create_1dplot()` once the logger is set up (the `logger is None` branch).
- `create_2dplot.py`: added `_format_run_command()` and log it in `validate_and_initialize_parameters()` once the logger is set up.

The command is rebuilt with `shlex.join([sys.executable, *sys.argv])` so arguments containing spaces stay unambiguous. `shlex` is standard library, so no new dependencies are introduced.

_Labels: enhancement_

### Expected Outcome of Changes

A new line near the top of the log, e.g.:

```
2026-08-04 09:15:22 - INFO - Run command: /path/to/python bin/visualization/create_1dplot.py -o cbofs -s 2025-07-01T00:00:00Z -e 2025-07-02T00:00:00Z -d MLLW -ws nowcast,forecast_b
```

No change to output files, plots, or skill values. As shipped, `conf/logging.conf` enables only the stdout `StreamHandler`; the line reaches an on-disk log when the file handler is enabled or stdout is redirected to a file (which is how the existing `log/*.log` captures are produced).

### Developer Questions and Checklist

**Is this a high priority PR? If yes, why and is there a date by which it needs to be merged?**
No.

**Are there any changes needed to how the code should be run for operational runs? (Commands, flags, job timings, etc.)**
No. No new flags or arguments; behavior is identical aside from one extra log line.

**Does this update need to be deployed for operational runs?**
No (nice-to-have for debugging; not required).

**Does this update require front end/web app changes? (If yes, provide documentation to Min)**
No.

**Does this impact code development work on adding SCHISM?**
No.

**Does this impact code development work on adding ADCIRC?**
No.

**Does this impact the expected number of output files for integration tests (i.e., will the integration test fail even though code changes result in desired change in outputs?)**
No. Only an additional log line is emitted; no output files are added, removed, or renamed.

- [x] Developer's name is removed throughout the code?
- [x] Did you add relevant labels to the PR?
- [x] Have you run pylint and is the code at an acceptable pylint score (>8)? (ruff + mypy pre-commit hooks pass)
- [x] Jobs contain the appropriate file checking and handle errors for any missing data? (unchanged; the new helper only reads `sys.argv`/`sys.executable`)
- [x] Is log free of critical ERRORs or WARNINGs? For errors that are not critical and can remain in code, is there sufficient handling and logging?

### Testing Instructions

1. Enable file logging (optional) or capture stdout to a file. To use the built-in file handler, in `conf/logging.conf` set `handlers=fileHandler` under `[logger_root]` and `keys=fileHandler` under `[handlers]`.
2. Run a 1D assessment, e.g.:
   ```bash
   python ./bin/visualization/create_1dplot.py -p ./ -o cbofs -s 2025-07-01T00:00:00Z -e 2025-07-02T00:00:00Z -d MLLW -ws nowcast,forecast_b
   ```
3. Run a 2D assessment, e.g.:
   ```bash
   python ./bin/visualization/create_2dplot.py -p ./ -o sfbofs -s 2025-06-01T00:00:00Z -e 2025-06-02T00:00:00Z -ws nowcast,forecast_b
   ```
4. Confirm that near the top of the log (before `Using config ...`) there is a `Run command: ...` line that matches the command you typed, with spaces in arguments quoted.

Expected result: the logged command is a faithful reconstruction of the invocation and is re-runnable (POSIX quoting; on Windows `cmd.exe` it is readable and easily adapted).

### Reminder checklist for PR reviewer

- [ ] Run PEP8 compliance tests to ensure the code follows best practices
- [ ] Check that documentation in the script is sufficient
- [ ] Validate the output values (if applicable) to make sure the calculations are correct and make scientific/physical sense; include a comment on the pull request including what validation you performed, for replicability.
- [ ] Test code both on Windows and Linux (and MacOS, if available), using several OFS as test cases
- [ ] **Test for all 'cast' options: forecast_a, forecast_b, and nowcast**
- [ ] When approving or commenting on a pull request, add information on the calls you use in case they need to be replicated or referenced.
