### PR TITLE
Fix 2D Great Lakes null SST and vector/scalar time mismatch (#195)

### DIFF
--- a/src/ofs_skill/visualization/processing_2d.py
+++ b/src/ofs_skill/visualization/processing_2d.py
@@ -61,12 +61,12 @@ if TYPE_CHECKING:
 # Module-level constants for model variable processing
 MODEL_VAR_NAMES = ('sst', 'ssh', 'sss', 'ssu', 'ssv')
 VELOCITY_VARS = ('ssu', 'ssv')
-CAST_PREFIX_MAP = {
-    'nowcast': 'n',
-    'forecast_a': 'f',
-    'forecast_b': 'f',
-    'hindcast': 'h',
-}
+
+# Great Lakes OFS. The global_land_mask library classifies the Great Lakes
+# as land, which zeroes out every interpolated grid cell for these domains.
+# For these OFS we skip the global land mask in interp_grid() and rely solely
+# on the OFS shapefile domain mask to define valid water points.
+GREAT_LAKES_OFS = ('leofs', 'lmhofs', 'loofs', 'loofs2', 'lsofs')
 
 
 def param_val(netcdf_file_sat: str | None, prop1=None) -> tuple[Logger, list]:
@@ -757,24 +757,41 @@ def _build_ascii_grid_filename(
     """
     Generate output filename for current vector ASCII grid files.
 
+    Hourly current-vector grids are tagged with the same ``YYYYMMDD-HHz``
+    timestamp used by the scalar model JSON files (see
+    :func:`_build_model_output_filename`). This lets the front end pair the
+    vector (dir/mag) layers with the SST/SSH/SSS layers on a shared time
+    axis. Previously the vector grids used a sequential per-timestep counter
+    (``n001``, ``n002`` ...) that rolled continuously across day boundaries
+    and never encoded the model hour, so the vector and scalar layers could
+    not be aligned (issue #195, symptom 3).
+
     Args:
         outdir: Output directory path
         ofs: OFS name (e.g., 'cbofs', 'wcofs')
         dtime: Datetime for the file
         derived_var: Derived variable name ('mag' or 'dir')
         whichcast: Forecast type ('nowcast', 'forecast_a', etc.)
-        step_number: Sequential 1-based timestep number
+        step_number: Sequential 1-based timestep number (retained for API
+            compatibility; no longer used for hourly filenames)
         is_daily: If True, generate daily average filename
 
     Returns:
         Full path to output .txt file
     """
-    date_str = dtime.strftime('%Y%m%d')
     if is_daily:
+        date_str = dtime.strftime('%Y%m%d')
         suffix = 'daily'
     else:
-        prefix = CAST_PREFIX_MAP.get(whichcast, 'n')
-        suffix = f'{prefix}{step_number:03d}'
+        # Match the scalar model JSON hour tag so the front end can pair the
+        # vector layers with the SST/SSH/SSS layers on the same time axis.
+        date_str = dtime.strftime('%Y%m%d-%Hz')
+        suffix = None
+    if suffix is None:
+        return os.path.join(
+            outdir,
+            f'{ofs}_{derived_var}_{date_str}.txt',
+        )
     return os.path.join(
         outdir,
         f'{ofs}_{derived_var}_{date_str}_{suffix}.txt',
@@ -1014,14 +1031,23 @@ def interp_grid(
     # ==========================================
     # --- Apply Land Mask ---
     # ==========================================
-    logger.info('--- Applying Land Mask ---')
+    # global_land_mask misclassifies the Great Lakes as land, which would
+    # null out every interpolated cell for Great Lakes OFS. Skip the global
+    # land mask for those domains and rely on the OFS shapefile mask below.
+    if str(getattr(prop1, 'ofs', '')).lower() in GREAT_LAKES_OFS:
+        logger.info(
+            '--- Skipping global land mask for Great Lakes OFS %s '
+            '(relying on shapefile domain mask) ---', prop1.ofs,
+        )
+    else:
+        logger.info('--- Applying Land Mask ---')
 
-    # globe.is_land returns True for land, False for water (and oceans)
-    # Pass the grid coordinates to check every point
-    is_land = globe.is_land(lat_grid, lon_grid)
+        # globe.is_land returns True for land, False for water (and oceans)
+        # Pass the grid coordinates to check every point
+        is_land = globe.is_land(lat_grid, lon_grid)
 
-    # Set all land points to NaN (making them transparent in plotting)
-    sst_out[is_land] = np.nan
+        # Set all land points to NaN (making them transparent in plotting)
+        sst_out[is_land] = np.nan
 
     # ==========================================
     # --- Apply Shapefile Mask ---

--- a/tests/ascii_grid_output_test.py
+++ b/tests/ascii_grid_output_test.py
@@ -264,34 +264,51 @@ class TestBuildAsciiGridFilename:
     """Tests for _build_ascii_grid_filename."""
 
     def test_nowcast_filename(self):
-        """Nowcast generates n-prefixed filename with step number."""
+        """Hourly nowcast grids are tagged with the YYYYMMDD-HHz hour so the
+        vector layers align with the scalar model JSON time axis."""
         result = _build_ascii_grid_filename(
             '/out', 'cbofs',
             datetime(2026, 1, 20, 3, 0, tzinfo=timezone.utc),
             'mag', 'nowcast', 4,
         )
-        assert result == os.path.join('/out', 'cbofs_mag_20260120_n004.txt')
+        assert result == os.path.join('/out', 'cbofs_mag_20260120-03z.txt')
 
     def test_first_step(self):
-        """First step generates 001."""
+        """Hour tag reflects the model hour, not a sequential counter."""
         result = _build_ascii_grid_filename(
             '/out', 'wcofs',
             datetime(2026, 1, 20, 3, 0, tzinfo=timezone.utc),
             'dir', 'nowcast', 1,
         )
-        assert result == os.path.join('/out', 'wcofs_dir_20260120_n001.txt')
+        assert result == os.path.join('/out', 'wcofs_dir_20260120-03z.txt')
 
     def test_forecast_filename(self):
-        """Forecast generates f-prefixed filename."""
+        """Forecast hourly grids use the same YYYYMMDD-HHz hour tag."""
         result = _build_ascii_grid_filename(
             '/out', 'dbofs',
             datetime(2026, 1, 20, 6, 0, tzinfo=timezone.utc),
             'mag', 'forecast_a', 7,
         )
-        assert result == os.path.join('/out', 'dbofs_mag_20260120_f007.txt')
+        assert result == os.path.join('/out', 'dbofs_mag_20260120-06z.txt')
+
+    def test_step_number_ignored_for_hourly(self):
+        """The step_number arg no longer affects hourly filenames; the hour
+        tag comes solely from dtime (regression guard for issue #195)."""
+        early = _build_ascii_grid_filename(
+            '/out', 'sfbofs',
+            datetime(2026, 6, 20, 10, 0, tzinfo=timezone.utc),
+            'mag', 'nowcast', 25,
+        )
+        late = _build_ascii_grid_filename(
+            '/out', 'sfbofs',
+            datetime(2026, 6, 20, 10, 0, tzinfo=timezone.utc),
+            'mag', 'nowcast', 1,
+        )
+        assert early == late
+        assert early == os.path.join('/out', 'sfbofs_mag_20260620-10z.txt')
 
     def test_daily_filename(self):
-        """Daily filename uses 'daily' suffix instead of step number."""
+        """Daily filename uses 'daily' suffix instead of an hour tag."""
         result = _build_ascii_grid_filename(
             '/out', 'cbofs',
             datetime(2026, 1, 20, 0, 0, tzinfo=timezone.utc),
@@ -301,10 +318,10 @@ class TestBuildAsciiGridFilename:
         assert result == os.path.join('/out', 'cbofs_mag_20260120_daily.txt')
 
     def test_hindcast_filename(self):
-        """Hindcast generates h-prefixed filename."""
+        """Hindcast hourly grids use the YYYYMMDD-HHz hour tag."""
         result = _build_ascii_grid_filename(
             '/out', 'loofs2',
             datetime(2026, 1, 20, 2, 0, tzinfo=timezone.utc),
             'dir', 'hindcast', 3,
         )
-        assert result == os.path.join('/out', 'loofs2_dir_20260120_h003.txt')
+        assert result == os.path.join('/out', 'loofs2_dir_20260120-02z.txt')


### PR DESCRIPTION
### Description of Changes

Closes #195.

While hardening the 2D front end for v1.8, issue #195 reported three problems.
I reproduced them against fresh field data (2026-08-01 → 2026-08-02, nowcast),
one OFS per symptom group, and found the current state to be:

1. **Missing SST JSON for CBOFS/CIOFS/DBOFS (ROMS)** — no longer reproduces.
   Both CBOFS and DBOFS now produce a complete set of hourly SST JSON files
   with valid data. This was already resolved on `main` by the earlier ROMS
   mask indexing fix (`38bbcca`), so no code change is needed here.
2. **All-null SST for LMHOFS/LOOFS/LSOFS (FVCOM, Great Lakes)** — still broken;
   **fixed in this PR.**
3. **SST nowcast/forecast time axis mismatched the modeled dir/mag vector data
   for NGOFS/SFBOFS** — still broken; **fixed in this PR.**

This PR addresses symptoms 2 and 3.

**Symptom 2 — Great Lakes SST rendered as all-null.**
The source model data is fine (surface `temp` in the LOOFS field files is fully
finite, ~16–25 °C), but `interp_grid()` applies the `global_land_mask` library,
which classifies the entire Great Lakes as *land*. As a result
`sst_out[is_land] = np.nan` nulled out every interpolated cell for the Great
Lakes FVCOM domains before the JSON was written. I confirmed directly that
`globe.is_land()` returns `True` for open-water points in Lake Ontario,
Michigan, Huron, Superior, and Erie, while a Chesapeake Bay open-water point
correctly returns `False`.

Fix: skip the global land mask for Great Lakes OFS
(`leofs, lmhofs, loofs, loofs2, lsofs`) and rely solely on the OFS shapefile
domain mask, which is already applied immediately afterward and correctly
defines valid water points. Coastal/ocean OFS are unchanged. The Great Lakes
grouping matches the existing `GREAT_LAKES_OFS` list used elsewhere
(`gui_helpers.py`).

**Symptom 3 — vector (dir/mag) layers not aligned with scalar (SST/SSH/SSS)
layers.**
Scalar model JSON files are keyed by hour (`{ofs}_{YYYYMMDD-HHz}_{var}_model...`),
but the current dir/mag ASCII grids were tagged with a sequential per-timestep
counter (`n001`, `n002`, ...) that rolled continuously across day boundaries
and never encoded the actual model hour. So a nowcast spanning 15z day 1 → 15z
day 2 produced `..._20260619_n001..n009` then `..._20260620_n010..n025`,
and the front end could only show vectors where the running index happened to
line up with a visible hour.

Fix: tag hourly current-vector grids with the same `YYYYMMDD-HHz` hour stamp
used by the scalar model JSON, so both layers share a single time axis. Daily
grids keep the existing `_daily` suffix. The `step_number` argument is retained
for API compatibility but no longer influences hourly filenames. This also makes
the model vector grids consistent with the HF radar vector grids, which already
use `YYYYMMDD-HHz`.

Suggested labels: `bug`, `user experience`, `v1.8 hardening`.

### Expected Outcome of Changes

- **Web app:** Great Lakes OFS (LMHOFS, LOOFS, LSOFS, LEOFS) will now display
  actual 2D SST fields instead of blank/transparent layers. On the 2D map, the
  current dir/mag vector layers will line up on the same hourly time slider as
  the SST/SSH/SSS scalar layers for all OFS, so vectors appear for every hour a
  scalar frame exists.
- **Output files:**
  - Great Lakes model SST/SSH/SSS/SSU/SSV JSON files now contain non-null data
    inside the domain (previously all null for the Great Lakes).
  - Hourly current-vector ASCII grid filenames change from
    `{ofs}_{mag|dir}_{YYYYMMDD}_{n|f|h}NNN.txt` to
    `{ofs}_{mag|dir}_{YYYYMMDD-HHz}.txt`. Daily grids
    (`{ofs}_{mag|dir}_{YYYYMMDD}_daily.txt`) are unchanged.

### Developer Questions and Checklist

**Is this a high priority PR? If yes, why and is there a date by which it needs to be merged?**
No hard deadline; it is part of v1.8 hardening and fixes visibly broken 2D
output for the Great Lakes and misaligned vector layers, so it is worth
including in the v1.8 release.

**Are there any changes needed to how the code should be run for operational runs? (Commands, flags, job timings, etc.)**
No. Same commands and flags as before.

**Does this update need to be deployed for operational runs?**
Yes — to produce corrected Great Lakes SST and correctly-tagged vector grids in
operational 2D output.

**Does this update require front end/web app changes? (If yes, provide documentation to Min)**
Yes. The hourly current-vector ASCII grid filenames changed from a sequential
`nNNN`/`fNNN` suffix to the `YYYYMMDD-HHz` hour tag (daily grids unchanged). If
the web app parses these filenames to place vectors on the time slider, Min
should update the parser to read the `YYYYMMDD-HHz` tag (the same format already
used for the scalar model JSON and HF radar grids). This is the intended fix for
the vector/scalar alignment.

**Does this impact code development work on adding SCHISM?**
No.

**Does this impact code development work on adding ADCIRC?**
No.

**Does this impact the expected number of output files for integration tests (i.e., will the integration test fail even though code changes result in desired change in outputs?)**
The *number* of hourly current-vector grid files per run is unchanged. Their
*names* change (hour tag instead of sequential counter). If an integration test
asserts on the old `nNNN`/`fNNN` grid filenames, it will need to be updated to
the `YYYYMMDD-HHz` names. Great Lakes SST/SSH/SSS/SSU/SSV JSON file counts are
unchanged (only their contents go from all-null to populated).

- [x] Developer's name is removed throughout the code?
- [ ] Did you add relevant labels to the PR?
- [ ] Have you run pylint and is the code at an acceptable pylint score (>8)?
- [x] Jobs contain the appropriate file checking and handle errors for any missing data?
- [x] Is log free of critical ERRORs or WARNINGs? For errors that are not critical and can remain in code, is there sufficient handling and logging? (For Great Lakes OFS the log now emits an informational "Skipping global land mask ..." line instead of the misleading land-mask application.)

### Testing Instructions

Environment: `ofs_dps` conda env. Delete or rename any existing `data/` and
`control_files/` before each run.

**Symptom 2 — Great Lakes SST (LOOFS as the representative case):**

```bash
python ./bin/utils/get_model_data.py -p ./ -o loofs -s 2026-08-01T00:00:00Z -e 2026-08-02T00:00:00Z -ws nowcast -t fields
python ./bin/visualization/create_2dplot.py -p ./ -o loofs -s 2026-08-01T00:00:00Z -e 2026-08-02T00:00:00Z -ws nowcast
```

Expected: `data/model/2d/loofs_20260801-12z_sst_model.nowcast.json` contains
non-null SST inside the domain and populated `val_min`/`val_max`. In my run this
file went from **0 non-null of 65,720** (before) to **22,519 non-null**
(16.5–24.68 °C); the non-null count matches the shapefile domain exactly. Repeat
with `lmhofs` / `lsofs` to confirm. A coastal ROMS OFS such as `cbofs` should
still mask land correctly (unchanged behavior).

**Symptom 3 — vector/scalar time alignment (SFBOFS as the representative case):**

```bash
python ./bin/utils/get_model_data.py -p ./ -o sfbofs -s 2026-08-01T00:00:00Z -e 2026-08-02T00:00:00Z -ws nowcast -t fields
python ./bin/visualization/create_2dplot.py -p ./ -o sfbofs -s 2026-08-01T00:00:00Z -e 2026-08-02T00:00:00Z -ws nowcast
```

Expected: the hourly current-vector grids
(`data/model/2d/sfbofs_mag_*.txt`, `sfbofs_dir_*.txt`) are labeled
`20260801-00z` … `20260801-23z`, `20260802-00z` — matching the 25 hourly
`sfbofs_*_sst_model.nowcast.json` labels exactly — plus one
`sfbofs_mag_20260801_daily.txt`. Repeat with `ngofs`.

Note: these runs abort at the very end with
`No files found in directory ./data/observations/2d` / "No satellite data
available for stats" because no satellite/obs data was retrieved. That is the
expected pre-existing behavior when running the model-only 2D path; the model
JSON and vector grids are all written before that point.

**Unit tests:**

```bash
pytest tests/ascii_grid_output_test.py tests/hf_radar_test.py tests/plotting_2d_json_listing_test.py
```

All 80 pass. `tests/ascii_grid_output_test.py::TestBuildAsciiGridFilename` was
updated to the new `YYYYMMDD-HHz` scheme and includes a regression guard
(`test_step_number_ignored_for_hourly`) proving two different step numbers at
the same hour now yield identical filenames.

### Reminder checklist for PR reviewer

- [ ] Run PEP8 compliance tests to ensure the code follows best practices
- [ ] Check that documentation in the script is sufficient
- [ ] Validate the output values (if applicable) to make sure the calculations are correct and make scientific/physical sense; include a comment on the pull request including what validation you performed, for replicability.
- [ ] Test code both on Windows and Linux (and MacOS, if available), using several OFS as test cases
- [ ] Test for all 'cast' options: forecast_a, forecast_b, and nowcast
- [ ] When approving or commenting on a pull request, add information on the calls you use in case they need to be replicated or referenced.
