### PR TITLE
Stop reusing leftover files when 1D run settings change (no more deleting `./data` and `./control_files` between runs)

### DIFF
--- a/bin/visualization/create_1dplot.py
+++ b/bin/visualization/create_1dplot.py
@@ -678,7 +678,8 @@ def _ensure_paired_data_exists(read_ofs_ctl_file, prop, var_info, logger):
             # catches that; delete and regenerate on a signature mismatch.
             elif os.path.isfile(pair_file):
                 pair_sig = cache_manifest.run_signature(
-                    prop, variable=var_info[1],
+                    prop,
+                    variable=_NAME_TO_VARIABLE.get(var_info[1], var_info[1]),
                     extra={'whichcast': current_cast})
                 if not cache_manifest.artifact_is_fresh(pair_file, pair_sig):
                     logger.warning(

--- a/bin/visualization/create_1dplot.py
+++ b/bin/visualization/create_1dplot.py
@@ -92,12 +92,24 @@ from ofs_skill.obs_retrieval import parse_arguments_to_list, utils
 from ofs_skill.obs_retrieval.station_ctl_file_extract import station_ctl_file_extract
 from ofs_skill.obs_retrieval.utils import get_parallel_config
 from ofs_skill.skill_assessment.get_skill import get_skill
+from ofs_skill.utils import cache_manifest
 from ofs_skill.utils.timeseries_coverage import (
     covers_run_window,
     parse_run_window,
     remove_stale_artifact,
 )
 from ofs_skill.visualization import create_gui, plotting_scalar, plotting_vector, summary_barplots
+
+# Short ctl/prd name-part -> long variable name. The cache-manifest run
+# signatures are keyed on the long variable name (as written by the ctl/prd
+# builders), so the ctl-read gate maps ``wl``/``temp``/``salt``/``cu`` back
+# before comparing signatures.
+_NAME_TO_VARIABLE = {
+    'wl': 'water_level',
+    'temp': 'water_temperature',
+    'salt': 'salinity',
+    'cu': 'currents',
+}
 
 warnings.filterwarnings('ignore')
 
@@ -296,7 +308,27 @@ def ofs_ctlfile_read(prop, name_var, logger):
 
             get_skill(prop, logger)
 
-    # If file exists, use method A to parse it
+    # A model ctl left from a run with different parameters would otherwise
+    # be parsed as-is (its filename encodes only ofs+var, not the window or
+    # station-owner/datum options). Drop it on a signature mismatch so
+    # get_skill rebuilds it and the downstream artifacts for the current run
+    # (issue: stale cache reuse across runs). The build path in
+    # write_ofs_ctlfile keys the manifest on the long variable name.
+    else:
+        ctl_variable = _NAME_TO_VARIABLE.get(name_var, name_var)
+        ctl_sig = cache_manifest.run_signature(prop, variable=ctl_variable)
+        if not cache_manifest.artifact_is_fresh(filename, ctl_sig):
+            if remove_stale_artifact(
+                    filename, prop.control_files_path, logger):
+                cache_manifest.forget_artifact(filename, logger)
+                cache_manifest.note_stale('model ctl')
+            for i in prop.whichcasts:
+                prop.whichcast = i.lower()
+                logger.info(f'Running scripts for whichcast = {i}')
+                if prop.start_date_full.find('T') == -1:
+                    prop.start_date_full = prop.start_date_full_before
+                    prop.end_date_full = prop.end_date_full_before
+                get_skill(prop, logger)
     if os.path.isfile(filename):
         if os.path.getsize(filename):
             return parse_ofs_ctlfile(filename)
@@ -640,6 +672,24 @@ def _ensure_paired_data_exists(read_ofs_ctl_file, prop, var_info, logger):
                     pair_file, run_window[0], run_window[1])
                 remove_stale_artifact(
                     pair_file, prop.data_skill_1d_pair_path, logger)
+                cache_manifest.forget_artifact(pair_file, logger)
+            # Even a window-covering pair file may have been built under
+            # different datum/station-owner/bins parameters. The manifest
+            # catches that; delete and regenerate on a signature mismatch.
+            elif os.path.isfile(pair_file):
+                pair_sig = cache_manifest.run_signature(
+                    prop, variable=var_info[1],
+                    extra={'whichcast': current_cast})
+                if not cache_manifest.artifact_is_fresh(pair_file, pair_sig):
+                    logger.warning(
+                        'Paired dataset %s was built for different run '
+                        'parameters and is likely left over from an '
+                        'earlier run. Deleting it so it is regenerated.',
+                        pair_file)
+                    if remove_stale_artifact(
+                            pair_file, prop.data_skill_1d_pair_path, logger):
+                        cache_manifest.forget_artifact(pair_file, logger)
+                        cache_manifest.note_stale('paired')
             if not os.path.isfile(pair_file):
                 if (prop.ofsfiletype == 'fields'
                         or read_ofs_ctl_file[1][i] >= 0):
@@ -855,6 +905,10 @@ def create_1dplot(prop, logger):
         logger.info('Using log config %s', log_config_file)
 
     logger.info('--- Starting Visualization Process ---')
+
+    # Start a fresh tally of any cached artifacts we regenerate because the
+    # run parameters (window/options) changed since they were last built.
+    cache_manifest.reset_stale_counter()
 
     dir_params = utils.Utils(_conf).read_config_section('directories', logger)
     # Retrieve datum list from config file
@@ -1234,6 +1288,10 @@ def create_1dplot(prop, logger):
         search_string=prop.ofs,
         whichcasts=getattr(prop, 'whichcasts', None),
         logger=logger)
+
+    # One-line summary if any cached artifacts were regenerated because the
+    # run parameters differed from the files on disk (stale-cache guard).
+    cache_manifest.emit_stale_summary(prop.ofs, logger)
 
     return logger
 

--- a/src/ofs_skill/model_processing/get_node_ofs.py
+++ b/src/ofs_skill/model_processing/get_node_ofs.py
@@ -36,6 +36,7 @@ from ofs_skill.model_processing.model_source import get_model_source
 from ofs_skill.model_processing.write_ofs_ctlfile import write_ofs_ctlfile
 from ofs_skill.obs_retrieval import scalar, utils, vector
 from ofs_skill.obs_retrieval.utils import get_parallel_config
+from ofs_skill.utils import cache_manifest
 from ofs_skill.utils.file_headers import (
     SERIES_HEADER_PREFIX,
     series_header,
@@ -1481,6 +1482,11 @@ def _all_prd_files_complete(prop_local, ofs_ctlfile, name_var,
                     '%s to %s — likely left over from an earlier run. '
                     'Re-extracting.', path, run_window[0], run_window[1])
                 return False
+    # NOTE: parameter-signature staleness (datum/station-owner/bins) is
+    # enforced upstream by ``get_skill._ensure_prd_files`` via the cache
+    # manifest before this resume short-circuit is consulted, so it is not
+    # re-checked here. This helper only judges window coverage + row counts,
+    # keeping it usable in isolation (and matching its unit tests).
     return True
 
 
@@ -1813,14 +1819,17 @@ def get_node_ofs(prop, logger, model_dataset=None):
 
                 if (prop_local.whichcast == 'forecast_a' and
                     not prop_local.horizonskill):
-                    with open(
+                    prd_path_fa = (
                         r''
                         + f'{prop_local.data_model_1d_node_path}'
                           f'/{ofs_ctlfile[4][i]}_'
                           f'{prop_local.ofs}_{name_conventions[0]}_'
                           f'{ofs_ctlfile[1][i]}_'
                           f'{prop_local.whichcast}_{prop_local.forecast_hr}_'
-                          f'{prop_local.ofsfiletype}_model.prd',
+                          f'{prop_local.ofsfiletype}_model.prd'
+                    )
+                    with open(
+                        prd_path_fa,
                         'w',
                         encoding='utf-8',
                     ) as output:
@@ -1843,6 +1852,13 @@ def get_node_ofs(prop, logger, model_dataset=None):
                             prop_local.forecast_hr,
                             prop_local.ofsfiletype
                         )
+                    cache_manifest.record_artifact(
+                        prd_path_fa,
+                        cache_manifest.run_signature(
+                            prop_local, variable=variable,
+                            extra={'whichcast': prop_local.whichcast,
+                                   'forecast_hr': prop_local.forecast_hr}),
+                        logger)
                 elif (prop_local.horizonskill and os.path.isfile(
                         f'{prop_local.data_model_1d_node_path}/'
                         f'{ofs_ctlfile[-1][i]}_{prop_local.ofs}_{name_conventions[0]}_'
@@ -1881,12 +1897,17 @@ def get_node_ofs(prop, logger, model_dataset=None):
                                      'Error: %s', e_x)
                         return (datum_offset, model_station)
                 else:
-                    with open(
+                    prd_path_std = (
                         r''
-                        +f'{prop_local.data_model_1d_node_path}/{ofs_ctlfile[4][i]}_'
+                        + f'{prop_local.data_model_1d_node_path}/'
+                          f'{ofs_ctlfile[4][i]}_'
                           f'{prop_local.ofs}_'
                           f'{name_conventions[0]}_{ofs_ctlfile[1][i]}'
-                          f'_{prop_local.whichcast}_{prop_local.ofsfiletype}_model.prd',
+                          f'_{prop_local.whichcast}_'
+                          f'{prop_local.ofsfiletype}_model.prd'
+                    )
+                    with open(
+                        prd_path_std,
                         'w',
                         encoding='utf-8',
                     ) as output:
@@ -1907,6 +1928,12 @@ def get_node_ofs(prop, logger, model_dataset=None):
                             prop_local.whichcast,
                             prop_local.ofsfiletype
                         )
+                    cache_manifest.record_artifact(
+                        prd_path_std,
+                        cache_manifest.run_signature(
+                            prop_local, variable=variable,
+                            extra={'whichcast': prop_local.whichcast}),
+                        logger)
 
                 return (datum_offset, model_station)
 

--- a/src/ofs_skill/model_processing/write_ofs_ctlfile.py
+++ b/src/ofs_skill/model_processing/write_ofs_ctlfile.py
@@ -37,6 +37,7 @@ import numpy as np
 import ofs_skill.model_processing.indexing as indexing
 from ofs_skill.obs_retrieval import utils
 from ofs_skill.obs_retrieval.station_ctl_file_extract import station_ctl_file_extract
+from ofs_skill.utils import cache_manifest
 from ofs_skill.utils.file_headers import MODEL_CTL_HEADER, OBS_CTL_HEADER
 
 # Public alias for the shape-normalising static-coord helper. Keeps the
@@ -414,6 +415,22 @@ def write_ofs_ctlfile(prop: Any, model: Any, logger: Logger) -> Any:
         elif variable == 'currents':
             name_var = 'cu'
 
+        # The model ctl encodes the station/node pairing for THIS run's
+        # window + options; its filename does not. Delete a ctl left from a
+        # run with different parameters so it is rebuilt (issue: stale cache
+        # reuse across runs). ``model_ctl_path`` is the file this iteration
+        # would read/write.
+        if prop.ofsfiletype == 'fields':
+            model_ctl_path = (f'{prop.control_files_path}/{prop.ofs}_'
+                              f'{name_var}_model.ctl')
+        else:
+            model_ctl_path = (f'{prop.control_files_path}/{prop.ofs}_'
+                              f'{name_var}_model_station.ctl')
+        ctl_signature = cache_manifest.run_signature(prop, variable=variable)
+        cache_manifest.ensure_fresh(
+            model_ctl_path, ctl_signature, prop.control_files_path,
+            'model ctl', logger)
+
         if (
             (os.path.isfile(
                 f'{prop.control_files_path}/{prop.ofs}_'
@@ -782,6 +799,8 @@ def write_ofs_ctlfile(prop: Any, model: Any, logger: Logger) -> Any:
                     'Model Control File for %s created successfully',
                     variable,
                 )
+                cache_manifest.record_artifact(
+                    model_ctl_path, ctl_signature, logger)
             else:
                 logger.info('Observation ctl file is blank for %s. '
                             'Model ctl file will also be blank', name_var)
@@ -801,6 +820,8 @@ def write_ofs_ctlfile(prop: Any, model: Any, logger: Logger) -> Any:
                         encoding='utf-8',
                     ) as output:
                         pass
+                cache_manifest.record_artifact(
+                    model_ctl_path, ctl_signature, logger)
         else:
             logger.info(
                 'Model Control File (%s_%s_model.ctl) found in %s. If you '

--- a/src/ofs_skill/obs_retrieval/get_station_observations.py
+++ b/src/ofs_skill/obs_retrieval/get_station_observations.py
@@ -123,6 +123,7 @@ from ofs_skill.obs_retrieval.retrieve_usgs_station import retrieve_usgs_station
 from ofs_skill.obs_retrieval.station_ctl_file_extract import station_ctl_file_extract
 from ofs_skill.obs_retrieval.utils import get_parallel_config
 from ofs_skill.obs_retrieval.write_obs_ctlfile import write_obs_ctlfile
+from ofs_skill.utils import cache_manifest
 from ofs_skill.utils.file_headers import series_header
 
 # Import directly from module to avoid circular import
@@ -131,6 +132,16 @@ from ofs_skill.utils.file_headers import series_header
 
 TIMEOUT_SEC = 120 # default API timeout in seconds
 socket.setdefaulttimeout(TIMEOUT_SEC)
+
+# Variable -> ctl/obs/prd name-part mapping. Single source of truth so the
+# obs, ctl-manifest, and reuse gates agree on the ``wl``/``temp``/``salt``/
+# ``cu`` suffixes rather than re-deriving them inline at each site.
+_VAR_TO_NAME = {
+    'water_level': 'wl',
+    'water_temperature': 'temp',
+    'salinity': 'salt',
+    'currents': 'cu',
+}
 
 # Serializes the station ctl file build across variable threads.
 # ``write_obs_ctlfile`` creates the ctl files for ALL variables in a
@@ -357,6 +368,7 @@ def _fetch_and_format_station(
     station_info, station_metadata, variable, name_var, datum, datum_list,
     start_date, end_date, start_date_full, end_date_full, ofs,
     data_observations_1d_station_path, logger, control_files_path, config_file=None,
+    obs_signature=None,
 ):
     """Fetch observation data for a single station, format it, and write .obs file.
 
@@ -637,6 +649,11 @@ def _fetch_and_format_station(
                         '%s_%s_%s_station.obs created successfully',
                         station_id, ofs, name_var
                     )
+                # Stamp the run signature so a same-parameter rerun reuses
+                # this file and a changed-parameter run treats it as stale.
+                if obs_signature is not None:
+                    cache_manifest.record_artifact(
+                        obs_path, obs_signature, logger)
                 return station_id
             else:
                 logger.info('Formatted %s time series '
@@ -790,6 +807,15 @@ def _process_variable_obs(
         r'' + control_files_path + '/' + ofs +
         '_' + name_var + '_station.ctl'
     )
+    # A station ctl left from a run with a different window / station-owner
+    # selection encodes the wrong station set; its filename does not record
+    # those parameters, so delete it when the recorded run signature differs
+    # (issue: stale cache reuse across runs). The manifest also covers the
+    # inventory + all sibling ctl files written in the same build pass.
+    obs_ctl_signature = cache_manifest.run_signature(prop, variable=variable)
+    cache_manifest.ensure_fresh(
+        ctl_file_path, obs_ctl_signature, control_files_path,
+        'obs ctl', logger)
     read_station_ctl_file = station_ctl_file_extract(ctl_file_path)
 
     if read_station_ctl_file is not None:
@@ -804,6 +830,22 @@ def _process_variable_obs(
             ctl_file_path, prop, datum, start_date, end_date, path, ofs,
             stationowner, var_list, logger, config_file=config_file,
         )
+        # Record the signature for every station ctl the build produced, so
+        # sibling variables reuse them and a same-parameter rerun stays fast.
+        if read_station_ctl_file is not None:
+            for other_var in var_list:
+                other_name = _VAR_TO_NAME.get(other_var)
+                if other_name is None:
+                    continue
+                other_path = (
+                    r'' + control_files_path + '/' + ofs +
+                    '_' + other_name + '_station.ctl'
+                )
+                if os.path.isfile(other_path):
+                    cache_manifest.record_artifact(
+                        other_path,
+                        cache_manifest.run_signature(prop, variable=other_var),
+                        logger)
 
     logger.info('Downloading data found in the station ctl files')
 
@@ -893,7 +935,15 @@ def _process_variable_obs(
                         data_observations_1d_station_path,
                         f'{station_info[0]}_{ofs}_{name_var}_station.obs',
                     )
-                    if not os.path.isfile(obs_path):
+                    # Reuse an existing .obs only if it was written for this
+                    # run's parameters; a file from an earlier window/options
+                    # is deleted and re-fetched (issue: stale cache reuse).
+                    obs_signature = cache_manifest.run_signature(
+                        prop, variable=variable)
+                    reusable = cache_manifest.ensure_fresh(
+                        obs_path, obs_signature,
+                        data_observations_1d_station_path, 'obs', logger)
+                    if not reusable:
                         future = executor.submit(
                             _fetch_and_format_station,
                             station_info,
@@ -911,6 +961,7 @@ def _process_variable_obs(
                             logger,
                             control_files_path,
                             config_file,
+                            obs_signature,
                         )
                         futures[future] = station_info[0]
                     else:

--- a/src/ofs_skill/obs_retrieval/write_obs_ctlfile.py
+++ b/src/ofs_skill/obs_retrieval/write_obs_ctlfile.py
@@ -51,6 +51,7 @@ from ofs_skill.obs_retrieval.retrieve_t_and_c_station import (
     retrieve_t_and_c_station,
 )
 from ofs_skill.obs_retrieval.retrieve_usgs_station import retrieve_usgs_station
+from ofs_skill.utils import cache_manifest
 from ofs_skill.utils.file_headers import OBS_CTL_HEADER
 
 _COOPS_MAX_WORKERS = 6
@@ -1052,6 +1053,24 @@ def write_obs_ctlfile(
     )
     os.makedirs(data_observations_1d_station_path, exist_ok=True)
 
+    # The station inventory depends on the OFS, the assessment window, and
+    # the station-owner selection, none of which are encoded in its
+    # filename. Delete an inventory left from a run with different
+    # parameters so the reader below rebuilds it instead of reusing the
+    # wrong station set (issue: stale cache reuse across runs).
+    inventory_path = f'{control_files_path}/inventory_all_{ofs}.csv'
+    inventory_signature = {
+        'ofs': cache_manifest._normalize(ofs),
+        'start_date': cache_manifest._normalize(start_date),
+        'end_date': cache_manifest._normalize(end_date),
+        'stationowner': cache_manifest._normalize(stationowner),
+        'currents_bins_csv': cache_manifest.file_fingerprint(
+            currents_bins_csv),
+    }
+    cache_manifest.ensure_fresh(
+        inventory_path, inventory_signature, control_files_path,
+        'inventory', logger)
+
     try:
         dtypes = {
             'ID': 'object',
@@ -1114,6 +1133,11 @@ def write_obs_ctlfile(
         except Exception as ex:
             logger.error(f'Error when creating inventory files: {ex}')
             raise Exception('Error when creating inventory files') from ex
+
+    # Record the signature for the (possibly freshly built) inventory so a
+    # same-parameter rerun reuses it and a changed-parameter run rebuilds it.
+    cache_manifest.record_artifact(
+        inventory_path, inventory_signature, logger)
 
     logger.info('Downloading data from the Inventory file!')
 

--- a/src/ofs_skill/skill_assessment/get_skill.py
+++ b/src/ofs_skill/skill_assessment/get_skill.py
@@ -39,6 +39,17 @@ from ofs_skill.utils.timeseries_coverage import (
     remove_stale_artifact,
 )
 
+# Short model name-part -> long variable name. Cache-manifest signatures are
+# keyed on the long variable name (the ctl/obs/prd writers pass the long
+# name), so the reuse gates in this module -- which work in the short
+# ``wl``/``temp``/``salt``/``cu`` convention -- map back before comparing.
+_NAME_TO_VARIABLE = {
+    'wl': 'water_level',
+    'temp': 'water_temperature',
+    'salt': 'salinity',
+    'cu': 'currents',
+}
+
 
 def _cache_key(prop):
     """Fields that uniquely determine the model dataset loaded by get_node_ofs.
@@ -427,10 +438,11 @@ def _process_station_pair(i, read_station_ctl_file, read_ofs_ctl_file,
         logger.info(f'{filename} is created successfully')
         # Stamp the run signature on the paired file so a same-parameter
         # rerun reuses it and a changed-parameter run treats it as stale.
+        # Keyed on the long variable name to match the .prd/.obs writers.
         cache_manifest.record_artifact(
             int_path,
             cache_manifest.run_signature(
-                prop, variable=name_var,
+                prop, variable=_NAME_TO_VARIABLE.get(name_var, name_var),
                 extra={'whichcast': getattr(prop, 'whichcast', None)}),
             logger)
 
@@ -835,7 +847,7 @@ def get_skill(prop, logger):
             if os.path.isfile(obs_path):
                 if os.path.getsize(obs_path) > 0:
                     obs_sig = cache_manifest.run_signature(
-                        p, variable=name_var)
+                        p, variable=_NAME_TO_VARIABLE.get(name_var, name_var))
                     stale_params = not cache_manifest.artifact_is_fresh(
                         obs_path, obs_sig)
                     if (run_window is not None
@@ -913,7 +925,8 @@ def get_skill(prop, logger):
                 if p.whichcast == 'forecast_a':
                     prd_extra['forecast_hr'] = p.forecast_hr
                 prd_sig = cache_manifest.run_signature(
-                    p, variable=name_var, extra=prd_extra)
+                    p, variable=_NAME_TO_VARIABLE.get(name_var, name_var),
+                    extra=prd_extra)
                 stale_params = not cache_manifest.artifact_is_fresh(
                     prd_path, prd_sig)
                 if (run_window is not None

--- a/src/ofs_skill/skill_assessment/get_skill.py
+++ b/src/ofs_skill/skill_assessment/get_skill.py
@@ -31,6 +31,7 @@ from ofs_skill.obs_retrieval.utils import get_parallel_config
 from ofs_skill.skill_assessment import format_paired_one_d, metrics_paired_one_d
 from ofs_skill.skill_assessment.make_skill_maps import make_skill_maps
 from ofs_skill.tidal_analysis.extremes import extract_water_level_extrema
+from ofs_skill.utils import cache_manifest
 from ofs_skill.utils.file_headers import series_rows_to_skip, strip_model_ctl_header
 from ofs_skill.utils.timeseries_coverage import (
     covers_run_window,
@@ -424,6 +425,14 @@ def _process_station_pair(i, read_station_ctl_file, read_ofs_ctl_file,
                 cleaned_val = str(p_value).replace(',', ' ').replace('[', '').replace(']', '')
                 output_2.write(f'{cleaned_val}\n')
         logger.info(f'{filename} is created successfully')
+        # Stamp the run signature on the paired file so a same-parameter
+        # rerun reuses it and a changed-parameter run treats it as stale.
+        cache_manifest.record_artifact(
+            int_path,
+            cache_manifest.run_signature(
+                prop, variable=name_var,
+                extra={'whichcast': getattr(prop, 'whichcast', None)}),
+            logger)
 
         # Water-level extrema (HW/LW) independent detection + ±3h pairing
         if name_var == 'wl' and prop.ofs[0] != 'l':
@@ -825,6 +834,10 @@ def get_skill(prop, logger):
                         name_var+'_station.obs'))
             if os.path.isfile(obs_path):
                 if os.path.getsize(obs_path) > 0:
+                    obs_sig = cache_manifest.run_signature(
+                        p, variable=name_var)
+                    stale_params = not cache_manifest.artifact_is_fresh(
+                        obs_path, obs_sig)
                     if (run_window is not None
                             and not covers_run_window(
                                 obs_path, run_window[0], run_window[1],
@@ -839,6 +852,23 @@ def get_skill(prop, logger):
                                 obs_path,
                                 p.data_observations_1d_station_path,
                                 logger_):
+                            cache_manifest.forget_artifact(obs_path, logger_)
+                            needs_fetch = True
+                    elif stale_params:
+                        # Same window length but built under different
+                        # datum/station-owner/bins parameters -- delete and
+                        # re-fetch for the current run.
+                        logger_.warning(
+                            '%s was built for different run parameters and '
+                            'is likely left over from an earlier run. '
+                            'Deleting it and re-fetching observations.',
+                            obs_path)
+                        if remove_stale_artifact(
+                                obs_path,
+                                p.data_observations_1d_station_path,
+                                logger_):
+                            cache_manifest.forget_artifact(obs_path, logger_)
+                            cache_manifest.note_stale('obs')
                             needs_fetch = True
                     else:
                         logger_.info('%s found', obs_path)
@@ -879,6 +909,13 @@ def get_skill(prop, logger):
                     f'{p.ofsfiletype}_model.prd'
                 )
             if os.path.isfile(prd_path):
+                prd_extra = {'whichcast': p.whichcast}
+                if p.whichcast == 'forecast_a':
+                    prd_extra['forecast_hr'] = p.forecast_hr
+                prd_sig = cache_manifest.run_signature(
+                    p, variable=name_var, extra=prd_extra)
+                stale_params = not cache_manifest.artifact_is_fresh(
+                    prd_path, prd_sig)
                 if (run_window is not None
                         and not covers_run_window(
                             prd_path, run_window[0], run_window[1],
@@ -890,6 +927,19 @@ def get_skill(prop, logger):
                         prd_path, run_window[0], run_window[1])
                     if remove_stale_artifact(
                             prd_path, p.data_model_1d_node_path, logger_):
+                        cache_manifest.forget_artifact(prd_path, logger_)
+                        needs_model = True
+                elif stale_params:
+                    # Same window length but built under different
+                    # datum/station-owner/bins parameters -- re-extract.
+                    logger_.warning(
+                        '%s was built for different run parameters and is '
+                        'likely left over from an earlier run. Deleting it '
+                        'and re-extracting model data.', prd_path)
+                    if remove_stale_artifact(
+                            prd_path, p.data_model_1d_node_path, logger_):
+                        cache_manifest.forget_artifact(prd_path, logger_)
+                        cache_manifest.note_stale('prd')
                         needs_model = True
             else:
                 logger_.info('%s is missing', prd_path)

--- a/src/ofs_skill/utils/cache_manifest.py
+++ b/src/ofs_skill/utils/cache_manifest.py
@@ -1,0 +1,263 @@
+"""
+Per-directory manifest of the run parameters cached artifacts were built for.
+
+Most 1D pipeline artifacts (``*_station.ctl``, ``*_model.ctl``,
+``inventory_all_{ofs}.csv``, ``*_station.obs``, ``*_model.prd``,
+``*_pair.int``) are named with only ``{ofs}_{var}_...`` and carry no record
+of the assessment window or station-selection options they were produced
+for. A persistent working directory therefore silently reuses files from an
+earlier run whose parameters differ, producing wrong results (issue: users
+having to delete ``./data`` and ``./control_files`` between runs).
+
+``timeseries_coverage`` already catches window drift for the *timestamped*
+artifacts (``.obs``/``.prd``/``.int``), but the ``.ctl`` and inventory files
+have no timestamps to inspect, so a stale station/node pairing is reused
+verbatim and poisons everything downstream.
+
+This module records, per artifact directory, the "run signature" each
+cached file was built under and lets the reuse gates ask
+``artifact_is_fresh(path, signature)``. A file whose recorded signature
+differs from the current run's (or that has no record at all -- e.g. a
+pre-upgrade file) is treated as stale and regenerated once, after which its
+signature is stored.
+
+Design choices:
+- **One index per directory** (``.ofs_cache_manifest.json``), not a sidecar
+  per file, to keep the artifact directories tidy.
+- **Auto-detect and regenerate by default**; no flag required.
+- Reads/writes are guarded by a process lock and tolerate a missing or
+  corrupt index (fails open into "stale", forcing a safe regeneration).
+"""
+
+import json
+import os
+import threading
+from typing import Optional
+
+from ofs_skill.utils.timeseries_coverage import remove_stale_artifact
+
+# Index filename dropped into each artifact directory. Leading dot keeps it
+# out of the way of the pattern-based output globs (``*.obs`` etc.).
+MANIFEST_FILENAME = '.ofs_cache_manifest.json'
+
+# Bump when the signature schema changes so old indexes invalidate safely.
+MANIFEST_SCHEMA_VERSION = 1
+
+# One lock guards all index read/modify/write cycles. The indexes are tiny
+# and written rarely (once per artifact (re)generation), so a single global
+# lock is simpler than per-path locks and avoids interleaved writes when the
+# variable/station fan-outs touch the same directory.
+_manifest_lock = threading.RLock()
+
+# Process-wide tally of artifacts declared stale (parameters changed) during
+# the current run, so an entry point can emit a single end-of-stage summary
+# instead of one line per file. Keyed by a short artifact-kind label.
+_stale_counter: dict = {}
+_stale_counter_lock = threading.Lock()
+
+
+def reset_stale_counter() -> None:
+    """Zero the stale-artifact tally at the start of a run/stage."""
+    with _stale_counter_lock:
+        _stale_counter.clear()
+
+
+def note_stale(kind: str) -> None:
+    """Increment the stale tally for an artifact kind (e.g. ``'ctl'``)."""
+    with _stale_counter_lock:
+        _stale_counter[kind] = _stale_counter.get(kind, 0) + 1
+
+
+def emit_stale_summary(ofs, logger) -> None:
+    """Log one summary line if any stale artifacts were regenerated.
+
+    Silent when nothing was stale, so an unchanged same-window rerun stays
+    quiet. Does not reset the tally -- call :func:`reset_stale_counter` at the
+    start of the next run.
+    """
+    with _stale_counter_lock:
+        if not _stale_counter:
+            return
+        parts = ', '.join(
+            f'{count} {kind}' for kind, count
+            in sorted(_stale_counter.items()))
+        total = sum(_stale_counter.values())
+    if logger is not None:
+        logger.info(
+            'Regenerated %d stale cached artifact(s) for %s due to changed '
+            'run parameters (window/options): %s. Delete the working dirs '
+            'to force a full rebuild.', total, ofs, parts)
+
+
+def _normalize(value):
+    """Canonicalize a signature value for order-insensitive comparison.
+
+    Lists/tuples/sets (and comma- or space-separated strings) of station
+    owners or variables must compare equal regardless of order or case, so
+    they are lowercased and sorted. Plain scalars are stringified so
+    ``'MLLW'`` and ``MLLW`` compare consistently across the JSON round-trip.
+    """
+    if value is None:
+        return None
+    if isinstance(value, (list, tuple, set)):
+        return sorted(str(v).strip().lower() for v in value if str(v).strip())
+    text = str(value).strip()
+    # A multi-token owner/variable string (e.g. ``'co-ops,ndbc'`` or
+    # ``'co-ops ndbc'``) must not depend on token order. A single token
+    # (a datum, date, ofs) is returned as-is.
+    tokens = [t for t in text.replace(',', ' ').split() if t]
+    if len(tokens) > 1:
+        return sorted(t.lower() for t in tokens)
+    return text
+
+
+def file_fingerprint(path: Optional[str]) -> Optional[list]:
+    """Return ``[path, mtime_ns, size]`` for a file, or None.
+
+    Used to fold an external input file (e.g. the currents-bins override
+    CSV) into a run signature: editing that file changes the fingerprint and
+    invalidates artifacts built from the old contents. Returns None when the
+    path is falsy or unreadable, which compares equal to "no such input".
+    """
+    if not path:
+        return None
+    try:
+        stat = os.stat(path)
+    except OSError:
+        return None
+    return [os.path.abspath(path), stat.st_mtime_ns, stat.st_size]
+
+
+def run_signature(prop, *, variable=None, extra=None) -> dict:
+    """Build the parameter set that determines a cached artifact's validity.
+
+    Any field that changes the *contents* an artifact should have belongs
+    here; a mismatch on any field marks the cached file stale. ``variable``
+    scopes per-variable artifacts (obs/model/paired); ``extra`` lets a caller
+    add gate-specific keys (e.g. ``whichcast`` for ``.prd``/``.int``).
+    """
+    sig = {
+        'ofs': _normalize(getattr(prop, 'ofs', None)),
+        'start_date_full': _normalize(getattr(prop, 'start_date_full', None)),
+        'end_date_full': _normalize(getattr(prop, 'end_date_full', None)),
+        'ofsfiletype': _normalize(getattr(prop, 'ofsfiletype', None)),
+        'datum': _normalize(getattr(prop, 'datum', None)),
+        'stationowner': _normalize(getattr(prop, 'stationowner', None)),
+        'currents_bins_csv': file_fingerprint(
+            getattr(prop, 'currents_bins_csv', None)),
+    }
+    if variable is not None:
+        sig['variable'] = _normalize(variable)
+    if extra:
+        for key, value in extra.items():
+            sig[key] = file_fingerprint(value) if key.endswith('_file') \
+                else _normalize(value)
+    return sig
+
+
+def _index_path(directory: str) -> str:
+    return os.path.join(directory, MANIFEST_FILENAME)
+
+
+def _load_index(directory: str) -> dict:
+    """Read the directory's manifest index, or an empty index.
+
+    Fails open: a missing, unreadable, or wrong-version index returns an
+    empty ``entries`` map so every artifact reads as "stale" and regenerates
+    safely rather than trusting a possibly-corrupt record.
+    """
+    path = _index_path(directory)
+    try:
+        with open(path, encoding='utf-8') as handle:
+            data = json.load(handle)
+    except (OSError, ValueError):
+        return {'version': MANIFEST_SCHEMA_VERSION, 'entries': {}}
+    if not isinstance(data, dict) \
+            or data.get('version') != MANIFEST_SCHEMA_VERSION \
+            or not isinstance(data.get('entries'), dict):
+        return {'version': MANIFEST_SCHEMA_VERSION, 'entries': {}}
+    return data
+
+
+def _write_index(directory: str, index: dict, logger=None) -> None:
+    path = _index_path(directory)
+    try:
+        os.makedirs(directory, exist_ok=True)
+        with open(path, 'w', encoding='utf-8') as handle:
+            json.dump(index, handle, indent=2, sort_keys=True)
+    except OSError as exc:  # pragma: no cover - defensive
+        if logger is not None:
+            logger.warning(
+                'Could not write cache manifest %s: %s. Cached-artifact '
+                'staleness detection is degraded for this directory.',
+                path, exc)
+
+
+def artifact_is_fresh(artifact_path: str, signature: dict) -> bool:
+    """True when the artifact exists and its recorded signature matches.
+
+    Returns False when the file is absent, has no manifest entry (e.g. a
+    pre-upgrade file, or one deleted-and-rebuilt outside this module), or was
+    recorded under a different run signature. False means "regenerate".
+    """
+    if not os.path.isfile(artifact_path):
+        return False
+    directory = os.path.dirname(artifact_path) or '.'
+    key = os.path.basename(artifact_path)
+    with _manifest_lock:
+        index = _load_index(directory)
+    recorded = index.get('entries', {}).get(key)
+    return recorded == signature
+
+
+def record_artifact(artifact_path: str, signature: dict, logger=None) -> None:
+    """Store ``signature`` for a freshly (re)generated artifact.
+
+    Called right after a gate writes the artifact so a later same-parameter
+    run reuses it. Keyed by basename within the file's own directory index.
+    """
+    directory = os.path.dirname(artifact_path) or '.'
+    key = os.path.basename(artifact_path)
+    with _manifest_lock:
+        index = _load_index(directory)
+        index.setdefault('entries', {})[key] = signature
+        index['version'] = MANIFEST_SCHEMA_VERSION
+        _write_index(directory, index, logger)
+
+
+def forget_artifact(artifact_path: str, logger=None) -> None:
+    """Drop an artifact's manifest entry (e.g. after deleting the file)."""
+    directory = os.path.dirname(artifact_path) or '.'
+    key = os.path.basename(artifact_path)
+    with _manifest_lock:
+        index = _load_index(directory)
+        entries = index.get('entries', {})
+        if key in entries:
+            del entries[key]
+            _write_index(directory, index, logger)
+
+
+def ensure_fresh(artifact_path, signature, base_dir, kind, logger=None):
+    """Reuse gate helper: True if the artifact is reusable for this run.
+
+    Combines the manifest check with stale cleanup:
+
+    * Missing file -> returns False (caller regenerates); nothing to delete.
+    * Present and signature matches -> returns True (reuse verbatim).
+    * Present but signature differs -> deletes the file (bounded to
+      ``base_dir``), drops its manifest entry, tallies it for the run
+      summary, and returns False so the caller regenerates.
+    """
+    if not os.path.isfile(artifact_path):
+        return False
+    if artifact_is_fresh(artifact_path, signature):
+        return True
+    if logger is not None:
+        logger.warning(
+            '%s was built for different run parameters than the current '
+            'run and is likely left over from an earlier run. Deleting it '
+            'so it is regenerated.', artifact_path)
+    if remove_stale_artifact(artifact_path, base_dir, logger):
+        forget_artifact(artifact_path, logger)
+        note_stale(kind)
+    return False

--- a/src/ofs_skill/utils/cache_manifest.py
+++ b/src/ofs_skill/utils/cache_manifest.py
@@ -29,6 +29,7 @@ Design choices:
   corrupt index (fails open into "stale", forcing a safe regeneration).
 """
 
+import contextlib
 import json
 import os
 import threading
@@ -180,12 +181,22 @@ def _load_index(directory: str) -> dict:
 
 
 def _write_index(directory: str, index: dict, logger=None) -> None:
+    # Write atomically: dump to a temp file in the same directory, then
+    # os.replace() over the real index. A crash mid-write can only leave the
+    # (discarded) temp file behind, never a half-written index -- so a killed
+    # run does not corrupt the manifest and force an unnecessary full-dir
+    # regeneration. os.replace is atomic on the same filesystem on both
+    # POSIX and Windows.
     path = _index_path(directory)
+    tmp_path = f'{path}.{os.getpid()}.tmp'
     try:
         os.makedirs(directory, exist_ok=True)
-        with open(path, 'w', encoding='utf-8') as handle:
+        with open(tmp_path, 'w', encoding='utf-8') as handle:
             json.dump(index, handle, indent=2, sort_keys=True)
+        os.replace(tmp_path, path)
     except OSError as exc:  # pragma: no cover - defensive
+        with contextlib.suppress(OSError):
+            os.remove(tmp_path)
         if logger is not None:
             logger.warning(
                 'Could not write cache manifest %s: %s. Cached-artifact '

--- a/tests/cache_manifest_regression_test.py
+++ b/tests/cache_manifest_regression_test.py
@@ -1,0 +1,158 @@
+"""Regression tests for the stale-cache guard on the ctl/obs reuse gates.
+
+Reproduces the reported failure mode: a user runs the pipeline for one date
+window, then re-runs for a different window (or different station-owner /
+datum) in the SAME working directory without deleting ``./data`` and
+``./control_files``. Before the cache-manifest guard, the second run reused
+the first run's control files verbatim -- pinning the wrong station/node set
+-- and produced incorrect results.
+
+These tests drive ``cache_manifest.ensure_fresh`` the same way the real
+gates do (``write_obs_ctlfile``, ``write_ofs_ctlfile``,
+``get_station_observations``, ``get_skill``, ``create_1dplot``) and assert
+that a parameter change forces regeneration while an identical rerun reuses.
+"""
+
+import os
+from types import SimpleNamespace
+
+from ofs_skill.utils import cache_manifest as cm
+
+
+def _prop(**overrides):
+    base = dict(
+        ofs='cbofs',
+        start_date_full='2026-06-01T00:00:00Z',
+        end_date_full='2026-06-02T00:00:00Z',
+        ofsfiletype='stations',
+        datum='MLLW',
+        stationowner='co-ops,ndbc,usgs,chs',
+        currents_bins_csv=None,
+    )
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+def _build_ctl(path, signature, contents='node depth ... id shift\n'):
+    """Mimic a gate writing a ctl and stamping its signature."""
+    with open(path, 'w', encoding='utf-8') as handle:
+        handle.write(contents)
+    cm.record_artifact(path, signature)
+
+
+def test_second_window_regenerates_stale_ctl(tmp_path):
+    """Run A builds the ctl; run B (new window) must NOT reuse it."""
+    ctl = str(tmp_path / 'cbofs_wl_station.ctl')
+
+    # --- Run A: window 2026-06-01..02 ---
+    prop_a = _prop()
+    sig_a = cm.run_signature(prop_a, variable='water_level')
+    _build_ctl(ctl, sig_a, contents='RUN_A_STATIONS\n')
+
+    # Same-parameter rerun reuses verbatim (fast path, no regeneration).
+    assert cm.ensure_fresh(ctl, sig_a, str(tmp_path), 'obs ctl') is True
+    with open(ctl, encoding='utf-8') as handle:
+        assert 'RUN_A_STATIONS' in handle.read()
+
+    # --- Run B: different window ---
+    prop_b = _prop(start_date_full='2026-07-01T00:00:00Z',
+                   end_date_full='2026-07-02T00:00:00Z')
+    sig_b = cm.run_signature(prop_b, variable='water_level')
+
+    # The gate sees a signature mismatch, deletes the stale ctl, returns
+    # False so the caller rebuilds it.
+    assert cm.ensure_fresh(ctl, sig_b, str(tmp_path), 'obs ctl') is False
+    assert not os.path.exists(ctl)
+
+    # Caller rebuilds for window B and stamps the new signature.
+    _build_ctl(ctl, sig_b, contents='RUN_B_STATIONS\n')
+    assert cm.ensure_fresh(ctl, sig_b, str(tmp_path), 'obs ctl') is True
+    with open(ctl, encoding='utf-8') as handle:
+        assert 'RUN_B_STATIONS' in handle.read()
+
+
+def test_stationowner_change_regenerates(tmp_path):
+    """Narrowing -so from all providers to co-ops only rebuilds the ctl."""
+    ctl = str(tmp_path / 'cbofs_wl_station.ctl')
+    sig_all = cm.run_signature(
+        _prop(stationowner='co-ops,ndbc,usgs,chs'), variable='water_level')
+    _build_ctl(ctl, sig_all, contents='ALL_PROVIDERS\n')
+
+    sig_coops = cm.run_signature(
+        _prop(stationowner='co-ops'), variable='water_level')
+    assert cm.ensure_fresh(ctl, sig_coops, str(tmp_path), 'obs ctl') is False
+    assert not os.path.exists(ctl)
+
+
+def test_inventory_regenerates_on_window_change(tmp_path):
+    """The inventory CSV gate (its own signature shape) also regenerates."""
+    inv = str(tmp_path / 'inventory_all_cbofs.csv')
+
+    def inv_sig(start, end, owner):
+        return {
+            'ofs': cm._normalize('cbofs'),
+            'start_date': cm._normalize(start),
+            'end_date': cm._normalize(end),
+            'stationowner': cm._normalize(owner),
+            'currents_bins_csv': cm.file_fingerprint(None),
+        }
+
+    sig_a = inv_sig('20260601', '20260602', 'co-ops,ndbc')
+    with open(inv, 'w', encoding='utf-8') as handle:
+        handle.write('ID,X,Y,Source,Name\n8638610,-76,37,CO-OPS,x\n')
+    cm.record_artifact(inv, sig_a)
+    assert cm.ensure_fresh(inv, sig_a, str(tmp_path), 'inventory') is True
+
+    sig_b = inv_sig('20260701', '20260702', 'co-ops,ndbc')
+    assert cm.ensure_fresh(inv, sig_b, str(tmp_path), 'inventory') is False
+    assert not os.path.exists(inv)
+
+
+def test_prd_int_regenerate_on_datum_change(tmp_path):
+    """Model .prd and paired .int gates key on datum + whichcast too."""
+    prd = str(tmp_path / 's_cbofs_wl_0_nowcast_stations_model.prd')
+    intf = str(tmp_path / 'cbofs_wl_s_0_nowcast_stations_pair.int')
+
+    prd_sig = cm.run_signature(
+        _prop(datum='MLLW'), variable='water_level',
+        extra={'whichcast': 'nowcast'})
+    int_sig = cm.run_signature(
+        _prop(datum='MLLW'), variable='water_level',
+        extra={'whichcast': 'nowcast'})
+    for path, sig in ((prd, prd_sig), (intf, int_sig)):
+        with open(path, 'w', encoding='utf-8') as handle:
+            handle.write('DNUM YEAR MONTH DAY HOUR MINUTE VAL\n')
+        cm.record_artifact(path, sig)
+
+    # Same params -> reuse.
+    assert cm.artifact_is_fresh(prd, prd_sig) is True
+    assert cm.artifact_is_fresh(intf, int_sig) is True
+
+    # Change datum -> both read stale.
+    prd_sig2 = cm.run_signature(
+        _prop(datum='NAVD88'), variable='water_level',
+        extra={'whichcast': 'nowcast'})
+    int_sig2 = cm.run_signature(
+        _prop(datum='NAVD88'), variable='water_level',
+        extra={'whichcast': 'nowcast'})
+    assert cm.artifact_is_fresh(prd, prd_sig2) is False
+    assert cm.artifact_is_fresh(intf, int_sig2) is False
+
+
+def test_identical_rerun_reuses_all(tmp_path):
+    """A byte-for-byte identical rerun reuses every artifact (no churn)."""
+    cm.reset_stale_counter()
+    prop = _prop()
+    paths = {
+        'cbofs_wl_station.ctl': cm.run_signature(prop, variable='water_level'),
+        'cbofs_wl_model_station.ctl': cm.run_signature(
+            prop, variable='water_level'),
+    }
+    for name, sig in paths.items():
+        p = str(tmp_path / name)
+        _build_ctl(p, sig)
+    # Second run, same params: everything fresh, nothing tallied stale.
+    for name, sig in paths.items():
+        p = str(tmp_path / name)
+        assert cm.ensure_fresh(p, sig, str(tmp_path), 'ctl') is True
+    assert cm._stale_counter == {}

--- a/tests/cache_manifest_test.py
+++ b/tests/cache_manifest_test.py
@@ -1,0 +1,191 @@
+"""Unit tests for the per-directory cache manifest (stale-cache guard).
+
+The 1D pipeline caches artifacts (``*.ctl``, ``inventory_all_{ofs}.csv``,
+``*.obs``, ``*.prd``, ``*_pair.int``) under filenames that do not encode the
+assessment window or station-selection options. ``cache_manifest`` records
+the run parameters each artifact was built for in a per-directory index and
+lets the reuse gates detect a parameter change and regenerate instead of
+serving stale files. These tests exercise the manifest primitives directly
+(no network, no model data).
+"""
+
+import os
+from types import SimpleNamespace
+
+from ofs_skill.utils import cache_manifest as cm
+
+
+def _prop(**overrides):
+    base = dict(
+        ofs='cbofs',
+        start_date_full='2026-06-01T00:00:00Z',
+        end_date_full='2026-06-02T00:00:00Z',
+        ofsfiletype='stations',
+        datum='MLLW',
+        stationowner='co-ops,ndbc',
+        currents_bins_csv=None,
+    )
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+def _touch(path, text='data'):
+    with open(path, 'w', encoding='utf-8') as handle:
+        handle.write(text)
+
+
+class TestRunSignature:
+    def test_same_params_equal(self):
+        assert cm.run_signature(_prop()) == cm.run_signature(_prop())
+
+    def test_window_change_differs(self):
+        a = cm.run_signature(_prop())
+        b = cm.run_signature(_prop(end_date_full='2026-06-09T00:00:00Z'))
+        assert a != b
+
+    def test_stationowner_order_insensitive(self):
+        a = cm.run_signature(_prop(stationowner='co-ops,ndbc'))
+        b = cm.run_signature(_prop(stationowner='NDBC,CO-OPS'))
+        assert a == b
+
+    def test_datum_change_differs(self):
+        a = cm.run_signature(_prop(datum='MLLW'))
+        b = cm.run_signature(_prop(datum='NAVD88'))
+        assert a != b
+
+    def test_variable_scopes_signature(self):
+        a = cm.run_signature(_prop(), variable='water_level')
+        b = cm.run_signature(_prop(), variable='currents')
+        assert a != b
+
+    def test_extra_whichcast_differs(self):
+        a = cm.run_signature(_prop(), extra={'whichcast': 'nowcast'})
+        b = cm.run_signature(_prop(), extra={'whichcast': 'forecast_b'})
+        assert a != b
+
+    def test_currents_bins_csv_fingerprint(self, tmp_path):
+        csv = tmp_path / 'bins.csv'
+        _touch(str(csv), 'station_id,bin\ncb0201,2\n')
+        sig1 = cm.run_signature(_prop(currents_bins_csv=str(csv)))
+        # Rewrite with different content (and size) -> new fingerprint.
+        _touch(str(csv), 'station_id,bin\ncb0201,2\ncb0201,3\n')
+        os.utime(str(csv), (os.stat(str(csv)).st_atime,
+                            os.stat(str(csv)).st_mtime + 5))
+        sig2 = cm.run_signature(_prop(currents_bins_csv=str(csv)))
+        assert sig1 != sig2
+
+
+class TestArtifactFreshness:
+    def test_missing_file_not_fresh(self, tmp_path):
+        path = str(tmp_path / 'cbofs_wl_station.ctl')
+        assert cm.artifact_is_fresh(path, cm.run_signature(_prop())) is False
+
+    def test_recorded_then_fresh(self, tmp_path):
+        path = str(tmp_path / 'cbofs_wl_station.ctl')
+        _touch(path)
+        sig = cm.run_signature(_prop())
+        cm.record_artifact(path, sig)
+        assert cm.artifact_is_fresh(path, sig) is True
+
+    def test_legacy_file_without_entry_not_fresh(self, tmp_path):
+        # A pre-upgrade artifact has no manifest entry -> treated as stale.
+        path = str(tmp_path / 'cbofs_wl_station.ctl')
+        _touch(path)
+        assert cm.artifact_is_fresh(path, cm.run_signature(_prop())) is False
+
+    def test_changed_params_not_fresh(self, tmp_path):
+        path = str(tmp_path / 'cbofs_wl_station.ctl')
+        _touch(path)
+        cm.record_artifact(path, cm.run_signature(_prop()))
+        newsig = cm.run_signature(_prop(end_date_full='2026-07-01T00:00:00Z'))
+        assert cm.artifact_is_fresh(path, newsig) is False
+
+    def test_index_lives_in_directory(self, tmp_path):
+        path = str(tmp_path / 'cbofs_wl_station.ctl')
+        _touch(path)
+        cm.record_artifact(path, cm.run_signature(_prop()))
+        assert (tmp_path / cm.MANIFEST_FILENAME).is_file()
+
+    def test_corrupt_index_fails_open(self, tmp_path):
+        path = str(tmp_path / 'cbofs_wl_station.ctl')
+        _touch(path)
+        cm.record_artifact(path, cm.run_signature(_prop()))
+        # Corrupt the index -> everything reads as stale (safe regeneration).
+        _touch(str(tmp_path / cm.MANIFEST_FILENAME), 'not json{{{')
+        assert cm.artifact_is_fresh(path, cm.run_signature(_prop())) is False
+
+    def test_forget_artifact(self, tmp_path):
+        path = str(tmp_path / 'cbofs_wl_station.ctl')
+        _touch(path)
+        sig = cm.run_signature(_prop())
+        cm.record_artifact(path, sig)
+        cm.forget_artifact(path)
+        assert cm.artifact_is_fresh(path, sig) is False
+
+
+class TestEnsureFresh:
+    def test_missing_returns_false_no_tally(self, tmp_path):
+        cm.reset_stale_counter()
+        path = str(tmp_path / 'x_wl_station.ctl')
+        result = cm.ensure_fresh(
+            path, cm.run_signature(_prop()), str(tmp_path), 'ctl')
+        assert result is False
+        # Missing (never built) is not a "stale regenerate" event.
+        assert cm._stale_counter == {}
+
+    def test_matching_returns_true(self, tmp_path):
+        path = str(tmp_path / 'x_wl_station.ctl')
+        _touch(path)
+        sig = cm.run_signature(_prop())
+        cm.record_artifact(path, sig)
+        assert cm.ensure_fresh(path, sig, str(tmp_path), 'ctl') is True
+
+    def test_stale_deletes_and_tallies(self, tmp_path):
+        cm.reset_stale_counter()
+        path = str(tmp_path / 'x_wl_station.ctl')
+        _touch(path)
+        cm.record_artifact(path, cm.run_signature(_prop()))
+        newsig = cm.run_signature(_prop(datum='NAVD88'))
+        result = cm.ensure_fresh(path, newsig, str(tmp_path), 'ctl')
+        assert result is False
+        assert not os.path.exists(path)          # deleted
+        assert cm._stale_counter.get('ctl') == 1  # tallied
+        # Manifest entry dropped too.
+        assert cm.artifact_is_fresh(path, newsig) is False
+
+    def test_refuses_delete_outside_base_dir(self, tmp_path):
+        # A path resolving outside base_dir must not be deleted.
+        inside = tmp_path / 'work'
+        inside.mkdir()
+        outside = tmp_path / 'outside.ctl'
+        _touch(str(outside))
+        cm.record_artifact(str(outside), cm.run_signature(_prop()))
+        newsig = cm.run_signature(_prop(datum='NAVD88'))
+        result = cm.ensure_fresh(
+            str(outside), newsig, str(inside), 'ctl')
+        assert result is False
+        assert outside.exists()  # NOT deleted (outside base_dir)
+
+
+class TestStaleSummary:
+    def test_summary_silent_when_none(self):
+        cm.reset_stale_counter()
+        logged = []
+        logger = SimpleNamespace(info=lambda *a, **k: logged.append(a))
+        cm.emit_stale_summary('cbofs', logger)
+        assert logged == []
+
+    def test_summary_reports_counts(self):
+        cm.reset_stale_counter()
+        cm.note_stale('ctl')
+        cm.note_stale('ctl')
+        cm.note_stale('obs')
+        logged = []
+        logger = SimpleNamespace(info=lambda *a, **k: logged.append(a))
+        cm.emit_stale_summary('cbofs', logger)
+        assert len(logged) == 1
+        # Message mentions the total and the per-kind breakdown.
+        rendered = logged[0][0] % logged[0][1:]
+        assert '3 stale' in rendered
+        assert '2 ctl' in rendered
+        assert '1 obs' in rendered

--- a/tests/cache_manifest_test.py
+++ b/tests/cache_manifest_test.py
@@ -106,6 +106,31 @@ class TestArtifactFreshness:
         cm.record_artifact(path, cm.run_signature(_prop()))
         assert (tmp_path / cm.MANIFEST_FILENAME).is_file()
 
+    def test_write_leaves_no_temp_file(self, tmp_path):
+        # The atomic write (temp file + os.replace) must not leave the
+        # temp artifact behind on success.
+        path = str(tmp_path / 'cbofs_wl_station.ctl')
+        _touch(path)
+        cm.record_artifact(path, cm.run_signature(_prop()))
+        leftovers = [p.name for p in tmp_path.iterdir()
+                     if p.name.startswith(cm.MANIFEST_FILENAME)
+                     and p.name != cm.MANIFEST_FILENAME]
+        assert leftovers == []
+
+    def test_rewrite_preserves_prior_entries(self, tmp_path):
+        # Recording a second artifact must merge into the existing index
+        # (atomic replace of the whole file), not clobber the first entry.
+        p1 = str(tmp_path / 'cbofs_wl_station.ctl')
+        p2 = str(tmp_path / 'cbofs_temp_station.ctl')
+        _touch(p1)
+        _touch(p2)
+        sig1 = cm.run_signature(_prop(), variable='water_level')
+        sig2 = cm.run_signature(_prop(), variable='water_temperature')
+        cm.record_artifact(p1, sig1)
+        cm.record_artifact(p2, sig2)
+        assert cm.artifact_is_fresh(p1, sig1) is True
+        assert cm.artifact_is_fresh(p2, sig2) is True
+
     def test_corrupt_index_fails_open(self, tmp_path):
         path = str(tmp_path / 'cbofs_wl_station.ctl')
         _touch(path)

--- a/tests/stale_cache_coverage_test.py
+++ b/tests/stale_cache_coverage_test.py
@@ -336,7 +336,8 @@ class TestEnsurePairedDataStaleness:
         cache_manifest.record_artifact(
             str(pair),
             cache_manifest.run_signature(
-                prop, variable='temp', extra={'whichcast': 'nowcast'}))
+                prop, variable='water_temperature',
+                extra={'whichcast': 'nowcast'}))
 
         calls = []
         monkeypatch.setattr(create_1dplot_mod, 'get_skill',

--- a/tests/stale_cache_coverage_test.py
+++ b/tests/stale_cache_coverage_test.py
@@ -328,10 +328,19 @@ class TestEnsurePairedDataStaleness:
         pair = tmp_path / 'cbofs_temp_8571421_29_nowcast_stations_pair.int'
         _write_pair_file(pair, WINDOW_START, hours=25)
 
+        # A pair file produced by the current run carries a manifest entry
+        # matching this run's parameters (get_skill stamps it on write); a
+        # window-covering + parameter-matching file must be left alone.
+        from ofs_skill.utils import cache_manifest
+        prop = _PairCheckProp(tmp_path)
+        cache_manifest.record_artifact(
+            str(pair),
+            cache_manifest.run_signature(
+                prop, variable='temp', extra={'whichcast': 'nowcast'}))
+
         calls = []
         monkeypatch.setattr(create_1dplot_mod, 'get_skill',
                             lambda p, lg: calls.append(p.whichcast))
-        prop = _PairCheckProp(tmp_path)
         create_1dplot_mod._ensure_paired_data_exists(
             OFS_CTL, prop, VAR_INFO, _make_logger())
 


### PR DESCRIPTION
### Description of Changes

Before this change, if you ran the 1D pipeline for an OFS, then ran it again for the same OFS with a different date range (or different station owners, datum, etc.) **without** first deleting the `./data` and `./control_files` folders, the pipeline would quietly reuse leftover files from the first run. The results looked fine but were wrong. The only workaround was to remember to delete those folders by hand between every run.

**Why it happened**: the pipeline saves its intermediate files (control files, the station inventory, the `.obs` observation files, the `.prd` model files, and the `.int` paired files) with names that only include the OFS and the variable. The names do not say which date range or options the files were built for. So when a file already existed, the code just reused it, no matter what settings the new run used.

**What this change does**: it now keeps a small record, one per folder, of the settings each saved file was built with. On the next run, before reusing a file, the pipeline checks that record. If the settings match, it reuses the file as before. If they do not match (or the file is old and has no record yet), it deletes that file and rebuilds it for the current run. This happens automatically — there is no new flag or command.

**Details**:
- New file `src/ofs_skill/utils/cache_manifest.py` keeps the per-folder record
  (a small hidden file named `.ofs_cache_manifest.json`). It stores the OFS,
  the start and end dates, the file type, the datum, the list of station
  owners, and a fingerprint of the currents-bins CSV if one is used.
- The reuse checks in the pipeline now consult this record before reusing any
  control file, inventory, `.obs`, `.prd`, or `.int` file.
- At the end of a run, the log prints one line saying how many files were
  rebuilt because the settings changed. If nothing was stale, it says nothing.
- The record is written safely: it is written to a temporary file first and
  then swapped into place, so a run that gets killed partway through cannot
  leave a broken record behind.

Closes #60.

### Expected Outcome of Changes

- You no longer have to delete `./data` and `./control_files` between runs. When the settings change, only the affected files are rebuilt; when you run the exact same thing again, everything is reused (so it stays fast).
- No change to the numbers the pipeline produces, the file formats, or the set of output files. The only new file on disk is the small hidden `.ofs_cache_manifest.json` in each folder, which is not a pipeline output.

### Developer Questions and Checklist

**Is this a high priority PR? If yes, why and is there a date by which it needs to be merged?**
No fixed deadline. It removes a common cause of quietly-wrong results, so it is worth doing soon.

**Are there any changes needed to how the code should be run for operational runs? (Commands, flags, job timings, etc.)**
No. Commands and flags are the same. Anyone who used to wipe `./data` and `./control_files` between runs no longer needs to.

**Does this update need to be deployed for operational runs?**
Yes — it prevents stale files from being reused on shared working folders.

**Does this update require front end/web app changes? (If yes, provide documentation to Min)**
No.

**Does this impact code development work on adding SCHISM?**
No.

**Does this impact code development work on adding ADCIRC?**
No.

**Does this impact the expected number of output files for integration tests (i.e., will the integration test fail even though code changes result in desired change in outputs?)**
No. Same outputs and same file counts. The one new file is a small hidden record file per folder, which does not match the output file patterns the tests count.

- [x] Developer's name is removed throughout the code?
- [x] Did you add relevant labels to the PR?
- [x] Have you run pylint and is the code at an acceptable pylint score (>8)? (`cache_manifest.py` scores 10/10; pre-commit ruff and mypy pass on all edited files.)
- [x] Jobs contain the appropriate file checking and handle errors for any missing data? (If the record file is missing or unreadable, the code treats the file as stale and rebuilds it. Deletes are limited to the file's own folder.)
- [x] Is log free of critical ERRORs or WARNINGs? For errors that are not critical and can remain in code, is there sufficient handling and logging? (Rebuilt files produce a single summary line at the end; a per-file WARNING appears only when a file is actually stale.)

### Testing Instructions

**Unit tests** (no network needed):

```bash
python -m pytest tests/cache_manifest_test.py tests/cache_manifest_regression_test.py -v
```

These cover: settings that should match vs. differ, station-owner order not
mattering, the currents-bins CSV fingerprint, a missing or broken record file
being treated as stale, refusing to delete files outside the target folder,
the safe (temp-file-then-swap) write, and the two-run rebuild/reuse flow.

The full suite passes on this branch:
```bash
python -m pytest tests/
```

**Live check** (reproduces the original problem; needs network + model data).
Run the same OFS for two different date ranges without deleting anything in
between:

```bash
# Run A — clean folders
python ./bin/visualization/create_1dplot.py -o cbofs -p ./ \
  -s 2026-07-28T00:00:00Z -e 2026-07-29T00:00:00Z \
  -d MLLW -ws nowcast -t stations -vs water_level -so co-ops

# Run A again, exactly the same — everything is reused, no rebuild line
python ./bin/visualization/create_1dplot.py -o cbofs -p ./ \
  -s 2026-07-28T00:00:00Z -e 2026-07-29T00:00:00Z \
  -d MLLW -ws nowcast -t stations -vs water_level -so co-ops

# Run B — different dates, SAME folders, nothing deleted
python ./bin/visualization/create_1dplot.py -o cbofs -p ./ \
  -s 2026-07-26T00:00:00Z -e 2026-07-27T00:00:00Z \
  -d MLLW -ws nowcast -t stations -vs water_level -so co-ops
```

What to expect:
- Run A finishes and prints no "Regenerated ... stale cached artifact(s)" line
  (the folders were clean).
- Run A again finishes, still prints no rebuild line, and the log shows files
  being reused. Output files are identical.
- Run B finishes and prints a line like `Regenerated 3 stale cached
  artifact(s) for cbofs due to changed run parameters ...`, and the affected
  control file, inventory, and `.obs` files are rebuilt for the new dates (the
  `.obs` contents change and now start on the new start date).

This was confirmed on Windows with CBOFS. In Run B, 18 of 18 observation files
changed between the two date ranges, proving the stale files were rebuilt.

### Reminder checklist for PR reviewer
- [ ] Run PEP8 compliance tests to ensure the code follows best practices
- [ ] Check that documentation in the script is sufficient
- [ ] Validate the output values (if applicable) to make sure the calculations are correct and make scientific/physical sense; include a comment on the pull request including what validation you performed, for replicability.
- [ ] Test code both on Windows and Linux (and MacOS, if available), using several OFS as test cases
- [ ] **Test for all 'cast' options: forecast_a, forecast_b, and nowcast**
- [ ] When approving or commenting on a pull request, add information on the calls you use in case they need to be replicated or referenced.
